### PR TITLE
Bugfix: Open referendum details

### DIFF
--- a/novawallet/Common/URLHandling/Parsing/OpenScreenUrlParsingService.swift
+++ b/novawallet/Common/URLHandling/Parsing/OpenScreenUrlParsingService.swift
@@ -13,10 +13,11 @@ enum OpenScreenUrlParsingError: Error {
     case openDAppScreen(DAppError)
 
     enum GovScreenError: Error {
-        case govTypeIsAmbiguous
+        case govTypeIsNotSpecified
         case invalidChainId
         case invalidReferendumId
         case chainNotSupportsGovType(type: String)
+        case chainNotSupportsGov
         case chainNotFound
     }
 
@@ -40,7 +41,7 @@ extension OpenScreenUrlParsingError.GovScreenError {
     func message(locale: Locale) -> String {
         let languages = locale.rLanguages
         switch self {
-        case .govTypeIsAmbiguous:
+        case .govTypeIsNotSpecified:
             return R.string.localizable.deeplinkErrorNoGovernanceTypeMessage(
                 preferredLanguages: languages)
         case .invalidChainId:
@@ -49,7 +50,7 @@ extension OpenScreenUrlParsingError.GovScreenError {
         case .invalidReferendumId:
             return R.string.localizable.deeplinkErrorInvalidReferendumIdMessage(
                 preferredLanguages: languages)
-        case .chainNotSupportsGovType:
+        case .chainNotSupportsGovType, .chainNotSupportsGov:
             return R.string.localizable.deeplinkErrorInvalidGovernanceTypeMessage(
                 preferredLanguages: languages)
         case .chainNotFound:


### PR DESCRIPTION
If type is not provided then

- opengov must be opened if the chain supports multiple types and opengov in the list
- the target gov must be opened if the chain supports the only gov type
- nothing must be opened if there are multiple gov types and a user must see a dialog with the problem