### PR TITLE
Github Actions. Checkout on current PR

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: pull/${{ github.event.pull_request.id }}/head
 
       - name: Cache Cocoapods
         id: cache-cocoapods


### PR DESCRIPTION
For [pull_request action](https://github.com/nova-wallet/nova-wallet-ios/blob/develop/.github/workflows/pull_request.yml#L4) pull_request_target is running on develop:
https://github.com/nova-wallet/nova-wallet-ios/runs/4309665318?check_suite_focus=true#step:3:462

This pull request fix it.

Signed-off-by: Stepan Lavrentev <lawrentievsv@gmail.com>