### PR TITLE
Support new balance logic from fungible trait

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -159,7 +159,7 @@ DEPENDENCIES:
   - SnapKit (~> 5.0.0)
   - SoraFoundation (from `https://github.com/ERussel/Foundation-iOS.git`, tag `1.1.0`)
   - SoraKeystore (~> 1.0.0)
-  - SoraUI (from `https://github.com/ERussel/UIkit-iOS.git`, commit `a4eb0139a27d77f11b8e5083e125c38ea82d8e5e`)
+  - SoraUI (from `https://github.com/ERussel/UIkit-iOS.git`, tag `1.12.0`)
   - Sourcery (~> 1.4)
   - Starscream (from `https://github.com/ERussel/Starscream.git`, tag `4.0.8`)
   - SubstrateSdk (from `https://github.com/nova-wallet/substrate-sdk-ios.git`, tag `1.14.0`)
@@ -213,8 +213,8 @@ EXTERNAL SOURCES:
     :git: https://github.com/ERussel/Foundation-iOS.git
     :tag: 1.1.0
   SoraUI:
-    :commit: a4eb0139a27d77f11b8e5083e125c38ea82d8e5e
     :git: https://github.com/ERussel/UIkit-iOS.git
+    :tag: 1.12.0
   Starscream:
     :git: https://github.com/ERussel/Starscream.git
     :tag: 4.0.8
@@ -244,8 +244,8 @@ CHECKOUT OPTIONS:
     :git: https://github.com/ERussel/Foundation-iOS.git
     :tag: 1.1.0
   SoraUI:
-    :commit: a4eb0139a27d77f11b8e5083e125c38ea82d8e5e
     :git: https://github.com/ERussel/UIkit-iOS.git
+    :tag: 1.12.0
   Starscream:
     :git: https://github.com/ERussel/Starscream.git
     :tag: 4.0.8
@@ -303,6 +303,6 @@ SPEC CHECKSUMS:
   ZMarkupParser: a92d31ba40695b790f1da5fec98c3d4505341aff
   ZNSTextAttachment: 4a9b4e8ee1ed087fc893ae6657dfb678f1a00340
 
-PODFILE CHECKSUM: 812e09964099216590d3e74fcb350c38b2ccbd38
+PODFILE CHECKSUM: 92c4460ed01f6a3d13c8409165eef6676907b3c3
 
 COCOAPODS: 1.13.0

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -4142,6 +4142,7 @@
 		0B556386CEEB76C95ED59897 /* ControllerAccountViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ControllerAccountViewController.swift; sourceTree = "<group>"; };
 		0B62C2CBCFF1865A1CA0F1B4 /* LedgerNetworkSelectionProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LedgerNetworkSelectionProtocols.swift; sourceTree = "<group>"; };
 		0BA85EE628D7029AC940DFA3 /* NominationPoolBondMoreBasePresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NominationPoolBondMoreBasePresenter.swift; sourceTree = "<group>"; };
+		0C0130482B0E5BD300746952 /* SubstrateDataModel22.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SubstrateDataModel22.xcdatamodel; sourceTree = "<group>"; };
 		0C04290B2A67A42A00C3583A /* SubstrateDataModel17.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SubstrateDataModel17.xcdatamodel; sourceTree = "<group>"; };
 		0C0CB37E2AC540B200EAC516 /* AssetConversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetConversion.swift; sourceTree = "<group>"; };
 		0C0CB3812AC545A800EAC516 /* AssetConversionExtrinsicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetConversionExtrinsicService.swift; sourceTree = "<group>"; };
@@ -24413,6 +24414,7 @@
 		843910CA253F7E6500E3C217 /* SubstrateDataModel.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				0C0130482B0E5BD300746952 /* SubstrateDataModel22.xcdatamodel */,
 				77AAE22B2AFCD7AA006872CC /* SubstrateDataModel21.xcdatamodel */,
 				0CEB4ECF2AF148500048FD84 /* SubstrateDataModel20.xcdatamodel */,
 				0C59E8C72AA5C3F4001E11F3 /* SubstrateDataModel19.xcdatamodel */,
@@ -24435,7 +24437,7 @@
 				88787F0328DB3A7B00B115AB /* SubstrateDataModel2.xcdatamodel */,
 				843910CB253F7E6500E3C217 /* SubstrateDataModel.xcdatamodel */,
 			);
-			currentVersion = 77AAE22B2AFCD7AA006872CC /* SubstrateDataModel21.xcdatamodel */;
+			currentVersion = 0C0130482B0E5BD300746952 /* SubstrateDataModel22.xcdatamodel */;
 			path = SubstrateDataModel.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/novawallet/Common/Migration/SubstrateStorageVersion.swift
+++ b/novawallet/Common/Migration/SubstrateStorageVersion.swift
@@ -20,6 +20,7 @@ enum SubstrateStorageVersion: String, CaseIterable {
     case version19 = "SubstrateDataModel19"
     case version20 = "SubstrateDataModel20"
     case version21 = "SubstrateDataModel21"
+    case version22 = "SubstrateDataModel22"
 
     static var current: SubstrateStorageVersion {
         allCases.last!
@@ -68,6 +69,8 @@ enum SubstrateStorageVersion: String, CaseIterable {
         case .version20:
             return .version21
         case .version21:
+            return .version22
+        case .version22:
             return nil
         }
     }

--- a/novawallet/Common/Services/RemoteSubscription/Equilibrium/Updaters/EquillibriumAssetsBalanceUpdater.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Equilibrium/Updaters/EquillibriumAssetsBalanceUpdater.swift
@@ -188,6 +188,8 @@ final class EquillibriumAssetsBalanceUpdater {
                         freeInPlank: freeInPlank,
                         reservedInPlank: reservedInPlank,
                         frozenInPlank: frozenInPlank,
+                        edCountMode: .basedOnTotal,
+                        transferrableMode: .regular,
                         blocked: false
                     )
                 }

--- a/novawallet/Common/Services/RemoteSubscription/Evm/ERC20/ERC20BalanceUpdateService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Evm/ERC20/ERC20BalanceUpdateService.swift
@@ -70,6 +70,8 @@ final class ERC20BalanceUpdateService: BaseSyncService, AnyCancellableCleaning {
                     freeInPlank: newBalance,
                     reservedInPlank: 0,
                     frozenInPlank: 0,
+                    edCountMode: .basedOnFree,
+                    transferrableMode: .regular,
                     blocked: false
                 )
             }

--- a/novawallet/Common/Services/RemoteSubscription/Evm/Native/EvmNativeBalanceUpdateService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Evm/Native/EvmNativeBalanceUpdateService.swift
@@ -61,6 +61,8 @@ final class EvmNativeBalanceUpdateService: BaseSyncService, AnyCancellableCleani
                 freeInPlank: newBalance,
                 reservedInPlank: 0,
                 frozenInPlank: 0,
+                edCountMode: .basedOnFree,
+                transferrableMode: .regular,
                 blocked: false
             )
 

--- a/novawallet/Common/Services/WebSocketService/StorageSubscription/AccountInfoSubscription.swift
+++ b/novawallet/Common/Services/WebSocketService/StorageSubscription/AccountInfoSubscription.swift
@@ -89,6 +89,8 @@ final class AccountInfoSubscription {
                 freeInPlank: account?.data.free ?? 0,
                 reservedInPlank: account?.data.reserved ?? 0,
                 frozenInPlank: account?.data.locked ?? 0,
+                edCountMode: account?.data.edCountMode ?? .basedOnFree,
+                transferrableMode: account?.data.transferrableModel ?? .regular,
                 blocked: false
             )
 

--- a/novawallet/Common/Services/WebSocketService/StorageSubscription/AssetsBalanceUpdater.swift
+++ b/novawallet/Common/Services/WebSocketService/StorageSubscription/AssetsBalanceUpdater.swift
@@ -181,6 +181,8 @@ final class AssetsBalanceUpdater {
                 freeInPlank: balance,
                 reservedInPlank: 0,
                 frozenInPlank: isFrozen ? balance : 0,
+                edCountMode: .basedOnTotal,
+                transferrableMode: .regular,
                 blocked: isBlocked
             )
 

--- a/novawallet/Common/Services/WebSocketService/StorageSubscription/OrmlAccountSubscription.swift
+++ b/novawallet/Common/Services/WebSocketService/StorageSubscription/OrmlAccountSubscription.swift
@@ -89,6 +89,8 @@ final class OrmlAccountSubscription {
                 freeInPlank: account?.free ?? 0,
                 reservedInPlank: account?.reserved ?? 0,
                 frozenInPlank: account?.frozen ?? 0,
+                edCountMode: .basedOnTotal,
+                transferrableMode: .regular,
                 blocked: false
             )
 

--- a/novawallet/Common/Storage/EntityToModel/AssetBalanceMapper.swift
+++ b/novawallet/Common/Storage/EntityToModel/AssetBalanceMapper.swift
@@ -23,6 +23,8 @@ extension AssetBalanceMapper: CoreDataMapperProtocol {
         entity.freeInPlank = String(model.freeInPlank)
         entity.reservedInPlank = String(model.reservedInPlank)
         entity.frozenInPlank = String(model.frozenInPlank)
+        entity.transferrableMode = model.transferrableMode.toRepositoryValue()
+        entity.edCountMode = model.edCountMode.toRepositoryValue()
         entity.blocked = model.blocked
     }
 
@@ -30,6 +32,20 @@ extension AssetBalanceMapper: CoreDataMapperProtocol {
         let free = entity.freeInPlank.map { BigUInt($0) ?? 0 } ?? 0
         let reserved = entity.reservedInPlank.map { BigUInt($0) ?? 0 } ?? 0
         let frozen = entity.frozenInPlank.map { BigUInt($0) ?? 0 } ?? 0
+
+        guard
+            let transferrableMode = AssetBalance.TransferrableMode(
+                fromRepositoryValue: entity.transferrableMode
+            ) else {
+            throw CommonError.dataCorruption
+        }
+
+        guard
+            let edCountMode = AssetBalance.ExistentialDepositCountMode(
+                fromRepositoryValue: entity.edCountMode
+            ) else {
+            throw CommonError.dataCorruption
+        }
 
         let accountId = try Data(hexString: entity.chainAccountId!)
 
@@ -42,7 +58,53 @@ extension AssetBalanceMapper: CoreDataMapperProtocol {
             freeInPlank: free,
             reservedInPlank: reserved,
             frozenInPlank: frozen,
+            edCountMode: edCountMode,
+            transferrableMode: transferrableMode,
             blocked: entity.blocked
         )
+    }
+}
+
+extension AssetBalance.TransferrableMode {
+    func toRepositoryValue() -> Int16 {
+        switch self {
+        case .regular:
+            return 0
+        case .fungibleTrait:
+            return 1
+        }
+    }
+
+    init?(fromRepositoryValue: Int16) {
+        switch fromRepositoryValue {
+        case 0:
+            self = .regular
+        case 1:
+            self = .fungibleTrait
+        default:
+            return nil
+        }
+    }
+}
+
+extension AssetBalance.ExistentialDepositCountMode {
+    func toRepositoryValue() -> Int16 {
+        switch self {
+        case .basedOnFree:
+            return 0
+        case .basedOnTotal:
+            return 1
+        }
+    }
+
+    init?(fromRepositoryValue: Int16) {
+        switch fromRepositoryValue {
+        case 0:
+            self = .basedOnFree
+        case 1:
+            self = .basedOnTotal
+        default:
+            return nil
+        }
     }
 }

--- a/novawallet/Common/Storage/SubstrateDataModel.xcdatamodeld/.xccurrentversion
+++ b/novawallet/Common/Storage/SubstrateDataModel.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>SubstrateDataModel21.xcdatamodel</string>
+	<string>SubstrateDataModel22.xcdatamodel</string>
 </dict>
 </plist>

--- a/novawallet/Common/Storage/SubstrateDataModel.xcdatamodeld/SubstrateDataModel22.xcdatamodel/contents
+++ b/novawallet/Common/Storage/SubstrateDataModel.xcdatamodeld/SubstrateDataModel22.xcdatamodel/contents
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F66" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CDAsset" representedClassName="CDAsset" syncable="YES" codeGenerationType="class">
+        <attribute name="assetId" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="buyProviders" optional="YES" attributeType="Binary"/>
+        <attribute name="enabled" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="icon" optional="YES" attributeType="URI"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="precision" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="priceId" optional="YES" attributeType="String"/>
+        <attribute name="source" attributeType="String" defaultValueString="remote"/>
+        <attribute name="staking" optional="YES" attributeType="String"/>
+        <attribute name="symbol" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <attribute name="typeExtras" optional="YES" attributeType="Binary"/>
+        <relationship name="chain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDChain" inverseName="assets" inverseEntity="CDChain"/>
+    </entity>
+    <entity name="CDAssetBalance" representedClassName="CDAssetBalance" syncable="YES" codeGenerationType="class">
+        <attribute name="assetId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="blocked" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="chainAccountId" optional="YES" attributeType="String"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="edCountMode" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="freeInPlank" optional="YES" attributeType="String"/>
+        <attribute name="frozenInPlank" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="reservedInPlank" optional="YES" attributeType="String"/>
+        <attribute name="transferrableMode" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="CDAssetLock" representedClassName="CDAssetLock" syncable="YES" codeGenerationType="class">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="assetId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="chainAccountId" optional="YES" attributeType="String"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDChain" representedClassName="CDChain" syncable="YES" codeGenerationType="class">
+        <attribute name="additional" optional="YES" attributeType="Binary"/>
+        <attribute name="addressPrefix" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="chainId" attributeType="String"/>
+        <attribute name="color" optional="YES" attributeType="String"/>
+        <attribute name="explorers" optional="YES" attributeType="Binary"/>
+        <attribute name="hasCrowdloans" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="hasGovernance" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="hasGovernanceV1" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="hasSwapHub" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="icon" attributeType="URI"/>
+        <attribute name="isEthereumBased" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isTestnet" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="nodeSwitchStrategy" optional="YES" attributeType="String"/>
+        <attribute name="noSubstrateRuntime" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="order" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="parentId" optional="YES" attributeType="String"/>
+        <attribute name="types" optional="YES" attributeType="URI"/>
+        <attribute name="typesOverrideCommon" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <relationship name="assets" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="CDAsset" inverseName="chain" inverseEntity="CDAsset"/>
+        <relationship name="externalApis" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDChainApi" inverseName="chain" inverseEntity="CDChainApi"/>
+        <relationship name="nodes" optional="YES" toMany="YES" minCount="1" deletionRule="Cascade" destinationEntity="CDChainNodeItem" inverseName="chain" inverseEntity="CDChainNodeItem"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="chainId"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="CDChainApi" representedClassName="CDChainApi" syncable="YES" codeGenerationType="class">
+        <attribute name="apiType" optional="YES" attributeType="String"/>
+        <attribute name="parameters" optional="YES" attributeType="Binary"/>
+        <attribute name="serviceType" attributeType="String" defaultValueString=""/>
+        <attribute name="url" attributeType="URI"/>
+        <relationship name="chain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDChain" inverseName="externalApis" inverseEntity="CDChain"/>
+    </entity>
+    <entity name="CDChainNodeItem" representedClassName="CDChainNodeItem" syncable="YES" codeGenerationType="class">
+        <attribute name="features" optional="YES" attributeType="Binary"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <relationship name="chain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDChain" inverseName="nodes" inverseEntity="CDChain"/>
+    </entity>
+    <entity name="CDChainStorageItem" representedClassName="CDChainStorageItem" syncable="YES" codeGenerationType="class">
+        <attribute name="data" optional="YES" attributeType="Binary"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDContactItem" representedClassName="CDContactItem" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="peerAddress" optional="YES" attributeType="String"/>
+        <attribute name="peerName" optional="YES" attributeType="String"/>
+        <attribute name="targetAddress" optional="YES" attributeType="String"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="CDExternalBalance" representedClassName="CDExternalBalance" syncable="YES" codeGenerationType="class">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="assetId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="chainAccountId" optional="YES" attributeType="String"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="param" optional="YES" attributeType="String"/>
+        <attribute name="subtype" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDNft" representedClassName="CDNft" syncable="YES" codeGenerationType="class">
+        <attribute name="chainId" attributeType="String"/>
+        <attribute name="collectionId" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="instanceId" optional="YES" attributeType="String"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="media" optional="YES" attributeType="String"/>
+        <attribute name="metadata" optional="YES" attributeType="Binary"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="ownerId" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="String"/>
+        <attribute name="totalIssuance" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="type" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="CDPhishingItem" representedClassName="CDPhishingItem" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="publicKey" optional="YES" attributeType="String"/>
+        <attribute name="source" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDPhishingSite" representedClassName="CDPhishingSite" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDPrice" representedClassName="CDPrice" syncable="YES" codeGenerationType="class">
+        <attribute name="currency" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dayChange" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDReferendumMetadata" representedClassName="CDReferendumMetadata" syncable="YES" codeGenerationType="class">
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="content" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="proposer" optional="YES" attributeType="String"/>
+        <attribute name="referendumId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timeline" optional="YES" attributeType="Binary"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDRuntimeMetadataItem" representedClassName="CDRuntimeMetadataItem" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="metadata" optional="YES" attributeType="Binary"/>
+        <attribute name="txVersion" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="version" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="CDSingleValue" representedClassName="CDSingleValue" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="payload" attributeType="Binary"/>
+    </entity>
+    <entity name="CDStakingAccount" representedClassName="CDStakingAccount" syncable="YES" codeGenerationType="class">
+        <attribute name="assetId" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="chainId" attributeType="String"/>
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="resolvedAccountId" attributeType="String"/>
+        <attribute name="rewardsAccountId" optional="YES" attributeType="String"/>
+        <attribute name="stakingType" attributeType="String"/>
+        <attribute name="walletAccountId" attributeType="String"/>
+    </entity>
+    <entity name="CDStakingDashboardItem" representedClassName="CDStakingDashboardItem" syncable="YES" codeGenerationType="class">
+        <attribute name="assetId" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="chainId" attributeType="String"/>
+        <attribute name="hasAssignedStake" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="maxApy" optional="YES" attributeType="Decimal"/>
+        <attribute name="onchainState" optional="YES" attributeType="String"/>
+        <attribute name="stake" optional="YES" attributeType="String"/>
+        <attribute name="stakingType" attributeType="String"/>
+        <attribute name="totalRewards" optional="YES" attributeType="String"/>
+        <attribute name="walletId" attributeType="String"/>
+    </entity>
+    <entity name="CDStashItem" representedClassName="CDStashItem" syncable="YES" codeGenerationType="class">
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="controller" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="stash" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDTransactionItem" representedClassName="CDTransactionItem" syncable="YES" codeGenerationType="class">
+        <attribute name="amountInPlank" optional="YES" attributeType="String"/>
+        <attribute name="assetId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="blockNumber" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="call" optional="YES" attributeType="Binary"/>
+        <attribute name="callName" optional="YES" attributeType="String"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="fee" optional="YES" attributeType="String"/>
+        <attribute name="feeAssetId" optional="YES" attributeType="Integer 32" usesScalarValueType="NO"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="moduleName" optional="YES" attributeType="String"/>
+        <attribute name="receiver" optional="YES" attributeType="String"/>
+        <attribute name="sender" optional="YES" attributeType="String"/>
+        <attribute name="source" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timestamp" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="txHash" optional="YES" attributeType="String"/>
+        <attribute name="txIndex" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO"/>
+        <relationship name="swap" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDTransactionSwapItem" inverseName="transaction" inverseEntity="CDTransactionSwapItem"/>
+    </entity>
+    <entity name="CDTransactionSwapItem" representedClassName="CDTransactionSwapItem" syncable="YES" codeGenerationType="class">
+        <attribute name="amountIn" optional="YES" attributeType="String"/>
+        <attribute name="amountOut" optional="YES" attributeType="String"/>
+        <attribute name="assetIdIn" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="assetIdOut" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <relationship name="transaction" optional="YES" maxCount="1" deletionRule="Deny" destinationEntity="CDTransactionItem" inverseName="swap" inverseEntity="CDTransactionItem"/>
+    </entity>
+</model>

--- a/novawallet/Common/Storage/SubstrateDataStorageFacade.swift
+++ b/novawallet/Common/Storage/SubstrateDataStorageFacade.swift
@@ -4,7 +4,7 @@ import CoreData
 enum SubstrateStorageParams {
     static let databaseName = "SubstrateDataModel.sqlite"
     static let modelDirectory: String = "SubstrateDataModel.momd"
-    static let modelVersion: SubstrateStorageVersion = .version21
+    static let modelVersion: SubstrateStorageVersion = .version22
 
     static let storageDirectoryURL: URL = {
         let baseURL = FileManager.default.urls(

--- a/novawallet/Common/Substrate/Types/AccountInfo.swift
+++ b/novawallet/Common/Substrate/Types/AccountInfo.swift
@@ -18,6 +18,7 @@ struct AccountData: Codable, Equatable {
     @OptionStringCodable var frozen: BigUInt?
     @OptionStringCodable var miscFrozen: BigUInt?
     @OptionStringCodable var feeFrozen: BigUInt?
+    @OptionStringCodable var flags: BigUInt?
 }
 
 extension AccountData {
@@ -32,4 +33,24 @@ extension AccountData {
     }
 
     var available: BigUInt { free > locked ? free - locked : 0 }
+}
+
+extension AccountData {
+    static let fungibleTraitLogic = BigUInt(1) << 127
+
+    var isFungibleTraitLogic: Bool {
+        guard let flags = flags else {
+            return false
+        }
+
+        return (flags & Self.fungibleTraitLogic) == Self.fungibleTraitLogic
+    }
+
+    var edCountMode: AssetBalance.ExistentialDepositCountMode {
+        isFungibleTraitLogic ? .basedOnFree : .basedOnTotal
+    }
+
+    var transferrableModel: AssetBalance.TransferrableMode {
+        isFungibleTraitLogic ? .fungibleTrait : .regular
+    }
 }

--- a/novawallet/Modules/Staking/NominationPools/BondMore/Setup/NominationPoolBondMoreSetupPresenter.swift
+++ b/novawallet/Modules/Staking/NominationPools/BondMore/Setup/NominationPoolBondMoreSetupPresenter.swift
@@ -75,9 +75,9 @@ final class NominationPoolBondMoreSetupPresenter: NominationPoolBondMoreBasePres
         }
         let fee = fee?.decimal(precision: chainAsset.asset.precision) ?? 0
         let transferable = assetBalance?.transferable.decimal(precision: chainAsset.asset.precision) ?? 0
-        let total = assetBalance?.totalInPlank.decimal(precision: chainAsset.asset.precision) ?? 0
+        let balanceCountingEd = assetBalance?.balanceCountingEd.decimal(precision: chainAsset.asset.precision) ?? 0
         let existentialDeposit = assetBalanceExistance?.minBalance.decimal(precision: chainAsset.asset.precision) ?? 0
-        let value = max(min(transferable - fee, total - fee - existentialDeposit), 0)
+        let value = max(min(transferable - fee, balanceCountingEd - fee - existentialDeposit), 0)
         return inputResult.absoluteValue(from: value)
     }
 

--- a/novawallet/Modules/Staking/NominationPools/ClaimRewards/NPoolsClaimRewardsPresenter.swift
+++ b/novawallet/Modules/Staking/NominationPools/ClaimRewards/NPoolsClaimRewardsPresenter.swift
@@ -138,7 +138,7 @@ extension NPoolsClaimRewardsPresenter: NPoolsClaimRewardsPresenterProtocol {
             ),
             dataValidatorFactory.notViolatingMinBalancePaying(
                 fee: fee,
-                total: assetBalance?.totalInPlank,
+                total: assetBalance?.balanceCountingEd,
                 minBalance: existentialDeposit,
                 locale: selectedLocale
             ),

--- a/novawallet/Modules/Staking/NominationPools/Redeem/NPoolsRedeemPresenter.swift
+++ b/novawallet/Modules/Staking/NominationPools/Redeem/NPoolsRedeemPresenter.swift
@@ -135,7 +135,7 @@ extension NPoolsRedeemPresenter: NPoolsRedeemPresenterProtocol {
             ),
             dataValidatorFactory.notViolatingMinBalancePaying(
                 fee: fee,
-                total: assetBalance?.totalInPlank,
+                total: assetBalance?.balanceCountingEd,
                 minBalance: existentialDeposit,
                 locale: selectedLocale
             )

--- a/novawallet/Modules/Staking/NominationPools/Unstake/Base/NPoolsUnstakeBasePresenter.swift
+++ b/novawallet/Modules/Staking/NominationPools/Unstake/Base/NPoolsUnstakeBasePresenter.swift
@@ -108,7 +108,7 @@ class NPoolsUnstakeBasePresenter: NPoolsUnstakeBaseInteractorOutputProtocol {
             ),
             dataValidatorFactory.notViolatingMinBalancePaying(
                 fee: fee,
-                total: assetBalance?.totalInPlank,
+                total: assetBalance?.balanceCountingEd,
                 minBalance: existentialDeposit,
                 locale: selectedLocale
             ),

--- a/novawallet/Modules/Staking/Validation/NominationPoolDataValidatorFactory.swift
+++ b/novawallet/Modules/Staking/Validation/NominationPoolDataValidatorFactory.swift
@@ -328,8 +328,8 @@ extension NominationPoolDataValidatorFactory: NominationPoolDataValidatorFactory
                 return
             }
 
-            let maxStake = assetBalance.totalInPlank > feeAndMinBalance ?
-                assetBalance.totalInPlank - feeAndMinBalance : 0
+            let maxStake = assetBalance.balanceCountingEd > feeAndMinBalance ?
+                assetBalance.balanceCountingEd - feeAndMinBalance : 0
             let maxStakeDecimal = maxStake.decimal(precision: precision)
             let maxStakeString = balanceFactory.amountFromValue(
                 maxStakeDecimal
@@ -381,7 +381,7 @@ extension NominationPoolDataValidatorFactory: NominationPoolDataValidatorFactory
                 return true
             }
 
-            return stakingAmountInPlank + fee + minBalance <= assetBalance.totalInPlank
+            return stakingAmountInPlank + fee + minBalance <= assetBalance.balanceCountingEd
         })
     }
 }

--- a/novawallet/Modules/Swaps/Base/SwapBasePresenter.swift
+++ b/novawallet/Modules/Swaps/Base/SwapBasePresenter.swift
@@ -262,7 +262,7 @@ class SwapBasePresenter {
             ),
             dataValidatingFactory.notViolatingMinBalancePaying(
                 fee: swapModel.feeChainAsset.isUtilityAsset ? swapModel.feeModel?.totalFee.targetAmount : 0,
-                total: swapModel.utilityAssetBalance?.freeInPlank,
+                total: swapModel.utilityAssetBalance?.balanceCountingEd,
                 minBalance: swapModel.feeChainAsset.isUtilityAsset ? swapModel.utilityAssetExistense?.minBalance : 0,
                 locale: locale
             ),

--- a/novawallet/Modules/Transfer/BaseTransfer/CrossChain/CrossChainTransferPresenter.swift
+++ b/novawallet/Modules/Transfer/BaseTransfer/CrossChain/CrossChainTransferPresenter.swift
@@ -20,9 +20,9 @@ class CrossChainTransferPresenter {
     private(set) var destSendingExistence: AssetBalanceExistence?
     private(set) var destUtilityMinBalance: BigUInt?
 
-    var senderUtilityAssetTotal: BigUInt? {
-        isOriginUtilityTransfer ? senderSendingAssetBalance?.totalInPlank :
-            senderUtilityAssetBalance?.totalInPlank
+    var senderUtilityBalanceCountingEd: BigUInt? {
+        isOriginUtilityTransfer ? senderSendingAssetBalance?.balanceCountingEd :
+            senderUtilityAssetBalance?.balanceCountingEd
     }
 
     var senderUtilityAssetTransferable: BigUInt? {
@@ -152,7 +152,7 @@ class CrossChainTransferPresenter {
 
             dataValidatingFactory.notViolatingMinBalancePaying(
                 fee: originFee,
-                total: senderUtilityAssetTotal,
+                total: senderUtilityBalanceCountingEd,
                 minBalance: isOriginUtilityTransfer ? originSendingMinBalance : originUtilityMinBalance,
                 locale: selectedLocale
             ),
@@ -168,7 +168,7 @@ class CrossChainTransferPresenter {
 
             dataValidatingFactory.receiverWillHaveAssetAccount(
                 sendingAmount: sendingAmount,
-                totalAmount: recepientSendingAssetBalance?.totalInPlank,
+                totalAmount: recepientSendingAssetBalance?.balanceCountingEd,
                 minBalance: destSendingExistence?.minBalance,
                 locale: selectedLocale
             ),

--- a/novawallet/Modules/Transfer/BaseTransfer/OnChain/OnChainTransferPresenter.swift
+++ b/novawallet/Modules/Transfer/BaseTransfer/OnChain/OnChainTransferPresenter.swift
@@ -19,9 +19,9 @@ class OnChainTransferPresenter {
     private(set) var sendingAssetExistence: AssetBalanceExistence?
     private(set) var utilityAssetMinBalance: BigUInt?
 
-    var senderUtilityAssetTotal: BigUInt? {
-        isUtilityTransfer ? senderSendingAssetBalance?.totalInPlank :
-            senderUtilityAssetBalance?.totalInPlank
+    var senderUtilityBalanceCountingEd: BigUInt? {
+        isUtilityTransfer ? senderSendingAssetBalance?.balanceCountingEd :
+            senderUtilityAssetBalance?.balanceCountingEd
     }
 
     var senderUtilityAssetTransferable: BigUInt? {
@@ -122,14 +122,14 @@ class OnChainTransferPresenter {
 
             dataValidatingFactory.notViolatingMinBalancePaying(
                 fee: fee?.value,
-                total: senderUtilityAssetTotal,
+                total: senderUtilityBalanceCountingEd,
                 minBalance: isUtilityTransfer ? sendingAssetExistence?.minBalance : utilityAssetMinBalance,
                 locale: selectedLocale
             ),
 
             dataValidatingFactory.receiverWillHaveAssetAccount(
                 sendingAmount: sendingAmount,
-                totalAmount: recepientSendingAssetBalance?.totalInPlank,
+                totalAmount: recepientSendingAssetBalance?.balanceCountingEd,
                 minBalance: sendingAssetExistence?.minBalance,
                 locale: selectedLocale
             ),

--- a/novawallet/Modules/Transfer/TransferSetup/CrossChain/CrossChainTransferSetupPresenter.swift
+++ b/novawallet/Modules/Transfer/TransferSetup/CrossChain/CrossChainTransferSetupPresenter.swift
@@ -404,7 +404,7 @@ extension CrossChainTransferSetupPresenter: TransferSetupChildPresenterProtocol 
             dataValidatingFactory.willBeReaped(
                 amount: sendingAmount,
                 fee: isOriginUtilityTransfer ? originFee : 0,
-                totalAmount: senderSendingAssetBalance?.totalInPlank,
+                totalAmount: senderSendingAssetBalance?.balanceCountingEd,
                 minBalance: originSendingMinBalance,
                 locale: selectedLocale
             )

--- a/novawallet/Modules/Transfer/TransferSetup/OnChain/OnChainTransferSetupPresenter.swift
+++ b/novawallet/Modules/Transfer/TransferSetup/OnChain/OnChainTransferSetupPresenter.swift
@@ -338,7 +338,7 @@ extension OnChainTransferSetupPresenter: TransferSetupChildPresenterProtocol {
             dataValidatingFactory.willBeReaped(
                 amount: sendingAmount,
                 fee: isUtilityTransfer ? fee?.value : 0,
-                totalAmount: senderSendingAssetBalance?.totalInPlank,
+                totalAmount: senderSendingAssetBalance?.balanceCountingEd,
                 minBalance: sendingAssetExistence?.minBalance,
                 locale: selectedLocale
             )

--- a/novawalletTests/Mocks/DataProviders/WalletLocalSubscriptionFactoryStub.swift
+++ b/novawalletTests/Mocks/DataProviders/WalletLocalSubscriptionFactoryStub.swift
@@ -25,6 +25,8 @@ final class WalletLocalSubscriptionFactoryStub: WalletLocalSubscriptionFactoryPr
                 freeInPlank: balance,
                 reservedInPlank: 0,
                 frozenInPlank: 0,
+                edCountMode: .basedOnFree,
+                transferrableMode: .fungibleTrait,
                 blocked: false
             )
         } else {

--- a/novawalletTests/Modules/ControllerAccount/ControllerAccountTests.swift
+++ b/novawalletTests/Modules/ControllerAccount/ControllerAccountTests.swift
@@ -112,6 +112,8 @@ class ControllerAccountTests: XCTestCase {
             freeInPlank: 100000000000000,
             reservedInPlank: 0,
             frozenInPlank: 0,
+            edCountMode: .basedOnFree,
+            transferrableMode: .fungibleTrait,
             blocked: false
         )
 
@@ -143,6 +145,8 @@ class ControllerAccountTests: XCTestCase {
             freeInPlank: 10,
             reservedInPlank: 0,
             frozenInPlank: 0,
+            edCountMode: .basedOnFree,
+            transferrableMode: .fungibleTrait,
             blocked: false
         )
 

--- a/novawalletTests/Modules/Staking/StakingBondMore/StakingBondMoreTests.swift
+++ b/novawalletTests/Modules/Staking/StakingBondMore/StakingBondMoreTests.swift
@@ -60,6 +60,8 @@ class StakingBondMoreTests: XCTestCase {
             freeInPlank: 100000000000000,
             reservedInPlank: 0,
             frozenInPlank: 0,
+            edCountMode: .basedOnFree,
+            transferrableMode: .fungibleTrait,
             blocked: false
         )
 

--- a/novawalletTests/Modules/Swaps/SwapsValidationTests.swift
+++ b/novawalletTests/Modules/Swaps/SwapsValidationTests.swift
@@ -17,12 +17,17 @@ final class SwapsValidationTests: XCTestCase {
         let accountId = try WestendStub.address.toAccountId()
         
         let freeBalance = amountInPlank(50, payChainAsset)
-        let payAssetBalance = AssetBalance(chainAssetId: payChainAsset.chainAssetId,
-                                           accountId: accountId,
-                                           freeInPlank: freeBalance,
-                                           reservedInPlank: 0,
-                                           frozenInPlank: 0,
-                                           blocked: false)
+        let payAssetBalance = AssetBalance(
+            chainAssetId: payChainAsset.chainAssetId,
+            accountId: accountId,
+            freeInPlank: freeBalance,
+            reservedInPlank: 0,
+            frozenInPlank: 0,
+            edCountMode: .basedOnFree,
+            transferrableMode: .fungibleTrait,
+            blocked: false
+        )
+        
         let existentialDeposit = amountInPlank(1, utilityChainAsset)
         let fee = amountInPlank(0.1, payChainAsset)
         let existentialDepositInFeeToken = amountInPlank(0.01, payChainAsset)
@@ -65,6 +70,8 @@ final class SwapsValidationTests: XCTestCase {
                                            freeInPlank: freeBalance,
                                            reservedInPlank: 0,
                                            frozenInPlank: 0,
+                                           edCountMode: .basedOnFree,
+                                           transferrableMode: .fungibleTrait,
                                            blocked: false)
         
         let fee = amountInPlank(0.1, payChainAsset)


### PR DESCRIPTION
- add ```AssetBalance.edCountMode``` to determine which part of the balance depends on ed (total or free). Previously, it was total balance but now onchain logic is changed and free balance must be used.

- adopted the following validations to take into account new ed logic: ```notViolatingMinBalancePaying```, ```willBeReaped```, ```poolStakingNotViolatingExistentialDeposit```, ```receiverWillHaveAssetAccount```.

- add ```AssetBalance.transferrableMode``` to determine how the transferrable balance is calculated. Previously it was ```free - frozen``` but now it is ```free - max(frozen - reserved, 0)```