### PR TITLE
GitHub Actions. Change trigger for pull-request runner

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,10 +1,7 @@
 name: Build and Test on PR
 
 on:
-  pull_request_target:
-    types: [labeled]
-  # pull_request:
-  #   branches: [ develop ]
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
That PR changes trigger CI in order to run unit tests for each commit in pull-request