### PR TITLE
Prepare for runtime upgrades on Moonriver/Moonbase

### DIFF
--- a/novawallet/Common/Substrate/Types/ParachainStaking/ConstantCodingPath+ParachainStaking.swift
+++ b/novawallet/Common/Substrate/Types/ParachainStaking/ConstantCodingPath+ParachainStaking.swift
@@ -26,8 +26,4 @@ extension ParachainStaking {
             constantName: "DelegationBondLessDelay"
         )
     }
-
-    static var blocksPerRound: ConstantCodingPath {
-        ConstantCodingPath(moduleName: "ParachainStaking", constantName: "DefaultBlocksPerRound")
-    }
 }

--- a/novawallet/Modules/Staking/Parachain/ParaStkStakeConfirm/ParaStkStakeConfirmInteractor.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkStakeConfirm/ParaStkStakeConfirmInteractor.swift
@@ -156,6 +156,7 @@ final class ParaStkStakeConfirmInteractor: RuntimeConstantFetching {
     private func provideStakingDuration() {
         let wrapper = stakingDurationFactory.createDurationOperation(
             from: runtimeProvider,
+            connection: connection,
             blockTimeEstimationService: blockEstimationService
         )
 

--- a/novawallet/Modules/Staking/Parachain/ParaStkStakeConfirm/ParaStkStakeConfirmViewFactory.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkStakeConfirm/ParaStkStakeConfirmViewFactory.swift
@@ -103,7 +103,13 @@ struct ParaStkStakeConfirmViewFactory {
             operationManager: OperationManagerFacade.sharedManager
         ).createService(account: selectedAccount.chainAccount, chain: chainAsset.chain)
 
+        let storageRequestFactory = StorageRequestFactory(
+            remoteFactory: StorageKeyFactory(),
+            operationManager: OperationManagerFacade.sharedManager
+        )
+
         let stakingDurationFactory = ParaStkDurationOperationFactory(
+            storageRequestFactory: storageRequestFactory,
             blockTimeOperationFactory: BlockTimeOperationFactory(chain: chainAsset.chain)
         )
 

--- a/novawallet/Modules/Staking/Parachain/ParaStkUnstake/Base/ParaStkBaseUnstakeInteractor.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkUnstake/Base/ParaStkBaseUnstakeInteractor.swift
@@ -86,6 +86,7 @@ class ParaStkBaseUnstakeInteractor {
     private func provideStakingDuration() {
         let wrapper = stakingDurationFactory.createDurationOperation(
             from: runtimeProvider,
+            connection: connection,
             blockTimeEstimationService: blocktimeEstimationService
         )
 

--- a/novawallet/Modules/Staking/Parachain/ParaStkUnstake/ParaStkUnstakeViewFactory.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkUnstake/ParaStkUnstakeViewFactory.swift
@@ -99,6 +99,7 @@ struct ParaStkUnstakeViewFactory {
 
         let identityOperationFactory = IdentityOperationFactory(requestFactory: requestFactory)
         let stakingDurationFactory = ParaStkDurationOperationFactory(
+            storageRequestFactory: requestFactory,
             blockTimeOperationFactory: BlockTimeOperationFactory(chain: chainAsset.chain)
         )
 

--- a/novawallet/Modules/Staking/Parachain/ParaStkUnstakeConfirm/ParaStkUnstakeConfirmViewFactory.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkUnstakeConfirm/ParaStkUnstakeConfirmViewFactory.swift
@@ -90,7 +90,13 @@ struct ParaStkUnstakeConfirmViewFactory {
         let storageFacade = SubstrateDataStorageFacade.shared
         let repositoryFactory = SubstrateRepositoryFactory(storageFacade: storageFacade)
 
+        let storageRequestFactory = StorageRequestFactory(
+            remoteFactory: StorageKeyFactory(),
+            operationManager: OperationManagerFacade.sharedManager
+        )
+
         let stakingDurationFactory = ParaStkDurationOperationFactory(
+            storageRequestFactory: storageRequestFactory,
             blockTimeOperationFactory: BlockTimeOperationFactory(chain: chainAsset.chain)
         )
 

--- a/novawallet/Modules/Staking/StakingMain/Parachain/StakingMainPresenterFactory+Parachain.swift
+++ b/novawallet/Modules/Staking/StakingMain/Parachain/StakingMainPresenterFactory+Parachain.swift
@@ -82,11 +82,15 @@ extension StakingMainPresenterFactory {
         let networkInfoFactory = ParaStkNetworkInfoOperationFactory()
 
         let blockTimeFactory = BlockTimeOperationFactory(chain: state.settings.value.chain)
-        let durationFactory = ParaStkDurationOperationFactory(blockTimeOperationFactory: blockTimeFactory)
 
         let storageRequestFactory = StorageRequestFactory(
             remoteFactory: StorageKeyFactory(),
             operationManager: operationManager
+        )
+
+        let durationFactory = ParaStkDurationOperationFactory(
+            storageRequestFactory: storageRequestFactory,
+            blockTimeOperationFactory: blockTimeFactory
         )
 
         let collatorsOperationFactory = ParaStkCollatorsOperationFactory(

--- a/novawallet/Modules/Staking/StakingMain/Parachain/StakingParachainInteractor+Provide.swift
+++ b/novawallet/Modules/Staking/StakingMain/Parachain/StakingParachainInteractor+Provide.swift
@@ -130,8 +130,14 @@ extension StakingParachainInteractor {
             return
         }
 
+        guard let connection = chainRegistry.getConnection(for: chainId) else {
+            presenter?.didReceiveError(ChainRegistryError.connectionUnavailable)
+            return
+        }
+
         let wrapper = durationOperationFactory.createDurationOperation(
             from: runtimeService,
+            connection: connection,
             blockTimeEstimationService: blockTimeService
         )
 


### PR DESCRIPTION
- replace ```DefaultBlocksPerRound``` query with ```Round.length``` storage query