### PR TITLE
Fixing the Ramp icon

### DIFF
--- a/novawallet/Common/Configs/ApplicationConfigs.swift
+++ b/novawallet/Common/Configs/ApplicationConfigs.swift
@@ -91,7 +91,7 @@ extension ApplicationConfig: ApplicationConfigProtocol {
 
     var logoURL: URL {
         // swiftlint:disable:next line_length
-        let logoString = "https://raw.githubusercontent.com/nova-wallet/branding/master/logos/Nova_Wallet_Horizontal_On_White_200px.png"
+        let logoString = "https://raw.githubusercontent.com/nova-wallet/branding/master/logos/Nova_Wallet_Horizontal_iOS_Ramp.png"
         return URL(string: logoString)!
     }
 


### PR DESCRIPTION
In Safari browser our icon is showing incorrect:
<details>
  <summary>Screen</summary>

<img width="1436" alt="Screenshot 2022-04-06 at 12 22 43" src="https://user-images.githubusercontent.com/40560660/162165856-78c11261-31fa-4dc2-8d57-ea82a611fd3b.png">

</details>

This PR is adding another icon which looks correct.
https://raw.githubusercontent.com/nova-wallet/branding/master/logos/Nova_Wallet_Horizontal_iOS_Ramp.png

<details>
  <summary>Proof</summary>

<img width="551" alt="Screenshot 2022-04-07 at 12 22 53" src="https://user-images.githubusercontent.com/40560660/162166827-71f0562c-c7ec-4db5-a473-9786f798bcc8.png">

</details>

#217 CU-2acxret