### PR TITLE
Network state management

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -178,7 +178,7 @@
 		0C66102B2A73816000E44634 /* StakingSharedStateFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102A2A73816000E44634 /* StakingSharedStateFactory.swift */; };
 		0C66102D2A73828800E44634 /* RelaychainStakingSharedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102C2A73828800E44634 /* RelaychainStakingSharedState.swift */; };
 		0C66102F2A78E9D700E44634 /* RelaychainStartStakingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102E2A78E9D700E44634 /* RelaychainStartStakingState.swift */; };
-		0C6941BF2B1F247C00A7CF6D /* RuntimePolicyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6941BE2B1F247C00A7CF6D /* RuntimePolicyService.swift */; };
+		0C6941BF2B1F247C00A7CF6D /* ChainSyncModeUpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6941BE2B1F247C00A7CF6D /* ChainSyncModeUpdateService.swift */; };
 		0C6941C22B1F271A00A7CF6D /* ChainRemoteAccountDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6941C12B1F271A00A7CF6D /* ChainRemoteAccountDetector.swift */; };
 		0C6941C62B1F51FE00A7CF6D /* RawDataStorageSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6941C52B1F51FE00A7CF6D /* RawDataStorageSubscription.swift */; };
 		0C6941CB2B203F3300A7CF6D /* ChainSyncMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6941CA2B203F3300A7CF6D /* ChainSyncMode.swift */; };
@@ -4297,7 +4297,7 @@
 		0C66102A2A73816000E44634 /* StakingSharedStateFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingSharedStateFactory.swift; sourceTree = "<group>"; };
 		0C66102C2A73828800E44634 /* RelaychainStakingSharedState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaychainStakingSharedState.swift; sourceTree = "<group>"; };
 		0C66102E2A78E9D700E44634 /* RelaychainStartStakingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaychainStartStakingState.swift; sourceTree = "<group>"; };
-		0C6941BE2B1F247C00A7CF6D /* RuntimePolicyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimePolicyService.swift; sourceTree = "<group>"; };
+		0C6941BE2B1F247C00A7CF6D /* ChainSyncModeUpdateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainSyncModeUpdateService.swift; sourceTree = "<group>"; };
 		0C6941C12B1F271A00A7CF6D /* ChainRemoteAccountDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainRemoteAccountDetector.swift; sourceTree = "<group>"; };
 		0C6941C52B1F51FE00A7CF6D /* RawDataStorageSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataStorageSubscription.swift; sourceTree = "<group>"; };
 		0C6941C92B203E2F00A7CF6D /* SubstrateDataModel23.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SubstrateDataModel23.xcdatamodel; sourceTree = "<group>"; };
@@ -12231,7 +12231,6 @@
 				8436E94526C85405003D4EA7 /* RuntimeSnapshot.swift */,
 				844CB57126F9EB2000396E13 /* RuntimeCodingService.swift */,
 				84452F4D25D5BB1C00F47EC5 /* RuntimeCoderFactory.swift */,
-				0C6941BE2B1F247C00A7CF6D /* RuntimePolicyService.swift */,
 			);
 			path = RuntimeProviderPool;
 			sourceTree = "<group>";
@@ -16013,6 +16012,7 @@
 				84282FBC26D05A54002CA322 /* ChainRegistryFacade.swift */,
 				844CB57526FA064700396E13 /* ChainRegistryError.swift */,
 				84BAD21B293B1BC200C55C49 /* ChainModelConversion.swift */,
+				0C6941BE2B1F247C00A7CF6D /* ChainSyncModeUpdateService.swift */,
 			);
 			path = ChainRegistry;
 			sourceTree = "<group>";
@@ -21882,7 +21882,7 @@
 				84EBFCE9285E7C100006327E /* XcmInstruction.swift in Sources */,
 				2AFF4BA2274D1E5C00D790B4 /* UsernameSetupViewLayout.swift in Sources */,
 				2A66CF4F25D109780006E4C1 /* CDPhishingItem+CoreDataDecodable.swift in Sources */,
-				0C6941BF2B1F247C00A7CF6D /* RuntimePolicyService.swift in Sources */,
+				0C6941BF2B1F247C00A7CF6D /* ChainSyncModeUpdateService.swift in Sources */,
 				8496ADDE276B123200306B24 /* PolkadotExtentionMessage.swift in Sources */,
 				84A15489262888CA0050D557 /* IdentityOperationFactory.swift in Sources */,
 				8473D4212657FFFB00B394B2 /* Crowdloan.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -178,6 +178,10 @@
 		0C66102B2A73816000E44634 /* StakingSharedStateFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102A2A73816000E44634 /* StakingSharedStateFactory.swift */; };
 		0C66102D2A73828800E44634 /* RelaychainStakingSharedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102C2A73828800E44634 /* RelaychainStakingSharedState.swift */; };
 		0C66102F2A78E9D700E44634 /* RelaychainStartStakingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102E2A78E9D700E44634 /* RelaychainStartStakingState.swift */; };
+		0C6941BF2B1F247C00A7CF6D /* RuntimePolicyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6941BE2B1F247C00A7CF6D /* RuntimePolicyService.swift */; };
+		0C6941C22B1F271A00A7CF6D /* ChainRemoteAccountDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6941C12B1F271A00A7CF6D /* ChainRemoteAccountDetector.swift */; };
+		0C6941C62B1F51FE00A7CF6D /* RawDataStorageSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6941C52B1F51FE00A7CF6D /* RawDataStorageSubscription.swift */; };
+		0C6941CB2B203F3300A7CF6D /* ChainSyncMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6941CA2B203F3300A7CF6D /* ChainSyncMode.swift */; };
 		0C6D66AB2A8C0B6700AAB988 /* BaseSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6D66AA2A8C0B6700AAB988 /* BaseSigner.swift */; };
 		0C6F0C9E2A69723B007170C6 /* StartStakingStateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6F0C9C2A69723B007170C6 /* StartStakingStateProtocol.swift */; };
 		0C77B55F2A83717000B5AE08 /* StaticValidatorListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C77B55E2A83717000B5AE08 /* StaticValidatorListViewController.swift */; };
@@ -4293,6 +4297,11 @@
 		0C66102A2A73816000E44634 /* StakingSharedStateFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingSharedStateFactory.swift; sourceTree = "<group>"; };
 		0C66102C2A73828800E44634 /* RelaychainStakingSharedState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaychainStakingSharedState.swift; sourceTree = "<group>"; };
 		0C66102E2A78E9D700E44634 /* RelaychainStartStakingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaychainStartStakingState.swift; sourceTree = "<group>"; };
+		0C6941BE2B1F247C00A7CF6D /* RuntimePolicyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimePolicyService.swift; sourceTree = "<group>"; };
+		0C6941C12B1F271A00A7CF6D /* ChainRemoteAccountDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainRemoteAccountDetector.swift; sourceTree = "<group>"; };
+		0C6941C52B1F51FE00A7CF6D /* RawDataStorageSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataStorageSubscription.swift; sourceTree = "<group>"; };
+		0C6941C92B203E2F00A7CF6D /* SubstrateDataModel23.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SubstrateDataModel23.xcdatamodel; sourceTree = "<group>"; };
+		0C6941CA2B203F3300A7CF6D /* ChainSyncMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainSyncMode.swift; sourceTree = "<group>"; };
 		0C6D66AA2A8C0B6700AAB988 /* BaseSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseSigner.swift; sourceTree = "<group>"; };
 		0C6F0C9C2A69723B007170C6 /* StartStakingStateProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartStakingStateProtocol.swift; sourceTree = "<group>"; };
 		0C77B55E2A83717000B5AE08 /* StaticValidatorListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticValidatorListViewController.swift; sourceTree = "<group>"; };
@@ -12222,6 +12231,7 @@
 				8436E94526C85405003D4EA7 /* RuntimeSnapshot.swift */,
 				844CB57126F9EB2000396E13 /* RuntimeCodingService.swift */,
 				84452F4D25D5BB1C00F47EC5 /* RuntimeCoderFactory.swift */,
+				0C6941BE2B1F247C00A7CF6D /* RuntimePolicyService.swift */,
 			);
 			path = RuntimeProviderPool;
 			sourceTree = "<group>";
@@ -12697,6 +12707,7 @@
 		8470D6CE253E31FB009E9A5D /* StorageSubscription */ = {
 			isa = PBXGroup;
 			children = (
+				0C6941C12B1F271A00A7CF6D /* ChainRemoteAccountDetector.swift */,
 				8470D6CC253E3170009E9A5D /* AccountInfoSubscription.swift */,
 				843910C0253F36F300E3C217 /* BaseStorageChildSubscription.swift */,
 				84F30EA025FD3EE700039D09 /* ChildSubscriptionFactory.swift */,
@@ -12713,6 +12724,7 @@
 				88AF35DD28C21D28003730DA /* LocksSubscription.swift */,
 				84757E13299A1E1500616C6C /* BatchSubscriptionHandler.swift */,
 				8455F1A12A1F5A6C003F072D /* BatchStorageSubscriptionResult.swift */,
+				0C6941C52B1F51FE00A7CF6D /* RawDataStorageSubscription.swift */,
 			);
 			path = StorageSubscription;
 			sourceTree = "<group>";
@@ -15519,6 +15531,7 @@
 				8419F053295ED55000A14E05 /* LocalChainExternalApi.swift */,
 				0C9525EA2A7B7F5000BD724D /* ChainModel+Additional.swift */,
 				0C79C8982A7BE46A00B171E3 /* AssetModel+Staking.swift */,
+				0C6941CA2B203F3300A7CF6D /* ChainSyncMode.swift */,
 			);
 			path = LocalChain;
 			sourceTree = "<group>";
@@ -20808,6 +20821,7 @@
 				848FFE8B25E69A6000652AA5 /* EraValidatorServiceProtocol.swift in Sources */,
 				AEA0C8C12681180900F9666F /* InitBondingCustomValidatorListWireframe.swift in Sources */,
 				849976C127B2823F00B14A6C /* DAppMetamaskBaseState.swift in Sources */,
+				0C6941C62B1F51FE00A7CF6D /* RawDataStorageSubscription.swift in Sources */,
 				842876A624AE049B00D91AD8 /* SelectableViewModelProtocol.swift in Sources */,
 				84B8AA7129F8E59300347A37 /* DAppInteractionPresenter.swift in Sources */,
 				8831F10028C65B95009F7682 /* AssetLock.swift in Sources */,
@@ -21868,6 +21882,7 @@
 				84EBFCE9285E7C100006327E /* XcmInstruction.swift in Sources */,
 				2AFF4BA2274D1E5C00D790B4 /* UsernameSetupViewLayout.swift in Sources */,
 				2A66CF4F25D109780006E4C1 /* CDPhishingItem+CoreDataDecodable.swift in Sources */,
+				0C6941BF2B1F247C00A7CF6D /* RuntimePolicyService.swift in Sources */,
 				8496ADDE276B123200306B24 /* PolkadotExtentionMessage.swift in Sources */,
 				84A15489262888CA0050D557 /* IdentityOperationFactory.swift in Sources */,
 				8473D4212657FFFB00B394B2 /* Crowdloan.swift in Sources */,
@@ -22226,6 +22241,7 @@
 				6D47EAB127FAB7559A9FA107 /* StakingPayoutConfirmationViewController.swift in Sources */,
 				849ABE772628103200011A2A /* ControllersListReducer.swift in Sources */,
 				88C7165628C8CD050015D1E9 /* UICollectionViewDiffableDataSource+apply.swift in Sources */,
+				0C6941CB2B203F3300A7CF6D /* ChainSyncMode.swift in Sources */,
 				84AF08D82941B6D800D0572B /* TokenManageViewModel.swift in Sources */,
 				840DFF532894189D001B11EA /* ChainAddressDetailsMeasurement.swift in Sources */,
 				9565BEB636E6D386B0C0FBE5 /* StakingPayoutConfirmationViewFactory.swift in Sources */,
@@ -22440,6 +22456,7 @@
 				8466781827EC9CDA007935D3 /* PersistTransferDetails.swift in Sources */,
 				84800B02273301C800E1E4DD /* RemoteChainModel.swift in Sources */,
 				88E74E8829538BF8008031A3 /* AssetReceiveInteractorError.swift in Sources */,
+				0C6941C22B1F271A00A7CF6D /* ChainRemoteAccountDetector.swift in Sources */,
 				849A4EF4279A7AC600AB6709 /* AssetType.swift in Sources */,
 				842643BD28785A940031B5B5 /* TuringStakingLocalSubscriptionFactory.swift in Sources */,
 				846A2606267C792000429A7F /* CrowdloanContributionResponse.swift in Sources */,
@@ -24450,6 +24467,7 @@
 		843910CA253F7E6500E3C217 /* SubstrateDataModel.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				0C6941C92B203E2F00A7CF6D /* SubstrateDataModel23.xcdatamodel */,
 				0C0130482B0E5BD300746952 /* SubstrateDataModel22.xcdatamodel */,
 				77AAE22B2AFCD7AA006872CC /* SubstrateDataModel21.xcdatamodel */,
 				0CEB4ECF2AF148500048FD84 /* SubstrateDataModel20.xcdatamodel */,
@@ -24473,7 +24491,7 @@
 				88787F0328DB3A7B00B115AB /* SubstrateDataModel2.xcdatamodel */,
 				843910CB253F7E6500E3C217 /* SubstrateDataModel.xcdatamodel */,
 			);
-			currentVersion = 0C0130482B0E5BD300746952 /* SubstrateDataModel22.xcdatamodel */;
+			currentVersion = 0C6941C92B203E2F00A7CF6D /* SubstrateDataModel23.xcdatamodel */;
 			path = SubstrateDataModel.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/novawallet/Common/Extension/SubstrateSdk/StorageKeyFactory+Implicit.swift
+++ b/novawallet/Common/Extension/SubstrateSdk/StorageKeyFactory+Implicit.swift
@@ -11,24 +11,6 @@ extension StorageKeyFactoryProtocol {
         )
     }
 
-    func bondedKeyForId(_ identifier: Data) throws -> Data {
-        try createStorageKey(
-            moduleName: "Staking",
-            storageName: "Bonded",
-            key: identifier,
-            hasher: .twox64Concat
-        )
-    }
-
-    func stakingInfoForControllerId(_ identifier: Data) throws -> Data {
-        try createStorageKey(
-            moduleName: "Staking",
-            storageName: "Ledger",
-            key: identifier,
-            hasher: .blake128Concat
-        )
-    }
-
     func activeEra() throws -> Data {
         try createStorageKey(
             moduleName: "Staking",

--- a/novawallet/Common/Migration/SubstrateStorageVersion.swift
+++ b/novawallet/Common/Migration/SubstrateStorageVersion.swift
@@ -21,6 +21,7 @@ enum SubstrateStorageVersion: String, CaseIterable {
     case version20 = "SubstrateDataModel20"
     case version21 = "SubstrateDataModel21"
     case version22 = "SubstrateDataModel22"
+    case version23 = "SubstrateDataModel23"
 
     static var current: SubstrateStorageVersion {
         allCases.last!
@@ -71,6 +72,8 @@ enum SubstrateStorageVersion: String, CaseIterable {
         case .version21:
             return .version22
         case .version22:
+            return .version23
+        case .version23:
             return nil
         }
     }

--- a/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
@@ -3,7 +3,7 @@ import RobinHood
 import SubstrateSdk
 import BigInt
 
-struct ChainModel: Equatable, Codable, Hashable {
+struct ChainModel: Equatable, Hashable {
     // swiftlint:disable:next type_name
     typealias Id = String
 
@@ -48,6 +48,7 @@ struct ChainModel: Equatable, Codable, Hashable {
     let explorers: [Explorer]?
     let order: Int64
     let additional: JSON?
+    let syncMode: ChainSyncMode
 
     init(
         chainId: Id,
@@ -63,7 +64,8 @@ struct ChainModel: Equatable, Codable, Hashable {
         externalApis: LocalChainExternalApiSet?,
         explorers: [Explorer]?,
         order: Int64,
-        additional: JSON?
+        additional: JSON?,
+        syncMode: ChainSyncMode
     ) {
         self.chainId = chainId
         self.parentId = parentId
@@ -79,13 +81,15 @@ struct ChainModel: Equatable, Codable, Hashable {
         self.explorers = explorers
         self.order = order
         self.additional = additional
+        self.syncMode = syncMode
     }
 
-    init(remoteModel: RemoteChainModel, assets: Set<AssetModel>, order: Int64) {
+    init(remoteModel: RemoteChainModel, assets: Set<AssetModel>, syncMode: ChainSyncMode, order: Int64) {
         chainId = remoteModel.chainId
         parentId = remoteModel.parentId
         name = remoteModel.name
         self.assets = assets
+        self.syncMode = syncMode
 
         let nodeList = remoteModel.nodes.enumerated().map { index, node in
             ChainNodeModel(remoteModel: node, order: Int16(index))
@@ -247,6 +251,14 @@ struct ChainModel: Equatable, Codable, Hashable {
 
         return UInt32(value)
     }
+    
+    var isReadyForOnchainRequests: Bool {
+        !hasSubstrateRuntime || syncMode == .full
+    }
+    
+    var isLightSyncMode: Bool {
+        syncMode == .light
+    }
 }
 
 extension ChainModel: Identifiable {
@@ -279,7 +291,8 @@ extension ChainModel {
             externalApis: externalApis,
             explorers: explorers,
             order: order,
-            additional: additional
+            additional: additional,
+            syncMode: syncMode
         )
     }
 
@@ -301,7 +314,8 @@ extension ChainModel {
             externalApis: externalApis,
             explorers: explorers,
             order: order,
-            additional: additional
+            additional: additional,
+            syncMode: syncMode
         )
     }
 
@@ -323,7 +337,28 @@ extension ChainModel {
             externalApis: externalApis,
             explorers: explorers,
             order: order,
-            additional: additional
+            additional: additional,
+            syncMode: syncMode
+        )
+    }
+
+    func updatingSyncMode(for newMode: ChainSyncMode) -> ChainModel {
+        .init(
+            chainId: chainId,
+            parentId: parentId,
+            name: name,
+            assets: assets,
+            nodes: nodes,
+            nodeSwitchStrategy: nodeSwitchStrategy,
+            addressPrefix: addressPrefix,
+            types: types,
+            icon: icon,
+            options: options,
+            externalApis: externalApis,
+            explorers: explorers,
+            order: order,
+            additional: additional,
+            syncMode: newMode
         )
     }
 }

--- a/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
@@ -42,7 +42,7 @@ struct ChainModel: Equatable, Hashable {
     let addressPrefix: UInt16
     let types: TypesSettings?
     let icon: URL
-    let options: [ChainOptions]?
+    let options: [LocalChainOptions]?
     let externalApis: LocalChainExternalApiSet?
     let nodeSwitchStrategy: NodeSwitchStrategy
     let explorers: [Explorer]?
@@ -60,7 +60,7 @@ struct ChainModel: Equatable, Hashable {
         addressPrefix: UInt16,
         types: TypesSettings?,
         icon: URL,
-        options: [ChainOptions]?,
+        options: [LocalChainOptions]?,
         externalApis: LocalChainExternalApiSet?,
         explorers: [Explorer]?,
         order: Int64,
@@ -103,7 +103,7 @@ struct ChainModel: Equatable, Hashable {
         types = remoteModel.types
         icon = remoteModel.icon
 
-        let remoteOptions = remoteModel.options?.compactMap { ChainOptions(rawValue: $0) } ?? []
+        let remoteOptions = remoteModel.options?.compactMap { LocalChainOptions(rawValue: $0) } ?? []
         options = !remoteOptions.isEmpty ? remoteOptions : nil
 
         externalApis = remoteModel.externalApi.map { LocalChainExternalApiSet(remoteApi: $0) }
@@ -272,7 +272,7 @@ extension ChainModel: Identifiable {
     var identifier: String { chainId }
 }
 
-enum ChainOptions: String, Codable {
+enum LocalChainOptions: String, Codable {
     case ethereumBased
     case testnet
     case crowdloans

--- a/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
@@ -102,7 +102,10 @@ struct ChainModel: Equatable, Hashable {
         addressPrefix = remoteModel.addressPrefix
         types = remoteModel.types
         icon = remoteModel.icon
-        options = remoteModel.options?.compactMap { ChainOptions(rawValue: $0) }
+
+        let remoteOptions = remoteModel.options?.compactMap { ChainOptions(rawValue: $0) } ?? []
+        options = !remoteOptions.isEmpty ? remoteOptions : nil
+
         externalApis = remoteModel.externalApi.map { LocalChainExternalApiSet(remoteApi: $0) }
         explorers = remoteModel.explorers
         additional = remoteModel.additional

--- a/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
@@ -251,11 +251,15 @@ struct ChainModel: Equatable, Hashable {
 
         return UInt32(value)
     }
-    
-    var isReadyForOnchainRequests: Bool {
-        !hasSubstrateRuntime || syncMode == .full
+
+    var isDisabled: Bool {
+        syncMode == .disabled
     }
-    
+
+    var isFullSyncMode: Bool {
+        syncMode == .full
+    }
+
     var isLightSyncMode: Bool {
         syncMode == .light
     }

--- a/novawallet/Common/Model/ChainRegistry/LocalChain/ChainSyncMode.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/ChainSyncMode.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum ChainSyncMode: Equatable {
+    case disabled
+    case light
+    case full
+}
+
+extension ChainSyncMode {
+    func toEntityValue() -> Int16 {
+        switch self {
+        case .disabled:
+            return 0
+        case .light:
+            return 1
+        case .full:
+            return 2
+        }
+    }
+
+    init?(entityValue: Int16) {
+        switch entityValue {
+        case 0:
+            self = .disabled
+        case 1:
+            self = .light
+        case 2:
+            self = .full
+        default:
+            return nil
+        }
+    }
+}

--- a/novawallet/Common/Model/ChainRegistry/RemoteChain/RemoteChainModel.swift
+++ b/novawallet/Common/Model/ChainRegistry/RemoteChain/RemoteChainModel.swift
@@ -37,3 +37,7 @@ extension RemoteChainModel {
         )
     }
 }
+
+enum RemoteOnlyChainOptions: String {
+    case fullSyncByDefault
+}

--- a/novawallet/Common/Services/ChainRegistry/ChainModelConversion.swift
+++ b/novawallet/Common/Services/ChainRegistry/ChainModelConversion.swift
@@ -32,7 +32,12 @@ final class ChainModelConverter: ChainModelConversionProtocol {
         }
 
         let newAssets = Set(chainAssets).union(localUserAssets)
-        let newChainModel = ChainModel(remoteModel: remoteModel, assets: newAssets, order: order)
+        let newChainModel = ChainModel(
+            remoteModel: remoteModel,
+            assets: newAssets,
+            syncMode: localModel?.syncMode ?? .light,
+            order: order
+        )
 
         return newChainModel != localModel ? newChainModel : nil
     }

--- a/novawallet/Common/Services/ChainRegistry/ChainModelConversion.swift
+++ b/novawallet/Common/Services/ChainRegistry/ChainModelConversion.swift
@@ -10,8 +10,6 @@ protocol ChainModelConversionProtocol {
 }
 
 final class ChainModelConverter: ChainModelConversionProtocol {
-    static let fullSyncByDefaultOption = "fullSyncByDefault"
-
     func update(
         localModel: ChainModel?,
         remoteModel: RemoteChainModel,
@@ -53,13 +51,13 @@ final class ChainModelConverter: ChainModelConversionProtocol {
             return .disabled
         }
 
-        let shouldFullSync = remoteModel.options?.contains(Self.fullSyncByDefaultOption) ?? false
+        let shouldFullSync = remoteModel.options?.contains(RemoteOnlyChainOptions.fullSyncByDefault.rawValue) ?? false
 
         if shouldFullSync {
             return .full
         }
 
-        let hasNoRuntime = remoteModel.options?.contains(ChainOptions.noSubstrateRuntime.rawValue) ?? false
+        let hasNoRuntime = remoteModel.options?.contains(LocalChainOptions.noSubstrateRuntime.rawValue) ?? false
 
         // no runtime (e.g. evm) networks always work in full sync
         if hasNoRuntime {

--- a/novawallet/Common/Services/ChainRegistry/ChainRegistry.swift
+++ b/novawallet/Common/Services/ChainRegistry/ChainRegistry.swift
@@ -27,6 +27,11 @@ protocol ChainRegistryProtocol: AnyObject {
 }
 
 final class ChainRegistry {
+    struct RuntimeSubscriptionInfo {
+        let subscription: SpecVersionSubscriptionProtocol
+        let syncMode: ChainSyncMode
+    }
+
     let runtimeProviderPool: RuntimeProviderPoolProtocol
     let connectionPool: ConnectionPoolProtocol
     let chainSyncService: ChainSyncServiceProtocol
@@ -36,8 +41,8 @@ final class ChainRegistry {
     let specVersionSubscriptionFactory: SpecVersionSubscriptionFactoryProtocol
     let logger: LoggerProtocol?
 
-    private(set) var runtimeVersionSubscriptions: [ChainModel.Id: SpecVersionSubscriptionProtocol] = [:]
-    private var availableChains = Set<ChainModel>()
+    private(set) var runtimeVersionSubscriptions: [ChainModel.Id: RuntimeSubscriptionInfo] = [:]
+    private var availableChains: [ChainModel.Id: ChainModel] = [:]
 
     private let mutex = NSLock()
 
@@ -101,33 +106,14 @@ final class ChainRegistry {
         changes.forEach { change in
             do {
                 switch change {
-                case let .insert(newChain):
-                    availableChains.insert(newChain)
+                case let .insert(chain), let .update(chain):
+                    availableChains[chain.chainId] = chain
 
-                    let connection = try connectionPool.setupConnection(for: newChain)
-                    
-                    if newChain.isReadyForOnchainRequests {
-                        setupRuntimeHandlingIfNeeded(for: newChain, connection: connection)
-                        setupRuntimeVersionSubscriptionIfNeeded(for: newChain, connection: connection)
-                    }
-                case let .update(updatedChain):
-                    if let currentChain = availableChains.firstIndex(where: { $0.chainId == updatedChain.chainId }) {
-                        availableChains.remove(at: currentChain)
-                    }
-
-                    availableChains.insert(updatedChain)
-
-                    let connection = try connectionPool.setupConnection(for: updatedChain)
-                    
-                    if updatedChain.isReadyForOnchainRequests {
-                        setupRuntimeHandlingIfNeeded(for: newChain, connection: connection)
-                        setupRuntimeVersionSubscriptionIfNeeded(for: newChain, connection: connection)
-                    }
+                    try updateSyncMode(for: chain)
                 case let .delete(chainId):
-                    if let currentChain = availableChains.firstIndex(where: { $0.chainId == chainId }) {
-                        availableChains.remove(at: currentChain)
-                    }
+                    availableChains[chainId] = nil
 
+                    connectionPool.deactivateConnection(for: chainId)
                     clearRuntimeSubscriptionIfExists(for: chainId)
                     clearRuntimeHandlingIfNeeded(for: chainId)
 
@@ -139,24 +125,51 @@ final class ChainRegistry {
         }
     }
 
+    private func updateSyncMode(for chain: ChainModel) throws {
+        switch chain.syncMode {
+        case .full, .light:
+            let connection = try connectionPool.setupConnection(for: chain)
+
+            setupRuntimeHandlingIfNeeded(for: chain, connection: connection)
+            setupRuntimeVersionSubscriptionIfNeeded(for: chain, connection: connection)
+        case .disabled:
+            connectionPool.deactivateConnection(for: chain.chainId)
+            clearRuntimeSubscriptionIfExists(for: chain.chainId)
+            clearRuntimeHandlingIfNeeded(for: chain.chainId)
+        }
+
+        logger?.debug("Sync mode \(chain.syncMode) applied to \(chain.name)")
+    }
+
     private func setupRuntimeHandlingIfNeeded(for chain: ChainModel, connection: ChainConnection) {
-        if chain.hasSubstrateRuntime {
-            _ = runtimeProviderPool.setupRuntimeProviderIfNeeded(for: chain)
+        switch chain.syncMode {
+        case .full:
+            if chain.hasSubstrateRuntime {
+                _ = runtimeProviderPool.setupRuntimeProviderIfNeeded(for: chain)
 
-            runtimeSyncService.register(chain: chain, with: connection)
+                runtimeSyncService.register(chain: chain, with: connection)
 
-            logger?.debug("Subscribed runtime for: \(chain.name)")
-        } else {
+                logger?.debug("Subscribed runtime for: \(chain.name)")
+            } else {
+                clearRuntimeHandlingIfNeeded(for: chain.chainId)
+
+                logger?.debug("No runtime for: \(chain.chainId)")
+            }
+        case .light, .disabled:
             clearRuntimeHandlingIfNeeded(for: chain.chainId)
 
-            logger?.debug("No runtime for: \(chain.chainId)")
+            logger?.debug("No runtime \(chain.name) needed for sync mode \(chain.syncMode)")
         }
     }
 
     private func setupRuntimeVersionSubscriptionIfNeeded(for chain: ChainModel, connection: ChainConnection) {
-        guard runtimeVersionSubscriptions[chain.chainId] == nil else {
+        let optInfo = runtimeVersionSubscriptions[chain.chainId]
+
+        guard optInfo == nil || optInfo?.syncMode != chain.syncMode else {
             return
         }
+
+        optInfo?.subscription.unsubscribe()
 
         let subscription = specVersionSubscriptionFactory.createSubscription(
             for: chain,
@@ -165,7 +178,7 @@ final class ChainRegistry {
 
         subscription.subscribe()
 
-        runtimeVersionSubscriptions[chain.chainId] = subscription
+        runtimeVersionSubscriptions[chain.chainId] = .init(subscription: subscription, syncMode: chain.syncMode)
     }
 
     private func clearRuntimeHandlingIfNeeded(for chainId: ChainModel.Id) {
@@ -174,8 +187,8 @@ final class ChainRegistry {
     }
 
     private func clearRuntimeSubscriptionIfExists(for chainId: ChainModel.Id) {
-        if let subscription = runtimeVersionSubscriptions[chainId] {
-            subscription.unsubscribe()
+        if let info = runtimeVersionSubscriptions[chainId] {
+            info.subscription.unsubscribe()
         }
 
         runtimeVersionSubscriptions[chainId] = nil
@@ -195,7 +208,7 @@ extension ChainRegistry: ChainRegistryProtocol {
             mutex.unlock()
         }
 
-        return Set(runtimeVersionSubscriptions.keys)
+        return Set(availableChains.keys)
     }
 
     func getChain(for chainId: ChainModel.Id) -> ChainModel? {
@@ -205,7 +218,7 @@ extension ChainRegistry: ChainRegistryProtocol {
             mutex.unlock()
         }
 
-        return availableChains.first(where: { $0.chainId == chainId })
+        return availableChains[chainId]
     }
 
     func getConnection(for chainId: ChainModel.Id) -> ChainConnection? {
@@ -225,7 +238,7 @@ extension ChainRegistry: ChainRegistryProtocol {
             mutex.unlock()
         }
 
-        guard let chain = availableChains.first(where: { $0.chainId == chainId }) else {
+        guard let chain = availableChains[chainId] else {
             return nil
         }
 
@@ -241,35 +254,24 @@ extension ChainRegistry: ChainRegistryProtocol {
 
         return runtimeProviderPool.getRuntimeProvider(for: chainId)
     }
-    
+
     func switchSync(mode: ChainSyncMode, chainId: ChainModel.Id) throws {
         mutex.lock()
 
         defer {
             mutex.unlock()
         }
-        
-        guard let chain = availableChainIds[chainId], chain.syncMode != mode else {
-            return
-        }
-        
-        let newChain = chain.updatingSyncMode(for: mode)
-        
-        switch mode {
-        case .full:
-            guard let connection = connectionPool.getConnection(for: chain.chainId) else {
-                throw ChainRegistryError.connectionUnavailable
-            }
 
-            setupRuntimeHandlingIfNeeded(for: newChain, connection: connection)
-            setupRuntimeVersionSubscriptionIfNeeded(for: newChain, connection: connection)
-            
-        case .disabled, .light:
-            clearRuntimeSubscriptionIfExists(for: chainId)
-            clearRuntimeHandlingIfNeeded(for: chainId)
+        guard let chain = availableChains[chainId], chain.syncMode != mode else {
+            throw ChainRegistryError.noChain(chainId)
         }
-        
-        // TODO: save new chain sync mode to db
+
+        let newChain = chain.updatingSyncMode(for: mode)
+
+        availableChains[chainId] = newChain
+        try updateSyncMode(for: newChain)
+
+        chainSyncService.updateLocal(chain: newChain)
     }
 
     func chainsSubscribe(

--- a/novawallet/Common/Services/ChainRegistry/ChainSyncModeUpdateService.swift
+++ b/novawallet/Common/Services/ChainRegistry/ChainSyncModeUpdateService.swift
@@ -85,7 +85,7 @@ extension ChainSyncModeUpdateService: ChainRemoteAccountDetectorDelegate {
         if account.exists {
             do {
                 try chainRegistry.switchSync(mode: .full, chainId: chain.chainId)
-                
+
                 logger.debug("Switch to full mode for \(chain.name)")
             } catch {
                 logger.error("Can't switch full sync \(chain.name) \(error)")

--- a/novawallet/Common/Services/ChainRegistry/ChainSyncService.swift
+++ b/novawallet/Common/Services/ChainRegistry/ChainSyncService.swift
@@ -4,6 +4,7 @@ import SubstrateSdk
 
 protocol ChainSyncServiceProtocol {
     func syncUp()
+    func updateLocal(chain: ChainModel)
 }
 
 final class ChainSyncService {
@@ -211,6 +212,18 @@ extension ChainSyncService: ChainSyncServiceProtocol {
         }
 
         performSyncUpIfNeeded()
+    }
+
+    func updateLocal(chain: ChainModel) {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        let operation = repository.saveOperation({ [chain] }, { [] })
+
+        operationQueue.addOperation(operation)
     }
 }
 

--- a/novawallet/Common/Services/ChainRegistry/RuntimeProviderPool/RuntimePolicyService.swift
+++ b/novawallet/Common/Services/ChainRegistry/RuntimeProviderPool/RuntimePolicyService.swift
@@ -1,0 +1,112 @@
+import Foundation
+import SubstrateSdk
+import RobinHood
+
+protocol RuntimePolicyServiceProtocol: ApplicationServiceProtocol {
+    func update(wallet: MetaAccountModel)
+}
+
+final class RuntimePolicyService {
+    let chainRegistry: ChainRegistryProtocol
+    let logger: LoggerProtocol
+    let accountDetector: ChainRemoteAccountDetecting
+    let workingQueue = DispatchQueue.global(qos: .userInitiated)
+
+    private var selectedWallet: MetaAccountModel?
+
+    init(selectedWallet: MetaAccountModel?, chainRegistry: ChainRegistryProtocol, logger: LoggerProtocol) {
+        self.selectedWallet = selectedWallet
+        self.chainRegistry = chainRegistry
+        self.logger = logger
+
+        accountDetector = SubstrateRemoteAccountDetector(logger: logger)
+    }
+
+    private func handle(changes: [DataProviderChange<ChainModel>]) {
+        changes.forEach { change in
+            switch change {
+            case let .insert(chain), let .update(chain):
+                let request = chain.accountRequest()
+
+                // manage runtime sync only for substrate networks
+                guard !chain.isReadyForOnchainRequests && chain.isLightSyncMode else {
+                    accountDetector.stopTrackingAccount(for: chain.chainId)
+                    return
+                }
+
+                guard let accountId = selectedWallet?.fetch(for: request)?.accountId else {
+                    logger.warning("No account for \(chain.name) \(chain.chainId)")
+                    return
+                }
+
+                guard let connection = chainRegistry.getConnection(for: chain.chainId) else {
+                    logger.error("No connection for \(chain.name) \(chain.chainId)")
+                    return
+                }
+
+                do {
+                    try accountDetector.startTracking(
+                        accountId: accountId,
+                        chain: chain,
+                        connection: connection
+                    )
+                } catch {
+                    logger.error("Can't track account for \(chain.name) \(error)")
+                }
+            case let .delete(deletedIdentifier):
+                accountDetector.stopTrackingAccount(for: deletedIdentifier)
+            }
+        }
+    }
+
+    private func subscribeChains() {
+        chainRegistry.chainsSubscribe(self, runningInQueue: workingQueue) { [weak self] changes in
+            self?.handle(changes: changes)
+        }
+    }
+
+    private func unsubscribeChains() {
+        chainRegistry.chainsUnsubscribe(self)
+    }
+}
+
+extension RuntimePolicyService: ChainRemoteAccountDetectorDelegate {
+    func didReceiveDetected(account: ChainRemoteDetectedAccount, accountId: AccountId, chain: ChainModel) {
+        let request = chain.accountRequest()
+
+        guard
+            let currentAccountId = selectedWallet?.fetch(for: request)?.accountId,
+            currentAccountId == accountId else {
+            return
+        }
+
+        if account.exists {
+            do {
+                try chainRegistry.switchSync(mode: .full, chainId: chain.chainId)
+            } catch {
+                logger.error("Can't switch full sync \(chain.name) \(chain.chainId)")
+            }
+        }
+    }
+}
+
+extension RuntimePolicyService: RuntimePolicyServiceProtocol {
+    func setup() {
+        accountDetector.delegate = self
+        accountDetector.callbackQueue = .global(qos: .userInitiated)
+
+        subscribeChains()
+    }
+
+    func throttle() {
+        unsubscribeChains()
+        accountDetector.stopTrackingAll()
+    }
+
+    func update(wallet _: MetaAccountModel) {
+        unsubscribeChains()
+        accountDetector.stopTrackingAll()
+
+        subscribeChains()
+    }
+}

--- a/novawallet/Common/Services/ChainRegistry/SpecVersionSubscriptionFactory.swift
+++ b/novawallet/Common/Services/ChainRegistry/SpecVersionSubscriptionFactory.swift
@@ -50,7 +50,7 @@ extension SpecVersionSubscriptionFactory: SpecVersionSubscriptionFactoryProtocol
         for chain: ChainModel,
         connection: JSONRPCEngine
     ) -> SpecVersionSubscriptionProtocol {
-        if chain.hasSubstrateRuntime {
+        if chain.isFullSyncMode, chain.hasSubstrateRuntime {
             return SpecVersionSubscription(
                 chainId: chain.chainId,
                 runtimeSyncService: runtimeSyncService,

--- a/novawallet/Common/Services/RemoteSubscription/Equilibrium/EquilibriumAssetBalanceUpdatingService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Equilibrium/EquilibriumAssetBalanceUpdatingService.swift
@@ -29,6 +29,11 @@ final class EquilibriumAssetBalanceUpdatingService: AssetBalanceBatchBaseUpdatin
     }
 
     override func updateSubscription(for chain: ChainModel) {
+        guard chain.isFullSyncMode else {
+            removeSubscription(for: chain.chainId)
+            return
+        }
+
         guard let accountId = selectedMetaAccount.fetch(for: chain.accountRequest())?.accountId else {
             return
         }

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/AccountInfoUpdatingService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/AccountInfoUpdatingService.swift
@@ -84,7 +84,9 @@ final class AccountInfoUpdatingService {
     }
 
     private func checkChainReadyForSubscription(_ chain: ChainModel) -> Bool {
-        guard let runtimeProvider = chainRegistry.getRuntimeProvider(for: chain.chainId) else {
+        guard
+            chain.isReadyForOnchainRequests,
+            let runtimeProvider = chainRegistry.getRuntimeProvider(for: chain.chainId) else {
             return false
         }
 

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/AccountInfoUpdatingService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/AccountInfoUpdatingService.swift
@@ -85,7 +85,7 @@ final class AccountInfoUpdatingService {
 
     private func checkChainReadyForSubscription(_ chain: ChainModel) -> Bool {
         guard
-            chain.isReadyForOnchainRequests,
+            chain.isFullSyncMode,
             let runtimeProvider = chainRegistry.getRuntimeProvider(for: chain.chainId) else {
             return false
         }

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/AssetsUpdatingService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/AssetsUpdatingService.swift
@@ -83,7 +83,9 @@ final class AssetsUpdatingService {
     }
 
     private func checkChainReadyForSubscription(_ chain: ChainModel) -> Bool {
-        guard let runtimeProvider = chainRegistry.getRuntimeProvider(for: chain.chainId) else {
+        guard
+            chain.isReadyForOnchainRequests,
+            let runtimeProvider = chainRegistry.getRuntimeProvider(for: chain.chainId) else {
             return false
         }
 

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/AssetsUpdatingService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/AssetsUpdatingService.swift
@@ -84,7 +84,7 @@ final class AssetsUpdatingService {
 
     private func checkChainReadyForSubscription(_ chain: ChainModel) -> Bool {
         guard
-            chain.isReadyForOnchainRequests,
+            chain.isFullSyncMode,
             let runtimeProvider = chainRegistry.getRuntimeProvider(for: chain.chainId) else {
             return false
         }
@@ -94,6 +94,10 @@ final class AssetsUpdatingService {
 
     private func updateSubscription(for chain: ChainModel) {
         guard checkChainReadyForSubscription(chain) else {
+            chain.assets.forEach { asset in
+                dropSubscriptionIfNeeded(for: chain.chainId, assetId: asset.assetId)
+            }
+
             return
         }
 

--- a/novawallet/Common/Services/ServiceCoordinator.swift
+++ b/novawallet/Common/Services/ServiceCoordinator.swift
@@ -19,6 +19,7 @@ final class ServiceCoordinator {
     let githubPhishingService: ApplicationServiceProtocol
     let equilibriumService: AssetsUpdatingServiceProtocol
     let dappMediator: DAppInteractionMediating
+    let syncModeUpdateService: ChainSyncModeUpdateServiceProtocol
 
     init(
         walletSettings: SelectedWalletSettings,
@@ -28,7 +29,8 @@ final class ServiceCoordinator {
         evmNativeService: AssetsUpdatingServiceProtocol,
         githubPhishingService: ApplicationServiceProtocol,
         equilibriumService: AssetsUpdatingServiceProtocol,
-        dappMediator: DAppInteractionMediating
+        dappMediator: DAppInteractionMediating,
+        syncModeUpdateService: ChainSyncModeUpdateServiceProtocol
     ) {
         self.walletSettings = walletSettings
         self.accountInfoService = accountInfoService
@@ -38,6 +40,7 @@ final class ServiceCoordinator {
         self.equilibriumService = equilibriumService
         self.githubPhishingService = githubPhishingService
         self.dappMediator = dappMediator
+        self.syncModeUpdateService = syncModeUpdateService
     }
 }
 
@@ -49,6 +52,7 @@ extension ServiceCoordinator: ServiceCoordinatorProtocol {
             evmAssetsService.update(selectedMetaAccount: selectedMetaAccount)
             evmNativeService.update(selectedMetaAccount: selectedMetaAccount)
             equilibriumService.update(selectedMetaAccount: selectedMetaAccount)
+            syncModeUpdateService.update(selectedMetaAccount: selectedMetaAccount)
         }
     }
 
@@ -60,6 +64,7 @@ extension ServiceCoordinator: ServiceCoordinatorProtocol {
         evmNativeService.setup()
         equilibriumService.setup()
         dappMediator.setup()
+        syncModeUpdateService.setup()
     }
 
     func throttle() {
@@ -70,6 +75,7 @@ extension ServiceCoordinator: ServiceCoordinatorProtocol {
         evmNativeService.throttle()
         equilibriumService.throttle()
         dappMediator.throttle()
+        syncModeUpdateService.throttle()
     }
 }
 
@@ -154,6 +160,12 @@ extension ServiceCoordinator {
             logger: logger
         )
 
+        let syncModeUpdateService = ChainSyncModeUpdateService(
+            selectedMetaAccount: walletSettings.value,
+            chainRegistry: chainRegistry,
+            logger: logger
+        )
+
         return ServiceCoordinator(
             walletSettings: walletSettings,
             accountInfoService: accountInfoService,
@@ -162,7 +174,8 @@ extension ServiceCoordinator {
             evmNativeService: evmNativeService,
             githubPhishingService: githubPhishingAPIService,
             equilibriumService: equilibriumService,
-            dappMediator: DAppInteractionFactory.createMediator()
+            dappMediator: DAppInteractionFactory.createMediator(),
+            syncModeUpdateService: syncModeUpdateService
         )
     }
 }

--- a/novawallet/Common/Services/WebSocketService/StorageSubscription/ChainRemoteAccountDetector.swift
+++ b/novawallet/Common/Services/WebSocketService/StorageSubscription/ChainRemoteAccountDetector.swift
@@ -1,0 +1,72 @@
+import Foundation
+import SubstrateSdk
+
+protocol ChainRemoteAccountDetecting: AnyObject {
+    var delegate: ChainRemoteAccountDetectorDelegate? { get set }
+    var callbackQueue: DispatchQueue { get set }
+
+    func startTracking(accountId: AccountId, chain: ChainModel, connection: JSONRPCEngine) throws
+    func stopTrackingAccount(for chainId: ChainModel.Id)
+    func stopTrackingAll()
+}
+
+protocol ChainRemoteAccountDetectorDelegate: AnyObject {
+    func didReceiveDetected(account: ChainRemoteDetectedAccount, accountId: AccountId, chain: ChainModel)
+}
+
+struct ChainRemoteDetectedAccount {
+    let exists: Bool
+}
+
+final class SubstrateRemoteAccountDetector {
+    weak var delegate: ChainRemoteAccountDetectorDelegate?
+    var callbackQueue: DispatchQueue = .global()
+
+    let storageKeyFactory = StorageKeyFactory()
+
+    let logger: LoggerProtocol
+
+    private var subscriptions: [ChainModel.Id: StorageSubscriptionContainer] = [:]
+
+    init(logger: LoggerProtocol) {
+        self.logger = logger
+    }
+}
+
+extension SubstrateRemoteAccountDetector: ChainRemoteAccountDetecting {
+    func startTracking(accountId: AccountId, chain: ChainModel, connection: JSONRPCEngine) throws {
+        guard subscriptions[chain.chainId] == nil else {
+            return
+        }
+
+        let remoteKey = try storageKeyFactory.accountInfoKeyForId(accountId)
+
+        let handler = RawDataStorageSubscription(remoteStorageKey: remoteKey) { [weak self] data, _ in
+            let hasAccount = data != nil
+
+            self?.callbackQueue.async {
+                self?.delegate?.didReceiveDetected(
+                    account: .init(exists: hasAccount),
+                    accountId: accountId,
+                    chain: chain
+                )
+            }
+        }
+
+        let container = StorageSubscriptionContainer(
+            engine: connection,
+            children: [handler],
+            logger: logger
+        )
+
+        subscriptions[chain.chainId] = container
+    }
+
+    func stopTrackingAccount(for chainId: ChainModel.Id) {
+        subscriptions[chainId] = nil
+    }
+
+    func stopTrackingAll() {
+        subscriptions = [:]
+    }
+}

--- a/novawallet/Common/Services/WebSocketService/StorageSubscription/RawDataStorageSubscription.swift
+++ b/novawallet/Common/Services/WebSocketService/StorageSubscription/RawDataStorageSubscription.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+final class RawDataStorageSubscription {
+    let remoteStorageKey: Data
+    let callbackClosure: (Data?, Data?) -> Void
+
+    init(remoteStorageKey: Data, callbackClosure: @escaping (Data?, Data?) -> Void) {
+        self.remoteStorageKey = remoteStorageKey
+        self.callbackClosure = callbackClosure
+    }
+}
+
+extension RawDataStorageSubscription: StorageChildSubscribing {
+    func processUpdate(_ data: Data?, blockHash: Data?) {
+        callbackClosure(data, blockHash)
+    }
+}

--- a/novawallet/Common/Storage/EntityToModel/ChainModelMapper.swift
+++ b/novawallet/Common/Storage/EntityToModel/ChainModelMapper.swift
@@ -278,8 +278,8 @@ final class ChainModelMapper {
         }
     }
 
-    private func createChainOptions(from entity: CDChain) -> [ChainOptions]? {
-        var options: [ChainOptions] = []
+    private func createChainOptions(from entity: CDChain) -> [LocalChainOptions]? {
+        var options: [LocalChainOptions] = []
 
         if entity.isEthereumBased {
             options.append(.ethereumBased)

--- a/novawallet/Common/Storage/SubstrateDataModel.xcdatamodeld/.xccurrentversion
+++ b/novawallet/Common/Storage/SubstrateDataModel.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>SubstrateDataModel22.xcdatamodel</string>
+	<string>SubstrateDataModel23.xcdatamodel</string>
 </dict>
 </plist>

--- a/novawallet/Common/Storage/SubstrateDataModel.xcdatamodeld/SubstrateDataModel23.xcdatamodel/contents
+++ b/novawallet/Common/Storage/SubstrateDataModel.xcdatamodeld/SubstrateDataModel23.xcdatamodel/contents
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F66" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CDAsset" representedClassName="CDAsset" syncable="YES" codeGenerationType="class">
+        <attribute name="assetId" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="buyProviders" optional="YES" attributeType="Binary"/>
+        <attribute name="enabled" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="icon" optional="YES" attributeType="URI"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="precision" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="priceId" optional="YES" attributeType="String"/>
+        <attribute name="source" attributeType="String" defaultValueString="remote"/>
+        <attribute name="staking" optional="YES" attributeType="String"/>
+        <attribute name="symbol" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <attribute name="typeExtras" optional="YES" attributeType="Binary"/>
+        <relationship name="chain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDChain" inverseName="assets" inverseEntity="CDChain"/>
+    </entity>
+    <entity name="CDAssetBalance" representedClassName="CDAssetBalance" syncable="YES" codeGenerationType="class">
+        <attribute name="assetId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="blocked" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="chainAccountId" optional="YES" attributeType="String"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="edCountMode" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="freeInPlank" optional="YES" attributeType="String"/>
+        <attribute name="frozenInPlank" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="reservedInPlank" optional="YES" attributeType="String"/>
+        <attribute name="transferrableMode" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="CDAssetLock" representedClassName="CDAssetLock" syncable="YES" codeGenerationType="class">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="assetId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="chainAccountId" optional="YES" attributeType="String"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDChain" representedClassName="CDChain" syncable="YES" codeGenerationType="class">
+        <attribute name="additional" optional="YES" attributeType="Binary"/>
+        <attribute name="addressPrefix" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="chainId" attributeType="String"/>
+        <attribute name="color" optional="YES" attributeType="String"/>
+        <attribute name="explorers" optional="YES" attributeType="Binary"/>
+        <attribute name="hasCrowdloans" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="hasGovernance" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="hasGovernanceV1" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="hasSwapHub" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="icon" attributeType="URI"/>
+        <attribute name="isEthereumBased" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isTestnet" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="nodeSwitchStrategy" optional="YES" attributeType="String"/>
+        <attribute name="noSubstrateRuntime" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="order" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="parentId" optional="YES" attributeType="String"/>
+        <attribute name="syncMode" optional="YES" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES"/>
+        <attribute name="types" optional="YES" attributeType="URI"/>
+        <attribute name="typesOverrideCommon" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <relationship name="assets" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="CDAsset" inverseName="chain" inverseEntity="CDAsset"/>
+        <relationship name="externalApis" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDChainApi" inverseName="chain" inverseEntity="CDChainApi"/>
+        <relationship name="nodes" optional="YES" toMany="YES" minCount="1" deletionRule="Cascade" destinationEntity="CDChainNodeItem" inverseName="chain" inverseEntity="CDChainNodeItem"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="chainId"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="CDChainApi" representedClassName="CDChainApi" syncable="YES" codeGenerationType="class">
+        <attribute name="apiType" optional="YES" attributeType="String"/>
+        <attribute name="parameters" optional="YES" attributeType="Binary"/>
+        <attribute name="serviceType" attributeType="String" defaultValueString=""/>
+        <attribute name="url" attributeType="URI"/>
+        <relationship name="chain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDChain" inverseName="externalApis" inverseEntity="CDChain"/>
+    </entity>
+    <entity name="CDChainNodeItem" representedClassName="CDChainNodeItem" syncable="YES" codeGenerationType="class">
+        <attribute name="features" optional="YES" attributeType="Binary"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <relationship name="chain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDChain" inverseName="nodes" inverseEntity="CDChain"/>
+    </entity>
+    <entity name="CDChainStorageItem" representedClassName="CDChainStorageItem" syncable="YES" codeGenerationType="class">
+        <attribute name="data" optional="YES" attributeType="Binary"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDContactItem" representedClassName="CDContactItem" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="peerAddress" optional="YES" attributeType="String"/>
+        <attribute name="peerName" optional="YES" attributeType="String"/>
+        <attribute name="targetAddress" optional="YES" attributeType="String"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="CDExternalBalance" representedClassName="CDExternalBalance" syncable="YES" codeGenerationType="class">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="assetId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="chainAccountId" optional="YES" attributeType="String"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="param" optional="YES" attributeType="String"/>
+        <attribute name="subtype" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDNft" representedClassName="CDNft" syncable="YES" codeGenerationType="class">
+        <attribute name="chainId" attributeType="String"/>
+        <attribute name="collectionId" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="instanceId" optional="YES" attributeType="String"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="media" optional="YES" attributeType="String"/>
+        <attribute name="metadata" optional="YES" attributeType="Binary"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="ownerId" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="String"/>
+        <attribute name="totalIssuance" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="type" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="CDPhishingItem" representedClassName="CDPhishingItem" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="publicKey" optional="YES" attributeType="String"/>
+        <attribute name="source" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDPhishingSite" representedClassName="CDPhishingSite" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDPrice" representedClassName="CDPrice" syncable="YES" codeGenerationType="class">
+        <attribute name="currency" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dayChange" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDReferendumMetadata" representedClassName="CDReferendumMetadata" syncable="YES" codeGenerationType="class">
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="content" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="proposer" optional="YES" attributeType="String"/>
+        <attribute name="referendumId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timeline" optional="YES" attributeType="Binary"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDRuntimeMetadataItem" representedClassName="CDRuntimeMetadataItem" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="metadata" optional="YES" attributeType="Binary"/>
+        <attribute name="txVersion" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="version" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="CDSingleValue" representedClassName="CDSingleValue" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="payload" attributeType="Binary"/>
+    </entity>
+    <entity name="CDStakingAccount" representedClassName="CDStakingAccount" syncable="YES" codeGenerationType="class">
+        <attribute name="assetId" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="chainId" attributeType="String"/>
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="resolvedAccountId" attributeType="String"/>
+        <attribute name="rewardsAccountId" optional="YES" attributeType="String"/>
+        <attribute name="stakingType" attributeType="String"/>
+        <attribute name="walletAccountId" attributeType="String"/>
+    </entity>
+    <entity name="CDStakingDashboardItem" representedClassName="CDStakingDashboardItem" syncable="YES" codeGenerationType="class">
+        <attribute name="assetId" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="chainId" attributeType="String"/>
+        <attribute name="hasAssignedStake" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="maxApy" optional="YES" attributeType="Decimal"/>
+        <attribute name="onchainState" optional="YES" attributeType="String"/>
+        <attribute name="stake" optional="YES" attributeType="String"/>
+        <attribute name="stakingType" attributeType="String"/>
+        <attribute name="totalRewards" optional="YES" attributeType="String"/>
+        <attribute name="walletId" attributeType="String"/>
+    </entity>
+    <entity name="CDStashItem" representedClassName="CDStashItem" syncable="YES" codeGenerationType="class">
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="controller" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="stash" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDTransactionItem" representedClassName="CDTransactionItem" syncable="YES" codeGenerationType="class">
+        <attribute name="amountInPlank" optional="YES" attributeType="String"/>
+        <attribute name="assetId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="blockNumber" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="call" optional="YES" attributeType="Binary"/>
+        <attribute name="callName" optional="YES" attributeType="String"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="fee" optional="YES" attributeType="String"/>
+        <attribute name="feeAssetId" optional="YES" attributeType="Integer 32" usesScalarValueType="NO"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="moduleName" optional="YES" attributeType="String"/>
+        <attribute name="receiver" optional="YES" attributeType="String"/>
+        <attribute name="sender" optional="YES" attributeType="String"/>
+        <attribute name="source" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timestamp" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="txHash" optional="YES" attributeType="String"/>
+        <attribute name="txIndex" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO"/>
+        <relationship name="swap" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDTransactionSwapItem" inverseName="transaction" inverseEntity="CDTransactionSwapItem"/>
+    </entity>
+    <entity name="CDTransactionSwapItem" representedClassName="CDTransactionSwapItem" syncable="YES" codeGenerationType="class">
+        <attribute name="amountIn" optional="YES" attributeType="String"/>
+        <attribute name="amountOut" optional="YES" attributeType="String"/>
+        <attribute name="assetIdIn" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="assetIdOut" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <relationship name="transaction" optional="YES" maxCount="1" deletionRule="Deny" destinationEntity="CDTransactionItem" inverseName="swap" inverseEntity="CDTransactionItem"/>
+    </entity>
+</model>

--- a/novawallet/Common/Storage/SubstrateDataStorageFacade.swift
+++ b/novawallet/Common/Storage/SubstrateDataStorageFacade.swift
@@ -4,7 +4,7 @@ import CoreData
 enum SubstrateStorageParams {
     static let databaseName = "SubstrateDataModel.sqlite"
     static let modelDirectory: String = "SubstrateDataModel.momd"
-    static let modelVersion: SubstrateStorageVersion = .version22
+    static let modelVersion: SubstrateStorageVersion = .version23
 
     static let storageDirectoryURL: URL = {
         let baseURL = FileManager.default.urls(

--- a/novawallet/Modules/TransactionHistory/LocalFilter/TransactionHistoryLocalFilterFactory.swift
+++ b/novawallet/Modules/TransactionHistory/LocalFilter/TransactionHistoryLocalFilterFactory.swift
@@ -7,12 +7,12 @@ protocol TransactionHistoryLocalFilterFactoryProtocol {
 }
 
 final class TransactionHistoryLocalFilterFactory {
-    let runtimeProvider: RuntimeProviderProtocol?
+    let chainRegistry: ChainRegistryProtocol
     let chainAsset: ChainAsset
     let logger: LoggerProtocol
 
-    init(runtimeProvider: RuntimeProviderProtocol?, chainAsset: ChainAsset, logger: LoggerProtocol) {
-        self.runtimeProvider = runtimeProvider
+    init(chainRegistry: ChainRegistryProtocol, chainAsset: ChainAsset, logger: LoggerProtocol) {
+        self.chainRegistry = chainRegistry
         self.chainAsset = chainAsset
         self.logger = logger
     }
@@ -54,7 +54,9 @@ extension TransactionHistoryLocalFilterFactory: TransactionHistoryLocalFilterFac
     func createWrapper() -> CompoundOperationWrapper<TransactionHistoryLocalFilterProtocol> {
         let phishingFilter = TransactionHistoryPhishingFilter()
 
-        guard chainAsset.asset.hasPoolStaking, let runtimeProvider = runtimeProvider else {
+        guard
+            chainAsset.asset.hasPoolStaking,
+            let runtimeProvider = chainRegistry.getRuntimeProvider(for: chainAsset.chain.chainId) else {
             return CompoundOperationWrapper.createWithResult(phishingFilter)
         }
 

--- a/novawallet/Modules/TransactionHistory/TransactionHistoryViewFactory.swift
+++ b/novawallet/Modules/TransactionHistory/TransactionHistoryViewFactory.swift
@@ -66,7 +66,6 @@ struct TransactionHistoryViewFactory {
         currencyManager: CurrencyManagerProtocol
     ) -> TransactionHistoryInteractor {
         let chainRegistry = ChainRegistryFacade.sharedRegistry
-        let runtimeProvider = chainRegistry.getRuntimeProvider(for: chainAsset.chain.chainId)
 
         let operationQueue = OperationManagerFacade.sharedDefaultQueue
         let repositoryFactory = SubstrateRepositoryFactory(storageFacade: SubstrateDataStorageFacade.shared)
@@ -84,7 +83,7 @@ struct TransactionHistoryViewFactory {
         )
 
         let localFilterFactory = TransactionHistoryLocalFilterFactory(
-            runtimeProvider: runtimeProvider,
+            chainRegistry: chainRegistry,
             chainAsset: chainAsset,
             logger: Logger.shared
         )

--- a/novawalletTests/Helper/ChainModelGenerator.swift
+++ b/novawalletTests/Helper/ChainModelGenerator.swift
@@ -84,7 +84,8 @@ enum ChainModelGenerator {
                 externalApis: externalApis,
                 explorers: explorers,
                 order: Int64(index),
-                additional: nil
+                additional: nil,
+                syncMode: .full
             )
         }
     }
@@ -94,7 +95,8 @@ enum ChainModelGenerator {
         withTypes: Bool = true,
         hasStaking: Bool = false,
         hasCrowdloans: Bool = false,
-        hasSubstrateRuntime: Bool = true
+        hasSubstrateRuntime: Bool = true,
+        fullSyncByDefault: Bool = true
     ) -> [RemoteChainModel] {
         (0..<count).map { index in
             let chainId = Data.random(of: 32)!.toHex()
@@ -148,8 +150,12 @@ enum ChainModelGenerator {
                 )
             ]
 
-            let rawOptions = options.compactMap { $0.rawValue }
+            var rawOptions = options.compactMap { $0.rawValue }
 
+            if fullSyncByDefault {
+                rawOptions.append(ChainModelConverter.fullSyncByDefaultOption)
+            }
+            
             return RemoteChainModel(
                 chainId: chainId,
                 parentId: nil,
@@ -255,7 +261,8 @@ enum ChainModelGenerator {
             externalApis: externalApis,
             explorers: explorers,
             order: 0,
-            additional: nil
+            additional: nil,
+            syncMode: .full
         )
     }
 

--- a/novawalletTests/Helper/ChainModelGenerator.swift
+++ b/novawalletTests/Helper/ChainModelGenerator.swift
@@ -41,7 +41,7 @@ enum ChainModelGenerator {
                 overridesCommon: false
             ) : nil
 
-            var options: [ChainOptions] = []
+            var options: [LocalChainOptions] = []
 
             if hasCrowdloans {
                 options.append(.crowdloans)
@@ -125,14 +125,18 @@ enum ChainModelGenerator {
                 overridesCommon: false
             ) : nil
 
-            var options: [ChainOptions] = []
+            var options: [String] = []
 
             if hasCrowdloans {
-                options.append(.crowdloans)
+                options.append(LocalChainOptions.crowdloans.rawValue)
             }
 
             if !hasSubstrateRuntime {
-                options.append(.noSubstrateRuntime)
+                options.append(LocalChainOptions.noSubstrateRuntime.rawValue)
+            }
+            
+            if fullSyncByDefault {
+                options.append(RemoteOnlyChainOptions.fullSyncByDefault.rawValue)
             }
 
             let externalApi = generateRemoteExternaApis(
@@ -149,12 +153,6 @@ enum ChainModelGenerator {
                     event: nil
                 )
             ]
-
-            var rawOptions = options.compactMap { $0.rawValue }
-
-            if fullSyncByDefault {
-                rawOptions.append(ChainModelConverter.fullSyncByDefaultOption)
-            }
             
             return RemoteChainModel(
                 chainId: chainId,
@@ -166,7 +164,7 @@ enum ChainModelGenerator {
                 addressPrefix: UInt16(index),
                 types: types,
                 icon: URL(string: "https://github.com")!,
-                options: rawOptions.isEmpty ? nil : rawOptions,
+                options: options.isEmpty ? nil : options,
                 externalApi: externalApi,
                 explorers: explorers,
                 additional: nil
@@ -222,7 +220,7 @@ enum ChainModelGenerator {
             features: nil
         )
 
-        var options: [ChainOptions] = []
+        var options: [LocalChainOptions] = []
 
         if hasCrowdloans {
             options.append(.crowdloans)

--- a/novawalletTests/Mocks/CommonMocks.swift
+++ b/novawalletTests/Mocks/CommonMocks.swift
@@ -3066,6 +3066,21 @@ import SubstrateSdk
     
     
     
+     func switchSync(mode: ChainSyncMode, chainId: ChainModel.Id) throws {
+        
+    return try cuckoo_manager.callThrows("switchSync(mode: ChainSyncMode, chainId: ChainModel.Id) throws",
+            parameters: (mode, chainId),
+            escapingParameters: (mode, chainId),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.switchSync(mode: mode, chainId: chainId))
+        
+    }
+    
+    
+    
      func chainsSubscribe(_ target: AnyObject, runningInQueue: DispatchQueue, updateClosure: @escaping ([DataProviderChange<ChainModel>]) -> Void)  {
         
     return cuckoo_manager.call("chainsSubscribe(_: AnyObject, runningInQueue: DispatchQueue, updateClosure: @escaping ([DataProviderChange<ChainModel>]) -> Void)",
@@ -3173,6 +3188,11 @@ import SubstrateSdk
 	        return .init(stub: cuckoo_manager.createStub(for: MockChainRegistryProtocol.self, method: "getRuntimeProvider(for: ChainModel.Id) -> RuntimeProviderProtocol?", parameterMatchers: matchers))
 	    }
 	    
+	    func switchSync<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(mode: M1, chainId: M2) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(ChainSyncMode, ChainModel.Id)> where M1.MatchedType == ChainSyncMode, M2.MatchedType == ChainModel.Id {
+	        let matchers: [Cuckoo.ParameterMatcher<(ChainSyncMode, ChainModel.Id)>] = [wrap(matchable: mode) { $0.0 }, wrap(matchable: chainId) { $0.1 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockChainRegistryProtocol.self, method: "switchSync(mode: ChainSyncMode, chainId: ChainModel.Id) throws", parameterMatchers: matchers))
+	    }
+	    
 	    func chainsSubscribe<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(_ target: M1, runningInQueue: M2, updateClosure: M3) -> Cuckoo.ProtocolStubNoReturnFunction<(AnyObject, DispatchQueue, ([DataProviderChange<ChainModel>]) -> Void)> where M1.MatchedType == AnyObject, M2.MatchedType == DispatchQueue, M3.MatchedType == ([DataProviderChange<ChainModel>]) -> Void {
 	        let matchers: [Cuckoo.ParameterMatcher<(AnyObject, DispatchQueue, ([DataProviderChange<ChainModel>]) -> Void)>] = [wrap(matchable: target) { $0.0 }, wrap(matchable: runningInQueue) { $0.1 }, wrap(matchable: updateClosure) { $0.2 }]
 	        return .init(stub: cuckoo_manager.createStub(for: MockChainRegistryProtocol.self, method: "chainsSubscribe(_: AnyObject, runningInQueue: DispatchQueue, updateClosure: @escaping ([DataProviderChange<ChainModel>]) -> Void)", parameterMatchers: matchers))
@@ -3241,6 +3261,12 @@ import SubstrateSdk
 	    func getRuntimeProvider<M1: Cuckoo.Matchable>(for chainId: M1) -> Cuckoo.__DoNotUse<(ChainModel.Id), RuntimeProviderProtocol?> where M1.MatchedType == ChainModel.Id {
 	        let matchers: [Cuckoo.ParameterMatcher<(ChainModel.Id)>] = [wrap(matchable: chainId) { $0 }]
 	        return cuckoo_manager.verify("getRuntimeProvider(for: ChainModel.Id) -> RuntimeProviderProtocol?", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	    @discardableResult
+	    func switchSync<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(mode: M1, chainId: M2) -> Cuckoo.__DoNotUse<(ChainSyncMode, ChainModel.Id), Void> where M1.MatchedType == ChainSyncMode, M2.MatchedType == ChainModel.Id {
+	        let matchers: [Cuckoo.ParameterMatcher<(ChainSyncMode, ChainModel.Id)>] = [wrap(matchable: mode) { $0.0 }, wrap(matchable: chainId) { $0.1 }]
+	        return cuckoo_manager.verify("switchSync(mode: ChainSyncMode, chainId: ChainModel.Id) throws", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
 	    }
 	    
 	    @discardableResult
@@ -3313,6 +3339,12 @@ import SubstrateSdk
     
      func getRuntimeProvider(for chainId: ChainModel.Id) -> RuntimeProviderProtocol?  {
         return DefaultValueRegistry.defaultValue(for: (RuntimeProviderProtocol?).self)
+    }
+    
+    
+    
+     func switchSync(mode: ChainSyncMode, chainId: ChainModel.Id) throws  {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
     
@@ -3652,6 +3684,21 @@ import SubstrateSdk
         
     }
     
+    
+    
+     func deactivateConnection(for chainId: ChainModel.Id)  {
+        
+    return cuckoo_manager.call("deactivateConnection(for: ChainModel.Id)",
+            parameters: (chainId),
+            escapingParameters: (chainId),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.deactivateConnection(for: chainId))
+        
+    }
+    
 
 	 struct __StubbingProxy_ConnectionPoolProtocol: Cuckoo.StubbingProxy {
 	    private let cuckoo_manager: Cuckoo.MockManager
@@ -3684,6 +3731,11 @@ import SubstrateSdk
 	    func getOneShotConnection<M1: Cuckoo.Matchable>(for chain: M1) -> Cuckoo.ProtocolStubFunction<(ChainModel), JSONRPCEngine?> where M1.MatchedType == ChainModel {
 	        let matchers: [Cuckoo.ParameterMatcher<(ChainModel)>] = [wrap(matchable: chain) { $0 }]
 	        return .init(stub: cuckoo_manager.createStub(for: MockConnectionPoolProtocol.self, method: "getOneShotConnection(for: ChainModel) -> JSONRPCEngine?", parameterMatchers: matchers))
+	    }
+	    
+	    func deactivateConnection<M1: Cuckoo.Matchable>(for chainId: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(ChainModel.Id)> where M1.MatchedType == ChainModel.Id {
+	        let matchers: [Cuckoo.ParameterMatcher<(ChainModel.Id)>] = [wrap(matchable: chainId) { $0 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockConnectionPoolProtocol.self, method: "deactivateConnection(for: ChainModel.Id)", parameterMatchers: matchers))
 	    }
 	    
 	}
@@ -3732,6 +3784,12 @@ import SubstrateSdk
 	        return cuckoo_manager.verify("getOneShotConnection(for: ChainModel) -> JSONRPCEngine?", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
 	    }
 	    
+	    @discardableResult
+	    func deactivateConnection<M1: Cuckoo.Matchable>(for chainId: M1) -> Cuckoo.__DoNotUse<(ChainModel.Id), Void> where M1.MatchedType == ChainModel.Id {
+	        let matchers: [Cuckoo.ParameterMatcher<(ChainModel.Id)>] = [wrap(matchable: chainId) { $0 }]
+	        return cuckoo_manager.verify("deactivateConnection(for: ChainModel.Id)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
 	}
 }
 
@@ -3769,6 +3827,12 @@ import SubstrateSdk
     
      func getOneShotConnection(for chain: ChainModel) -> JSONRPCEngine?  {
         return DefaultValueRegistry.defaultValue(for: (JSONRPCEngine?).self)
+    }
+    
+    
+    
+     func deactivateConnection(for chainId: ChainModel.Id)   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
 }


### PR DESCRIPTION
Introduce disabled/light/full sync modes for chain: 

1) In disabled mode there is no connection or runtime created;
2) In light mode connection is created but no runtime. Also there is a class ChainSyncModeUpdateService running that monitors user's account info and in case it exists switches chain to the full sync mode;
3) In full mode both connection and runtime are created;

Add support for ```fullSyncByDefault``` option from remote config. It switches chain to full sync unless it is not disabled by the user (running in light mode).

Chain automatically switches to the full sync if it is running in light mode and some part of the code requested the runtime. The main idea here is that a chain doesn't consume resources if a user doesn't interact with it but when a user tries to make an operation (for example, goes to transfer) the chain switches to the full sync and automatically fetches the runtime.