### PR TITLE
Swaps: Slippage bugfixes

### DIFF
--- a/novawallet/Modules/Swaps/Slippage/SwapSlippagePresenter.swift
+++ b/novawallet/Modules/Swaps/Slippage/SwapSlippagePresenter.swift
@@ -62,7 +62,7 @@ final class SwapSlippagePresenter {
         view?.didReceiveInput(viewModel: inputViewModel)
     }
 
-    private func provideButtonsState() {
+    private func provideButtonStates() {
         let amountChanged = amountInput != initialPercent()
         view?.didReceiveResetState(available: amountChanged)
         view?.didReceiveButtonState(available: amountChanged)
@@ -117,7 +117,7 @@ extension SwapSlippagePresenter: SwapSlippagePresenterProtocol {
         }
 
         amountInput = initialPercent()
-        provideButtonsState()
+        provideButtonStates()
         provideAmountViewModel()
         provideWarnings()
         view?.didReceivePreFilledPercents(viewModel: viewModel)
@@ -126,14 +126,14 @@ extension SwapSlippagePresenter: SwapSlippagePresenterProtocol {
     func select(percent: SlippagePercentViewModel) {
         amountInput = percent.value
         provideAmountViewModel()
-        provideButtonsState()
+        provideButtonStates()
         provideErrors()
         provideWarnings()
     }
 
     func updateAmount(_ amount: Decimal?) {
         amountInput = amount
-        provideButtonsState()
+        provideButtonStates()
         provideErrors()
         provideWarnings()
     }
@@ -155,7 +155,7 @@ extension SwapSlippagePresenter: SwapSlippagePresenterProtocol {
     func reset() {
         amountInput = initialPercent()
         provideAmountViewModel()
-        provideButtonsState()
+        provideButtonStates()
         provideErrors()
         provideWarnings()
     }

--- a/novawallet/Modules/Swaps/Slippage/SwapSlippagePresenter.swift
+++ b/novawallet/Modules/Swaps/Slippage/SwapSlippagePresenter.swift
@@ -56,16 +56,16 @@ final class SwapSlippagePresenter {
             amount: amountInput,
             limit: 100,
             formatter: numberFormatter,
-            inputLocale: selectedLocale,
             precision: 1
         )
 
         view?.didReceiveInput(viewModel: inputViewModel)
     }
 
-    private func provideResetButtonState() {
+    private func provideButtonsState() {
         let amountChanged = amountInput != initialPercent()
         view?.didReceiveResetState(available: amountChanged)
+        view?.didReceiveButtonState(available: amountChanged)
     }
 
     private func provideErrors() {
@@ -79,8 +79,10 @@ final class SwapSlippagePresenter {
                 preferredLanguages: selectedLocale.rLanguages
             )
             view?.didReceiveInput(error: error)
+            view?.didReceiveButtonState(available: false)
         } else {
             view?.didReceiveInput(error: nil)
+            view?.didReceiveButtonState(available: amountInput != initialPercent())
         }
     }
 
@@ -115,7 +117,7 @@ extension SwapSlippagePresenter: SwapSlippagePresenterProtocol {
         }
 
         amountInput = initialPercent()
-        provideResetButtonState()
+        provideButtonsState()
         provideAmountViewModel()
         provideWarnings()
         view?.didReceivePreFilledPercents(viewModel: viewModel)
@@ -124,14 +126,14 @@ extension SwapSlippagePresenter: SwapSlippagePresenterProtocol {
     func select(percent: SlippagePercentViewModel) {
         amountInput = percent.value
         provideAmountViewModel()
-        provideResetButtonState()
+        provideButtonsState()
         provideErrors()
         provideWarnings()
     }
 
     func updateAmount(_ amount: Decimal?) {
         amountInput = amount
-        provideResetButtonState()
+        provideButtonsState()
         provideErrors()
         provideWarnings()
     }
@@ -153,7 +155,7 @@ extension SwapSlippagePresenter: SwapSlippagePresenterProtocol {
     func reset() {
         amountInput = initialPercent()
         provideAmountViewModel()
-        provideResetButtonState()
+        provideButtonsState()
         provideErrors()
         provideWarnings()
     }

--- a/novawallet/Modules/Swaps/Slippage/SwapSlippageProtocols.swift
+++ b/novawallet/Modules/Swaps/Slippage/SwapSlippageProtocols.swift
@@ -6,6 +6,7 @@ protocol SwapSlippageViewProtocol: ControllerBackedProtocol {
     func didReceiveInput(error: String?)
     func didReceiveInput(warning: String?)
     func didReceiveResetState(available: Bool)
+    func didReceiveButtonState(available: Bool)
 }
 
 protocol SwapSlippagePresenterProtocol: AnyObject {

--- a/novawallet/Modules/Swaps/Slippage/SwapSlippageViewController.swift
+++ b/novawallet/Modules/Swaps/Slippage/SwapSlippageViewController.swift
@@ -5,6 +5,7 @@ final class SwapSlippageViewController: UIViewController, ViewHolder {
     typealias RootViewType = SwapSlippageViewLayout
 
     let presenter: SwapSlippagePresenterProtocol
+    private var isApplyAvailable: Bool = false
 
     init(
         presenter: SwapSlippagePresenterProtocol,
@@ -74,7 +75,7 @@ final class SwapSlippageViewController: UIViewController, ViewHolder {
 
     private func updateActionButton() {
         let inputValid = rootView.amountInput.inputViewModel?.isValid == true
-        rootView.actionButton.isEnabled = inputValid && rootView.errorLabel.isHidden
+        rootView.actionButton.isEnabled = isApplyAvailable && inputValid
     }
 
     @objc private func applyButtonAction() {
@@ -112,6 +113,11 @@ extension SwapSlippageViewController: SwapSlippageViewProtocol {
 
     func didReceiveResetState(available: Bool) {
         navigationItem.rightBarButtonItem?.isEnabled = available
+    }
+
+    func didReceiveButtonState(available: Bool) {
+        isApplyAvailable = available
+        updateActionButton()
     }
 
     func didReceiveInput(error: String?) {


### PR DESCRIPTION
Bugs
- not possible to input decimals
- reset works only on input, saves applied slippage, maybe we can disable Apply button for already applied slippage

Done:

- Fix locale for input view model
- Add updating apply button state 