### PR TITLE
Improve start staking

### DIFF
--- a/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
@@ -199,6 +199,10 @@ struct ChainModel: Equatable, Codable, Hashable {
             return nil
         }
     }
+
+    var defaultBlockTimeMillis: BlockTime? {
+        additional?.defaultBlockTime?.unsignedIntValue
+    }
 }
 
 extension ChainModel: Identifiable {

--- a/novawallet/Common/Network/Subquery/Models/SubqueryHistory.swift
+++ b/novawallet/Common/Network/Subquery/Models/SubqueryHistory.swift
@@ -25,6 +25,7 @@ struct SubqueryTransfer: Codable {
 }
 
 struct SubqueryRewardOrSlash: Codable {
+    let eventIdx: Int
     let amount: String
     let isReward: Bool
     let era: Int?

--- a/novawallet/Common/Network/Subquery/SubqueryHistory+Wallet.swift
+++ b/novawallet/Common/Network/Subquery/SubqueryHistory+Wallet.swift
@@ -108,7 +108,7 @@ extension SubqueryHistoryElement: WalletRemoteHistoryItemProtocol {
         let context = HistoryRewardContext(
             validator: reward.validator,
             era: reward.era,
-            eventId: identifier
+            eventId: createEventId(from: reward.eventIdx)
         )
 
         let source = TransactionHistoryItemSource.substrate
@@ -140,7 +140,7 @@ extension SubqueryHistoryElement: WalletRemoteHistoryItemProtocol {
     ) -> TransactionHistoryItem {
         let context = HistoryPoolRewardContext(
             poolId: NominationPools.PoolId(reward.poolId),
-            eventId: identifier
+            eventId: createEventId(from: reward.eventIdx)
         )
 
         let source = TransactionHistoryItemSource.substrate
@@ -190,5 +190,9 @@ extension SubqueryHistoryElement: WalletRemoteHistoryItemProtocol {
             callPath: CallCodingPath(moduleName: extrinsic.module, callName: extrinsic.call),
             call: extrinsic.call.data(using: .utf8)
         )
+    }
+
+    private func createEventId(from remoteId: Int) -> String {
+        String(blockNumber) + "-" + String(remoteId)
     }
 }

--- a/novawallet/Modules/OperationDetails/ViewModel/OperationDetailsViewModelFactory.swift
+++ b/novawallet/Modules/OperationDetails/ViewModel/OperationDetailsViewModelFactory.swift
@@ -259,7 +259,7 @@ final class OperationDetailsViewModelFactory {
                 chainAsset: chainAsset,
                 locale: locale
             )
-            return .poolReward(viewModel)
+            return .poolSlash(viewModel)
         }
     }
 }

--- a/novawallet/Modules/Staking/Dashboard/Model/StakingDashboardModel.swift
+++ b/novawallet/Modules/Staking/Dashboard/Model/StakingDashboardModel.swift
@@ -1,10 +1,11 @@
 import Foundation
 import RobinHood
+import BigInt
 
 protocol StakingDashboardItemModelCommonProtocol {
     var chainAsset: ChainAsset { get }
     var accountId: AccountId? { get }
-    var balance: AssetBalance? { get }
+    var availableBalance: BigUInt? { get }
     var price: PriceData? { get }
     var maxApy: Decimal? { get }
     var isOnchainSync: Bool { get }
@@ -18,7 +19,7 @@ extension StakingDashboardItemModelCommonProtocol {
 
     func balanceValue() -> Decimal {
         Decimal.fiatValue(
-            from: balance?.freeInPlank,
+            from: availableBalance,
             price: price,
             precision: chainAsset.assetDisplayInfo.assetPrecision
         )
@@ -30,7 +31,7 @@ enum StakingDashboardItemModel: Equatable {
         let stakingOption: Multistaking.ChainAssetOption
         let dashboardItem: Multistaking.DashboardItem?
         let accountId: AccountId?
-        let balance: AssetBalance?
+        let availableBalance: BigUInt?
         let price: PriceData?
         let isOnchainSync: Bool
         let isOffchainSync: Bool
@@ -60,7 +61,7 @@ enum StakingDashboardItemModel: Equatable {
         let chainAsset: ChainAsset
         let maxApy: Decimal?
         let accountId: AccountId?
-        let balance: AssetBalance?
+        let availableBalance: BigUInt?
         let price: PriceData?
         let isOnchainSync: Bool
         let isOffchainSync: Bool
@@ -69,7 +70,7 @@ enum StakingDashboardItemModel: Equatable {
             chainAsset: ChainAsset,
             maxApy: Decimal?,
             accountId: AccountId?,
-            balance: AssetBalance?,
+            availableBalance: BigUInt?,
             price: PriceData?,
             isOnchainSync: Bool,
             isOffchainSync: Bool
@@ -77,18 +78,18 @@ enum StakingDashboardItemModel: Equatable {
             self.chainAsset = chainAsset
             self.maxApy = maxApy
             self.accountId = accountId
-            self.balance = balance
+            self.availableBalance = availableBalance
             self.price = price
             self.isOnchainSync = isOnchainSync
             self.isOffchainSync = isOffchainSync
         }
 
-        init(concrete: Concrete) {
+        init(concrete: Concrete, availableBalance: BigUInt?) {
             self.init(
                 chainAsset: concrete.chainAsset,
                 maxApy: concrete.dashboardItem?.maxApy,
                 accountId: concrete.accountId,
-                balance: concrete.balance,
+                availableBalance: availableBalance,
                 price: concrete.price,
                 isOnchainSync: concrete.isOnchainSync,
                 isOffchainSync: concrete.isOffchainSync
@@ -108,7 +109,7 @@ enum StakingDashboardItemModel: Equatable {
                 chainAsset: chainAsset,
                 maxApy: updatedApy,
                 accountId: accountId,
-                balance: balance,
+                availableBalance: availableBalance,
                 price: price,
                 isOnchainSync: isOnchainSync,
                 isOffchainSync: isOffchainSync
@@ -191,8 +192,8 @@ extension Array where Element: StakingDashboardItemModelCommonProtocol {
 
                 return CompoundComparator.compare(item1: balance1, item2: balance2, isAsc: false)
             }, {
-                let hasBalance1 = item1.balance != nil ? 0 : 1
-                let hasBalance2 = item2.balance != nil ? 0 : 1
+                let hasBalance1 = item1.availableBalance != nil ? 0 : 1
+                let hasBalance2 = item2.availableBalance != nil ? 0 : 1
 
                 return CompoundComparator.compare(item1: hasBalance1, item2: hasBalance2, isAsc: true)
             }, {
@@ -247,7 +248,7 @@ extension StakingDashboardItemModel.Combined {
             chainAsset: chainAsset,
             maxApy: maxApy,
             accountId: accountId,
-            balance: balance,
+            availableBalance: availableBalance,
             price: price,
             isOnchainSync: isOnchainSync,
             isOffchainSync: isOffchainSync
@@ -261,7 +262,7 @@ extension StakingDashboardItemModel.Concrete {
             stakingOption: stakingOption,
             dashboardItem: dashboardItem,
             accountId: accountId,
-            balance: balance,
+            availableBalance: availableBalance,
             price: price,
             isOnchainSync: isOnchainSync,
             isOffchainSync: isOffchainSync
@@ -301,12 +302,12 @@ extension StakingDashboardItemModel: StakingDashboardItemModelCommonProtocol {
         }
     }
 
-    var balance: AssetBalance? {
+    var availableBalance: BigUInt? {
         switch self {
         case let .combined(value):
-            return value.balance
+            return value.availableBalance
         case let .concrete(value):
-            return value.balance
+            return value.availableBalance
         }
     }
 

--- a/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModelFactory.swift
+++ b/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModelFactory.swift
@@ -221,7 +221,7 @@ extension StakingDashboardViewModelFactory: StakingDashboardViewModelFactoryProt
         )
 
         let balance = createAmount(
-            for: model.balance?.freeInPlank,
+            for: model.availableBalance,
             priceData: model.price,
             assetDisplayInfo: assetDisplayInfo,
             isSyncing: false,

--- a/novawallet/Modules/Staking/Operations/BlockTimeOperationFactory.swift
+++ b/novawallet/Modules/Staking/Operations/BlockTimeOperationFactory.swift
@@ -26,9 +26,14 @@ final class BlockTimeOperationFactory {
 
     private func createExpectedBlockTimeWrapper(
         dependingOn codingFactoryOperation: BaseOperation<RuntimeCoderFactoryProtocol>,
+        chainDefaultTime: BlockTime?,
         fallbackTime: BlockTime,
         fallbackThreshold: BlockTime
     ) -> CompoundOperationWrapper<BlockTime> {
+        if let chainDefaultTime = chainDefaultTime {
+            return CompoundOperationWrapper.createWithResult(chainDefaultTime)
+        }
+
         let babeTimeOperation: BaseOperation<BlockTime> = PrimitiveConstantOperation.operation(
             for: .babeBlockTime,
             dependingOn: codingFactoryOperation
@@ -67,6 +72,7 @@ extension BlockTimeOperationFactory: BlockTimeOperationFactoryProtocol {
         let estimatedOperation = blockTimeEstimationService.createEstimatedBlockTimeOperation()
         let expectedWrapper = createExpectedBlockTimeWrapper(
             dependingOn: codingFactoryOperation,
+            chainDefaultTime: chain.defaultBlockTimeMillis,
             fallbackTime: fallbackBlockTime,
             fallbackThreshold: Self.fallbackThreshold
         )

--- a/novawallet/Modules/Staking/StakingSetupAmount/Model/StakingTypeBalanceFactory.swift
+++ b/novawallet/Modules/Staking/StakingSetupAmount/Model/StakingTypeBalanceFactory.swift
@@ -14,6 +14,12 @@ protocol StakingTypeBalanceFactoryProtocol: AnyObject {
     ) -> BigUInt?
 }
 
+extension StakingTypeBalanceFactoryProtocol {
+    func getAvailableBalance(from assetBalance: AssetBalance?) -> BigUInt? {
+        getAvailableBalance(from: assetBalance, stakingMethod: .recommendation(nil))
+    }
+}
+
 final class StakingTypeBalanceFactory: StakingTypeBalanceFactoryProtocol {
     let stakingType: StakingType?
 

--- a/novawallet/Modules/Staking/StartStakingInfo/Model/DefaultStakingRewardDestination.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/Model/DefaultStakingRewardDestination.swift
@@ -1,4 +1,5 @@
 enum DefaultStakingRewardDestination {
     case balance
     case stake
+    case manual
 }

--- a/novawallet/Modules/Staking/StartStakingInfo/Model/StartStakingStateProtocol.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/Model/StartStakingStateProtocol.swift
@@ -8,5 +8,6 @@ protocol StartStakingStateProtocol {
     var maxApy: Decimal? { get }
     var rewardsAutoPayoutThresholdAmount: BigUInt? { get }
     var govThresholdAmount: BigUInt? { get }
+    var shouldHaveGovInfo: Bool { get }
     var rewardsDestination: DefaultStakingRewardDestination { get }
 }

--- a/novawallet/Modules/Staking/StartStakingInfo/Model/StartStakingViewModelFactory.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/Model/StartStakingViewModelFactory.swift
@@ -171,21 +171,31 @@ struct StartStakingViewModelFactory: StartStakingViewModelFactoryProtocol {
                 preferredLanguages: locale.rLanguages
             )
         } else {
-            let destinationString: String
             switch destination {
             case .balance:
-                destinationString = R.string.localizable.stakingStartRewardsDestinationBalance(
+                let destinationString = R.string.localizable.stakingStartRewardsDestinationBalance(
                     preferredLanguages: locale.rLanguages)
-            case .stake:
-                destinationString = R.string.localizable.stakingStartRewardsDestinationStake(
-                    preferredLanguages: locale.rLanguages)
-            }
 
-            text = R.string.localizable.stakingStartRewardsCommon(
-                rewardIntervals,
-                destinationString,
-                preferredLanguages: locale.rLanguages
-            )
+                text = R.string.localizable.stakingStartRewardsCommon(
+                    rewardIntervals,
+                    destinationString,
+                    preferredLanguages: locale.rLanguages
+                )
+            case .stake:
+                let destinationString = R.string.localizable.stakingStartRewardsDestinationStake(
+                    preferredLanguages: locale.rLanguages)
+
+                text = R.string.localizable.stakingStartRewardsCommon(
+                    rewardIntervals,
+                    destinationString,
+                    preferredLanguages: locale.rLanguages
+                )
+            case .manual:
+                text = R.string.localizable.stakingStartRewardsManualClaim(
+                    rewardIntervals,
+                    preferredLanguages: locale.rLanguages
+                )
+            }
         }
 
         let textWithAccents = AccentTextModel(

--- a/novawallet/Modules/Staking/StartStakingInfo/ParachainStaking/StartStakingInfoParachainPresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/ParachainStaking/StartStakingInfoParachainPresenter.swift
@@ -4,7 +4,7 @@ import BigInt
 final class StartStakingInfoParachainPresenter: StartStakingInfoBasePresenter {
     let interactor: StartStakingInfoParachainInteractorInputProtocol
 
-    private var state: State = .init() {
+    private var state: State {
         didSet {
             if state != oldValue {
                 provideViewModel(state: state)
@@ -22,6 +22,7 @@ final class StartStakingInfoParachainPresenter: StartStakingInfoBasePresenter {
         applicationConfig: ApplicationConfigProtocol,
         logger: LoggerProtocol
     ) {
+        state = .init(chainAsset: chainAsset)
         self.interactor = interactor
 
         super.init(
@@ -104,6 +105,8 @@ extension StartStakingInfoParachainPresenter: StartStakingInfoParachainInteracto
 
 extension StartStakingInfoParachainPresenter {
     struct State: StartStakingStateProtocol, Equatable {
+        let chainAsset: ChainAsset
+
         var networkInfo: ParachainStaking.NetworkInfo?
         var roundInfo: ParachainStaking.RoundInfo?
         var maxApy: Decimal?
@@ -121,6 +124,10 @@ extension StartStakingInfoParachainPresenter {
         }
 
         var govThresholdAmount: BigUInt? { nil }
+
+        var shouldHaveGovInfo: Bool {
+            chainAsset.chain.hasGovernance
+        }
 
         var rewardsAutoPayoutThresholdAmount: BigUInt? { nil }
 

--- a/novawallet/Modules/Staking/StartStakingInfo/ParachainStaking/StartStakingInfoParachainPresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/ParachainStaking/StartStakingInfoParachainPresenter.swift
@@ -17,6 +17,7 @@ final class StartStakingInfoParachainPresenter: StartStakingInfoBasePresenter {
         interactor: StartStakingInfoParachainInteractorInputProtocol,
         wireframe: StartStakingInfoWireframeProtocol,
         startStakingViewModelFactory: StartStakingViewModelFactoryProtocol,
+        balanceDerivationFactory: StakingTypeBalanceFactoryProtocol,
         localizationManager: LocalizationManagerProtocol,
         applicationConfig: ApplicationConfigProtocol,
         logger: LoggerProtocol
@@ -28,6 +29,7 @@ final class StartStakingInfoParachainPresenter: StartStakingInfoBasePresenter {
             interactor: interactor,
             wireframe: wireframe,
             startStakingViewModelFactory: startStakingViewModelFactory,
+            balanceDerivationFactory: balanceDerivationFactory,
             localizationManager: localizationManager,
             applicationConfig: applicationConfig,
             logger: logger

--- a/novawallet/Modules/Staking/StartStakingInfo/RelaychainStaking/StartStakingInfoRelaychainPresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/RelaychainStaking/StartStakingInfoRelaychainPresenter.swift
@@ -22,7 +22,7 @@ final class StartStakingInfoRelaychainPresenter: StartStakingInfoBasePresenter {
         applicationConfig: ApplicationConfigProtocol,
         logger: LoggerProtocol
     ) {
-        state = .init(stakingType: selectedStakingType)
+        state = .init(stakingType: selectedStakingType, chainAsset: chainAsset)
         self.interactor = interactor
 
         super.init(
@@ -101,6 +101,7 @@ extension StartStakingInfoRelaychainPresenter: StartStakingInfoRelaychainInterac
 extension StartStakingInfoRelaychainPresenter {
     struct State: StartStakingStateProtocol {
         let stakingType: StakingType?
+        let chainAsset: ChainAsset
 
         var networkInfo: NetworkStakingInfo?
         var eraCountdown: EraCountdown?
@@ -153,6 +154,7 @@ extension StartStakingInfoRelaychainPresenter {
 
         var rewardsAutoPayoutThresholdAmount: BigUInt? {
             guard
+                stakingType == nil,
                 nominationPoolMinimumStake != nil,
                 let directStakingMinimumStake = directStakingMinimumStake,
                 let minStake = minStake else {
@@ -164,6 +166,15 @@ extension StartStakingInfoRelaychainPresenter {
 
         var govThresholdAmount: BigUInt? {
             rewardsAutoPayoutThresholdAmount
+        }
+
+        var shouldHaveGovInfo: Bool {
+            switch stakingType {
+            case .nominationPools:
+                return false
+            default:
+                return chainAsset.chain.hasGovernance
+            }
         }
 
         var unstakingTime: TimeInterval? {

--- a/novawallet/Modules/Staking/StartStakingInfo/RelaychainStaking/StartStakingInfoRelaychainPresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/RelaychainStaking/StartStakingInfoRelaychainPresenter.swift
@@ -16,6 +16,7 @@ final class StartStakingInfoRelaychainPresenter: StartStakingInfoBasePresenter {
         interactor: StartStakingInfoRelaychainInteractorInputProtocol,
         wireframe: StartStakingInfoWireframeProtocol,
         startStakingViewModelFactory: StartStakingViewModelFactoryProtocol,
+        balanceDerivationFactory: StakingTypeBalanceFactoryProtocol,
         localizationManager: LocalizationManagerProtocol,
         applicationConfig: ApplicationConfigProtocol,
         logger: LoggerProtocol
@@ -27,6 +28,7 @@ final class StartStakingInfoRelaychainPresenter: StartStakingInfoBasePresenter {
             interactor: interactor,
             wireframe: wireframe,
             startStakingViewModelFactory: startStakingViewModelFactory,
+            balanceDerivationFactory: balanceDerivationFactory,
             localizationManager: localizationManager,
             applicationConfig: applicationConfig,
             logger: logger

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
@@ -109,7 +109,7 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
             locale: selectedLocale
         ) : nil
 
-        let govModel = chainAsset.chain.hasGovernance ? startStakingViewModelFactory.govModel(
+        let govModel = state.shouldHaveGovInfo ? startStakingViewModelFactory.govModel(
             amount: state.govThresholdAmount,
             chainAsset: chainAsset,
             locale: selectedLocale

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
@@ -7,6 +7,7 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
     let wireframe: StartStakingInfoWireframeProtocol
     let baseInteractor: StartStakingInfoInteractorInputProtocol
     let startStakingViewModelFactory: StartStakingViewModelFactoryProtocol
+    let balanceDerivationFactory: StakingTypeBalanceFactoryProtocol
     let applicationConfig: ApplicationConfigProtocol
     let chainAsset: ChainAsset
     let logger: LoggerProtocol
@@ -21,6 +22,7 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
         interactor: StartStakingInfoInteractorInputProtocol,
         wireframe: StartStakingInfoWireframeProtocol,
         startStakingViewModelFactory: StartStakingViewModelFactoryProtocol,
+        balanceDerivationFactory: StakingTypeBalanceFactoryProtocol,
         localizationManager: LocalizationManagerProtocol,
         applicationConfig: ApplicationConfigProtocol,
         logger: LoggerProtocol
@@ -29,6 +31,7 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
         baseInteractor = interactor
         self.wireframe = wireframe
         self.startStakingViewModelFactory = startStakingViewModelFactory
+        self.balanceDerivationFactory = balanceDerivationFactory
         self.applicationConfig = applicationConfig
         self.logger = logger
         self.localizationManager = localizationManager
@@ -41,8 +44,12 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
 
         switch accountExistense {
         case let .assetBalance(balance):
+            guard let availableBalance = balanceDerivationFactory.getAvailableBalance(from: balance) else {
+                return
+            }
+
             let viewModel = startStakingViewModelFactory.balance(
-                amount: balance.freeInPlank,
+                amount: availableBalance,
                 priceData: price,
                 chainAsset: chainAsset,
                 locale: selectedLocale

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
@@ -87,6 +87,7 @@ struct StartStakingInfoViewFactory {
         )
 
         let presenter = StartStakingInfoRelaychainPresenter(
+            selectedStakingType: state.stakingType,
             chainAsset: chainAsset,
             interactor: interactor,
             wireframe: wireframe,

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
@@ -91,6 +91,7 @@ struct StartStakingInfoViewFactory {
             interactor: interactor,
             wireframe: wireframe,
             startStakingViewModelFactory: startStakingViewModelFactory,
+            balanceDerivationFactory: StakingTypeBalanceFactory(stakingType: state.stakingType),
             localizationManager: LocalizationManager.shared,
             applicationConfig: ApplicationConfig.shared,
             logger: Logger.shared
@@ -171,6 +172,7 @@ struct StartStakingInfoViewFactory {
             interactor: interactor,
             wireframe: wireframe,
             startStakingViewModelFactory: startStakingViewModelFactory,
+            balanceDerivationFactory: StakingTypeBalanceFactory(stakingType: stakingOption.type),
             localizationManager: LocalizationManager.shared,
             applicationConfig: ApplicationConfig.shared,
             logger: Logger.shared


### PR DESCRIPTION
- display the same available balance depending on staking type on Dashboard, Start Staking Info and Setup Amount #85ztugceh

- use default block time from chain #85ztrenv9

- display start staking info depending on selected staking type #85ztw2vtq

![combined-flow](https://github.com/novasamatech/nova-wallet-ios/assets/570634/0f95672e-4def-4195-8a60-c8cd44e72de0)

![direct-staking](https://github.com/novasamatech/nova-wallet-ios/assets/570634/b7005d4a-0103-40ca-8844-5a9efe23b604)

![pool-staking](https://github.com/novasamatech/nova-wallet-ios/assets/570634/1afd1f01-f41b-4994-86c5-775fe48d733a)
