### PR TITLE
Support realtime history updates for proxies 8693b5ayg

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -242,6 +242,7 @@
 		0C8AF7BC2B38076900005AC9 /* Pdc20NftModelConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8AF7BB2B38076900005AC9 /* Pdc20NftModelConverter.swift */; };
 		0C8AF7BF2B3A9E0600005AC9 /* Pdc20DetailsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8AF7BE2B3A9E0600005AC9 /* Pdc20DetailsInteractor.swift */; };
 		0C8AF7C12B3A9EFE00005AC9 /* NftDetailsPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8AF7C02B3A9EFE00005AC9 /* NftDetailsPrice.swift */; };
+		0C90C6C02B4DAB440084B5C2 /* NestedExtrinsicCallMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C90C6BF2B4DAB440084B5C2 /* NestedExtrinsicCallMapper.swift */; };
 		0C9525E32A7AAB2A00BD724D /* StakingTimeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9525E22A7AAB2A00BD724D /* StakingTimeModel.swift */; };
 		0C9525E52A7AF82B00BD724D /* DirectStakingMinStakeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9525E42A7AF82B00BD724D /* DirectStakingMinStakeBuilder.swift */; };
 		0C9525E72A7AFA2C00BD724D /* ValueResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9525E62A7AFA2C00BD724D /* ValueResolver.swift */; };
@@ -4441,6 +4442,7 @@
 		0C8AF7BD2B39567700005AC9 /* SubstrateDataModel24.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SubstrateDataModel24.xcdatamodel; sourceTree = "<group>"; };
 		0C8AF7BE2B3A9E0600005AC9 /* Pdc20DetailsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pdc20DetailsInteractor.swift; sourceTree = "<group>"; };
 		0C8AF7C02B3A9EFE00005AC9 /* NftDetailsPrice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NftDetailsPrice.swift; sourceTree = "<group>"; };
+		0C90C6BF2B4DAB440084B5C2 /* NestedExtrinsicCallMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedExtrinsicCallMapper.swift; sourceTree = "<group>"; };
 		0C9525E22A7AAB2A00BD724D /* StakingTimeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingTimeModel.swift; sourceTree = "<group>"; };
 		0C9525E42A7AF82B00BD724D /* DirectStakingMinStakeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectStakingMinStakeBuilder.swift; sourceTree = "<group>"; };
 		0C9525E62A7AFA2C00BD724D /* ValueResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueResolver.swift; sourceTree = "<group>"; };
@@ -8887,6 +8889,7 @@
 				0CA7821B2B03D0A9003F562A /* ExtrinsicProcessor+SwapMatching.swift */,
 				0C500B232B0511F400ABEE70 /* ExtrinsicProcessor+CustomFee.swift */,
 				0C500B262B07314000ABEE70 /* ExtrinsicProcessingResult.swift */,
+				0C90C6BF2B4DAB440084B5C2 /* NestedExtrinsicCallMapper.swift */,
 			);
 			path = TransactionSubscription;
 			sourceTree = "<group>";
@@ -23607,6 +23610,7 @@
 				85600C63BB1BEC76EDFA04CB /* ReferendumFullDetailsViewController.swift in Sources */,
 				EAAFB082E2BB0CA418714061 /* ReferendumFullDetailsViewLayout.swift in Sources */,
 				842D8B7C2A4179A000660005 /* ShimmeringAnimator.swift in Sources */,
+				0C90C6C02B4DAB440084B5C2 /* NestedExtrinsicCallMapper.swift in Sources */,
 				74F470AE889B0E49D9808802 /* ReferendumFullDetailsViewFactory.swift in Sources */,
 				84033055290FD745009C18E6 /* ReferendumsUnlocksViewModel.swift in Sources */,
 				003063A17B04BA6327EA355F /* ReferendumVotersProtocols.swift in Sources */,

--- a/novawallet/Common/Model/TokenOperation.swift
+++ b/novawallet/Common/Model/TokenOperation.swift
@@ -14,7 +14,7 @@ extension TokenOperation {
         chainAsset: ChainAsset
     ) -> ReceiveAvailableCheckResult {
         switch walletType {
-        case .secrets, .paritySigner, .polkadotVault:
+        case .secrets, .paritySigner, .polkadotVault, .proxied:
             return .common(.available)
         case .ledger:
             if let assetRawType = chainAsset.asset.type, case .orml = AssetType(rawValue: assetRawType) {
@@ -38,7 +38,7 @@ extension TokenOperation {
         }
 
         switch walletType {
-        case .secrets, .paritySigner, .polkadotVault:
+        case .secrets, .paritySigner, .polkadotVault, .proxied:
             return .common(.available)
         case .ledger:
             if let assetRawType = chainAsset.asset.type, case .orml = AssetType(rawValue: assetRawType) {
@@ -46,7 +46,7 @@ extension TokenOperation {
             } else {
                 return .common(.available)
             }
-        case .watchOnly, .proxied:
+        case .watchOnly:
             return .common(.noSigning)
         }
     }

--- a/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessing.swift
+++ b/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessing.swift
@@ -12,10 +12,10 @@ protocol ExtrinsicProcessing {
 }
 
 final class ExtrinsicProcessor {
-    let accountId: Data
+    let accountId: AccountId
     let chain: ChainModel
 
-    init(accountId: Data, chain: ChainModel) {
+    init(accountId: AccountId, chain: ChainModel) {
         self.accountId = accountId
         self.chain = chain
     }

--- a/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+Matching.swift
+++ b/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+Matching.swift
@@ -506,7 +506,7 @@ extension ExtrinsicProcessor {
 
             return (callPath, isAccountMatched, callAccountId, callResult.callSender, call.args.value)
         } else {
-            let callResult: NestedExtrinsicCallMapResult<RuntimeCall<TransferCall>> = try callMapper.mapRuntimeCall(
+            let callResult: NestedExtrinsicCallMapResult<RuntimeCall<TransferAllCall>> = try callMapper.mapRuntimeCall(
                 call: extrinsic.call,
                 context: context
             )

--- a/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+Matching.swift
+++ b/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+Matching.swift
@@ -6,6 +6,7 @@ private typealias OrmlParsingResult = (
     callPath: CallCodingPath,
     isAccountMatched: Bool,
     callAccountId: AccountId?,
+    callSenderId: AccountId,
     callCurrencyId: JSON,
     callAmount: BigUInt
 )
@@ -14,6 +15,7 @@ private typealias AssetsParsingResult = (
     callPath: CallCodingPath,
     isAccountMatched: Bool,
     callAccountId: AccountId?,
+    callSenderAccountId: AccountId,
     callAssetId: JSON,
     callAmount: BigUInt
 )
@@ -57,16 +59,20 @@ extension ExtrinsicProcessor {
                 with: context.toRawContext()
             ).accountId
 
+            guard let sender = maybeSender else {
+                return nil
+            }
+
             let eventRecords = eventRecords.filter { $0.extrinsicIndex == extrinsicIndex }
             let result = try parseOrmlExtrinsic(
                 extrinsic,
                 eventRecords: eventRecords,
                 metadata: metadata,
-                sender: maybeSender,
+                sender: sender,
                 context: context
             )
 
-            guard result.callPath.isTokensTransfer, result.isAccountMatched, let sender = maybeSender else {
+            guard result.callPath.isTokensTransfer, result.isAccountMatched else {
                 return nil
             }
 
@@ -84,7 +90,7 @@ extension ExtrinsicProcessor {
                 runtimeJsonContext: context
             )
 
-            let peerId = accountId == sender ? result.callAccountId : sender
+            let peerId = accountId == result.callSenderId ? result.callAccountId : result.callSenderId
 
             guard
                 let asset = findOrmlAssetMatching(
@@ -96,7 +102,7 @@ extension ExtrinsicProcessor {
             }
 
             return ExtrinsicProcessingResult(
-                sender: sender,
+                sender: result.callSenderId,
                 callPath: result.callPath,
                 call: extrinsic.call,
                 extrinsicHash: nil,
@@ -143,29 +149,37 @@ extension ExtrinsicProcessor {
         _ extrinsic: Extrinsic,
         eventRecords: [EventRecord],
         metadata: RuntimeMetadataProtocol,
-        sender: AccountId?,
+        sender: AccountId,
         context: RuntimeJsonContext
     ) throws -> OrmlParsingResult {
+        let callMapper = NestedExtrinsicCallMapper(extrinsicSender: sender)
+        let optResult: NestedExtrinsicCallMapResult<RuntimeCall<OrmlTokenTransfer>>?
+        optResult = try? callMapper.mapRuntimeCall(
+            call: extrinsic.call,
+            context: context
+        )
+
         if
-            let call = try? extrinsic.call.map(
-                to: RuntimeCall<OrmlTokenTransfer>.self,
-                with: context.toRawContext()
-            ) {
+            let callResult = optResult {
+            let call = callResult.call
             let callAccountId = call.args.dest.accountId
             let callPath = CallCodingPath(moduleName: call.moduleName, callName: call.callName)
-            let isAccountMatched = accountId == sender || accountId == callAccountId
+            let isAccountMatched = accountId == callResult.callSender || accountId == callAccountId
             let currencyId = call.args.currencyId
 
-            return (callPath, isAccountMatched, callAccountId, currencyId, call.args.amount)
+            return (callPath, isAccountMatched, callAccountId, callResult.callSender, currencyId, call.args.amount)
         } else {
-            let call = try extrinsic.call.map(
-                to: RuntimeCall<OrmlTokenTransferAll>.self,
-                with: context.toRawContext()
+            let callResult: NestedExtrinsicCallMapResult<RuntimeCall<OrmlTokenTransferAll>>
+            callResult = try callMapper.mapRuntimeCall(
+                call: extrinsic.call,
+                context: context
             )
+
+            let call = callResult.call
 
             let callAccountId = call.args.dest.accountId
             let callPath = CallCodingPath(moduleName: call.moduleName, callName: call.callName)
-            let isAccountMatched = accountId == sender || accountId == callAccountId
+            let isAccountMatched = accountId == callResult.extrinsicSender || accountId == callAccountId
             let currencyId = call.args.currencyId
 
             let amount = try? matchOrmlTransferAmount(
@@ -174,7 +188,7 @@ extension ExtrinsicProcessor {
                 context: context
             )
 
-            return (callPath, isAccountMatched, callAccountId, currencyId, amount ?? 0)
+            return (callPath, isAccountMatched, callAccountId, callResult.extrinsicSender, currencyId, amount ?? 0)
         }
     }
 
@@ -313,11 +327,13 @@ extension ExtrinsicProcessor {
             let maybeAddress = extrinsic.signature?.address
             let maybeSender = try maybeAddress?.map(to: MultiAddress.self, with: rawContext).accountId
 
-            let result = try parseAssetsExtrinsic(extrinsic, sender: maybeSender, context: context)
+            guard let sender = maybeSender else {
+                return nil
+            }
 
-            guard
-                result.isAccountMatched,
-                let sender = maybeSender else {
+            let result = try parseAssetsExtrinsic(extrinsic, sender: sender, context: context)
+
+            guard result.isAccountMatched else {
                 return nil
             }
 
@@ -335,7 +351,7 @@ extension ExtrinsicProcessor {
                 runtimeJsonContext: context
             )
 
-            let peerId = accountId == sender ? result.callAccountId : sender
+            let peerId = accountId == result.callSenderAccountId ? result.callAccountId : result.callSenderAccountId
 
             let remotePalletName = result.callPath.moduleName
             let remoteAssetId = try StatemineAssetSerializer.encode(
@@ -361,7 +377,7 @@ extension ExtrinsicProcessor {
             }
 
             return ExtrinsicProcessingResult(
-                sender: sender,
+                sender: result.callSenderAccountId,
                 callPath: result.callPath,
                 call: extrinsic.call,
                 extrinsicHash: nil,
@@ -381,19 +397,22 @@ extension ExtrinsicProcessor {
 
     private func parseAssetsExtrinsic(
         _ extrinsic: Extrinsic,
-        sender: AccountId?,
+        sender: AccountId,
         context: RuntimeJsonContext
     ) throws -> AssetsParsingResult {
-        let call = try extrinsic.call.map(
-            to: RuntimeCall<AssetsTransfer>.self,
-            with: context.toRawContext()
+        let callMapper = NestedExtrinsicCallMapper(extrinsicSender: sender)
+        let callResult: NestedExtrinsicCallMapResult<RuntimeCall<AssetsTransfer>> = try callMapper.mapRuntimeCall(
+            call: extrinsic.call,
+            context: context
         )
+
+        let call = callResult.call
         let callAccountId = call.args.target.accountId
         let callPath = CallCodingPath(moduleName: call.moduleName, callName: call.callName)
-        let isAccountMatched = accountId == sender || accountId == callAccountId
+        let isAccountMatched = accountId == callResult.callSender || accountId == callAccountId
         let assetId = call.args.assetId
 
-        return (callPath, isAccountMatched, callAccountId, assetId, call.args.amount)
+        return (callPath, isAccountMatched, callAccountId, callResult.callSender, assetId, call.args.amount)
     }
 
     func matchBalancesTransfer(
@@ -553,24 +572,32 @@ extension ExtrinsicProcessor {
             let metadata = codingFactory.metadata
             let context = codingFactory.createRuntimeJsonContext()
 
-            let sender: AccountId? = try extrinsic.signature?.address.map(
+            let optExtrinsicSender: AccountId? = try extrinsic.signature?.address.map(
                 to: MultiAddress.self,
                 with: context.toRawContext()
             ).accountId
 
-            let eventRecords = eventRecords.filter { $0.extrinsicIndex == extrinsicIndex }
-
-            guard let call = try? extrinsic.call.map(
-                to: RuntimeCall<EquilibriumTokenTransfer>.self,
-                with: context.toRawContext()
-            ) else {
+            guard let extrinsicSender = optExtrinsicSender else {
                 return nil
             }
+
+            let eventRecords = eventRecords.filter { $0.extrinsicIndex == extrinsicIndex }
+
+            let callMapper = NestedExtrinsicCallMapper(extrinsicSender: extrinsicSender)
+
+            let optCallResult: NestedExtrinsicCallMapResult<RuntimeCall<EquilibriumTokenTransfer>>?
+            optCallResult = try? callMapper.mapRuntimeCall(call: extrinsic.call, context: context)
+
+            guard let callResult = optCallResult else {
+                return nil
+            }
+
+            let call = callResult.call
             let callAccountId = call.args.destinationAccountId
             let callPath = CallCodingPath(moduleName: call.moduleName, callName: call.callName)
-            let isAccountMatched = accountId == sender || accountId == callAccountId
+            let isAccountMatched = accountId == callResult.callSender || accountId == callAccountId
 
-            guard callPath.isEquilibriumTransfer, isAccountMatched, let sender = sender else {
+            guard callPath.isEquilibriumTransfer, isAccountMatched else {
                 return nil
             }
 
@@ -584,13 +611,13 @@ extension ExtrinsicProcessor {
 
             let fee = findFee(
                 for: extrinsicIndex,
-                sender: sender,
+                sender: extrinsicSender,
                 eventRecords: eventRecords,
                 metadata: metadata,
                 runtimeJsonContext: context
             )
 
-            let peerId = accountId == sender ? callAccountId : sender
+            let peerId = accountId == callResult.callSender ? callAccountId : callResult.callSender
             guard let assetId = chain.equilibriumAssets.first(where: {
                 $0.equilibriumAssetId == call.args.assetId
             })?.assetId else {
@@ -598,7 +625,7 @@ extension ExtrinsicProcessor {
             }
 
             return ExtrinsicProcessingResult(
-                sender: sender,
+                sender: callResult.callSender,
                 callPath: callPath,
                 call: extrinsic.call,
                 extrinsicHash: nil,

--- a/novawallet/Common/Services/TransactionSubscription/NestedExtrinsicCallMapper.swift
+++ b/novawallet/Common/Services/TransactionSubscription/NestedExtrinsicCallMapper.swift
@@ -1,0 +1,171 @@
+import Foundation
+import SubstrateSdk
+
+indirect enum NestedExtrinsicCallNode<T: Codable> {
+    case proxy(proxiedAccountId: AccountId, child: NestedExtrinsicCallNode<T>)
+    case call(T)
+
+    var isCall: Bool {
+        switch self {
+        case .proxy:
+            return false
+        case .call:
+            return true
+        }
+    }
+
+    var callSender: AccountId? {
+        switch self {
+        case let .proxy(proxiedAccountId, child):
+            if let nestedCallOwner = child.callSender {
+                return nestedCallOwner
+            } else {
+                return proxiedAccountId
+            }
+        case .call:
+            return nil
+        }
+    }
+
+    var call: T {
+        switch self {
+        case let .proxy(_, child):
+            return child.call
+        case let .call(runtimeCall):
+            return runtimeCall
+        }
+    }
+}
+
+extension NestedExtrinsicCallNode where T == JSON {
+    func mapCall<T: Codable>(closure: (JSON) throws -> T) throws -> NestedExtrinsicCallNode<T> {
+        switch self {
+        case let .proxy(proxiedAccountId, child):
+            let newChild = try child.mapCall(closure: closure)
+            return .proxy(proxiedAccountId: proxiedAccountId, child: newChild)
+        case let .call(call):
+            let newCall = try closure(call)
+            return .call(newCall)
+        }
+    }
+}
+
+struct NestedExtrinsicCallMapResult<T: Codable> {
+    let extrinsicSender: AccountId
+    let node: NestedExtrinsicCallNode<T>
+
+    var callSender: AccountId {
+        if let nestedCallSender = node.callSender {
+            return nestedCallSender
+        } else {
+            return extrinsicSender
+        }
+    }
+
+    var call: T {
+        node.call
+    }
+}
+
+protocol NestedExtrinsicCallMapperProtocol {
+    func map(
+        call: JSON,
+        context: RuntimeJsonContext?,
+        matchingClosure: (JSON) -> Bool
+    ) throws -> NestedExtrinsicCallMapResult<JSON>
+}
+
+extension NestedExtrinsicCallMapperProtocol {
+    func mapRuntimeCall<T: Codable>(
+        call: JSON,
+        context: RuntimeJsonContext?
+    ) throws -> NestedExtrinsicCallMapResult<RuntimeCall<T>> {
+        let result = try map(call: call, context: context) { callJson in
+            do {
+                _ = try callJson.map(to: RuntimeCall<T>.self, with: context?.toRawContext())
+                return true
+            } catch {
+                return false
+            }
+        }
+
+        let newNode: NestedExtrinsicCallNode<RuntimeCall<T>> = try result.node.mapCall { callJson in
+            try callJson.map(to: RuntimeCall<T>.self, with: context?.toRawContext())
+        }
+
+        return NestedExtrinsicCallMapResult(
+            extrinsicSender: result.extrinsicSender,
+            node: newNode
+        )
+    }
+}
+
+final class NestedExtrinsicCallMapper {
+    enum NestedExtrinsicCallMapperError: Error {
+        case internalError(JSON)
+        case noMatch(JSON)
+    }
+
+    let extrinsicSender: AccountId
+
+    init(extrinsicSender: AccountId) {
+        self.extrinsicSender = extrinsicSender
+    }
+
+    func mapConcrete(call: JSON, matchingClosure: (JSON) -> Bool) throws -> NestedExtrinsicCallNode<JSON> {
+        if matchingClosure(call) {
+            return .call(call)
+        } else {
+            throw NestedExtrinsicCallMapperError.noMatch(call)
+        }
+    }
+
+    func mapProxy(
+        call: JSON,
+        context: RuntimeJsonContext?,
+        matchingClosure: (JSON) -> Bool
+    ) throws -> NestedExtrinsicCallNode<JSON> {
+        let proxyCall = try call.map(to: RuntimeCall<Proxy.ProxyCall>.self, with: context?.toRawContext())
+        let node: NestedExtrinsicCallNode<JSON> = try mapNested(
+            call: proxyCall.args.call,
+            context: context,
+            matchingClosure: matchingClosure
+        )
+
+        guard let proxiedAccountId = proxyCall.args.real.accountId else {
+            throw NestedExtrinsicCallMapperError.internalError(call)
+        }
+
+        return .proxy(proxiedAccountId: proxiedAccountId, child: node)
+    }
+
+    func mapNested(
+        call: JSON,
+        context: RuntimeJsonContext?,
+        matchingClosure: (JSON) -> Bool
+    ) throws -> NestedExtrinsicCallNode<JSON> {
+        let optNode: NestedExtrinsicCallNode<JSON>? = try? mapConcrete(call: call, matchingClosure: matchingClosure)
+
+        if let node = optNode {
+            return node
+        } else {
+            return try mapProxy(call: call, context: context, matchingClosure: matchingClosure)
+        }
+    }
+}
+
+extension NestedExtrinsicCallMapper: NestedExtrinsicCallMapperProtocol {
+    func map(
+        call: JSON,
+        context: RuntimeJsonContext?,
+        matchingClosure: (JSON) -> Bool
+    ) throws -> NestedExtrinsicCallMapResult<JSON> {
+        let node: NestedExtrinsicCallNode<JSON> = try mapNested(
+            call: call,
+            context: context,
+            matchingClosure: matchingClosure
+        )
+
+        return NestedExtrinsicCallMapResult(extrinsicSender: extrinsicSender, node: node)
+    }
+}

--- a/novawallet/Modules/AssetDetails/AssetDetailsPresenter.swift
+++ b/novawallet/Modules/AssetDetails/AssetDetailsPresenter.swift
@@ -134,7 +134,7 @@ extension AssetDetailsPresenter: AssetDetailsPresenterProtocol {
 
     func handleReceive() {
         switch selectedAccount.type {
-        case .secrets, .paritySigner, .polkadotVault:
+        case .secrets, .paritySigner, .polkadotVault, .proxied:
             showReceiveTokens()
         case .ledger:
             if let assetRawType = chainAsset.asset.type, case .orml = AssetType(rawValue: assetRawType) {
@@ -143,7 +143,7 @@ extension AssetDetailsPresenter: AssetDetailsPresenterProtocol {
                 showReceiveTokens()
             }
 
-        case .watchOnly, .proxied:
+        case .watchOnly:
             wireframe.showNoSigning(from: view)
         }
     }
@@ -154,7 +154,7 @@ extension AssetDetailsPresenter: AssetDetailsPresenterProtocol {
         }
 
         switch selectedAccount.type {
-        case .secrets, .paritySigner, .polkadotVault:
+        case .secrets, .paritySigner, .polkadotVault, .proxied:
             showPurchase()
         case .ledger:
             if let assetRawType = chainAsset.asset.type, case .orml = AssetType(rawValue: assetRawType) {
@@ -162,7 +162,7 @@ extension AssetDetailsPresenter: AssetDetailsPresenterProtocol {
             } else {
                 showPurchase()
             }
-        case .watchOnly, .proxied:
+        case .watchOnly:
             wireframe.showNoSigning(from: view)
         }
     }

--- a/novawallet/Modules/OperationDetails/OperationDataProviders/OperationDetailsDataProviderFactory.swift
+++ b/novawallet/Modules/OperationDetails/OperationDataProviders/OperationDetailsDataProviderFactory.swift
@@ -31,7 +31,7 @@ extension OperationDetailsDataProviderFactory: OperationDetailsDataProviderFacto
     func createProvider(for transaction: TransactionHistoryItem) -> OperationDetailsDataProviderProtocol? {
         guard
             let address = selectedAccount.chainAccount.toAddress(),
-            let transactionType = transaction.type(for: address) else {
+            let transactionType = transaction.type(for: address, chainAssetId: chainAsset.chainAssetId) else {
             return nil
         }
 

--- a/novawallet/Modules/OperationDetails/OperationDataProviders/OperationDetailsDirectStakingProvider.swift
+++ b/novawallet/Modules/OperationDetails/OperationDataProviders/OperationDetailsDirectStakingProvider.swift
@@ -32,7 +32,10 @@ final class OperationDetailsDirectStakingProvider: OperationDetailsBaseProvider,
             return
         }
 
-        let isReward = transaction.type(for: accountAddress) == .reward
+        let isReward = transaction.type(
+            for: accountAddress,
+            chainAssetId: chainAsset.chainAssetId
+        ) == .reward
 
         if isReward {
             completion(.reward(model))

--- a/novawallet/Modules/OperationDetails/OperationDataProviders/OperationDetailsPoolStakingProvider.swift
+++ b/novawallet/Modules/OperationDetails/OperationDataProviders/OperationDetailsPoolStakingProvider.swift
@@ -49,7 +49,10 @@ final class OperationDetailsPoolStakingProvider: OperationDetailsBaseProvider, A
             return
         }
 
-        let isReward = transaction.type(for: accountAddress) == .poolReward
+        let isReward = transaction.type(
+            for: accountAddress,
+            chainAssetId: chainAsset.chainAssetId
+        ) == .poolReward
 
         if isReward {
             progressClosure(.poolReward(model))

--- a/novawallet/Modules/OperationDetails/OperationDataProviders/OperationDetailsTransferProvider.swift
+++ b/novawallet/Modules/OperationDetails/OperationDataProviders/OperationDetailsTransferProvider.swift
@@ -46,7 +46,11 @@ extension OperationDetailsTransferProvider: OperationDetailsDataProviderProtocol
             return
         }
 
-        let isOutgoing = transaction.type(for: accountAddress) == .outgoing
+        let isOutgoing = transaction.type(
+            for: accountAddress,
+            chainAssetId: chainAsset.chainAssetId
+        ) == .outgoing
+
         let amount = transaction.amountInPlankIntOrZero
         let priceData = priceCalculator?.calculatePrice(for: UInt64(bitPattern: transaction.timestamp)).map {
             PriceData.amount($0)

--- a/novawallet/Modules/TransactionHistory/Model/TransactionHistoryViewModelFactory.swift
+++ b/novawallet/Modules/TransactionHistory/Model/TransactionHistoryViewModelFactory.swift
@@ -359,7 +359,7 @@ extension TransactionHistoryViewModelFactory: TransactionHistoryViewModelFactory
         address: AccountAddress,
         locale: Locale
     ) -> TransactionItemViewModel? {
-        guard let transactionType = data.type(for: address) else {
+        guard let transactionType = data.type(for: address, chainAssetId: chainAsset.chainAssetId) else {
             return nil
         }
         switch transactionType {
@@ -404,7 +404,7 @@ extension TransactionHistoryViewModelFactory: TransactionHistoryViewModelFactory
 }
 
 extension TransactionHistoryItem {
-    func type(for address: AccountAddress) -> TransactionType? {
+    func type(for address: AccountAddress, chainAssetId: ChainAssetId) -> TransactionType? {
         if swap != nil {
             return .swap
         }
@@ -419,7 +419,10 @@ extension TransactionHistoryItem {
         case .poolSlash:
             return .poolSlash
         default:
-            if callPath.isSubstrateOrEvmTransfer {
+            if
+                callPath.isSubstrateOrEvmTransfer,
+                chainAssetId.chainId == chainId,
+                chainAssetId.assetId == assetId {
                 return sender == address ? .outgoing : .incoming
             } else {
                 return TransactionType.extrinsic


### PR DESCRIPTION
The implementation idea is to use NestedExtrinsicCallMapper to recursively traverse the call and derive target call and call's sender. Call's sender is an account that is the origin for the call. Call sender differs from extrinsic sender only for proxies currently.