### PR TITLE
Prepare for Kusama runtime upgrade

### DIFF
--- a/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicSplitter.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicSplitter.swift
@@ -23,7 +23,7 @@ enum ExtrinsicSplitterError: Error {
 }
 
 final class ExtrinsicSplitter {
-    static let maxExtrinsicSizePercent: CGFloat = 0.8
+    static let maxExtrinsicSizePercent: CGFloat = 0.6
     static let blockSizeMultiplier: CGFloat = 0.64
 
     typealias CallConverter = (RuntimeJsonContext?) throws -> JSON

--- a/novawallet/Common/Substrate/Types/Preimage/Preimage.swift
+++ b/novawallet/Common/Substrate/Types/Preimage/Preimage.swift
@@ -10,6 +10,10 @@ enum Preimage {
         StorageCodingPath(moduleName: "Preimage", itemName: "StatusFor")
     }
 
+    static var requestStatusForStoragePath: StorageCodingPath {
+        StorageCodingPath(moduleName: "Preimage", itemName: "RequestStatusFor")
+    }
+
     struct PreimageKey: Encodable {
         let hash: Data
         let length: UInt32


### PR DESCRIPTION
- prefer RequestStatusFor to fetch preimage status of the call
- use 0.6 coefficient to address transaction acceptance issue for gov calls