### PR TITLE
Fixing triggering for "bump version from tag"

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,7 +1,7 @@
 name: Bump app version from tag
 
 on:
-  create:
+  push:
     tags:
       - '*'
 


### PR DESCRIPTION
Bump app version from tag have triggered with creating a new branch - it is unexpected behaviour.
So trigger was changed to "push" event and it works well. Tested on:

- Create new tag on local branch and push it to remote
- Create new tag with create new release from GtiHub UI
- Create new tag on existing branch
- Push some branch in develop (does not triggered this workflow)

Signed-off-by: Stepan Lavrentev <lawrentievsv@gmail.com>