### PR TITLE
Support spend local

### DIFF
--- a/novawallet/Common/Substrate/Types/Treasury/Treasury+Calls.swift
+++ b/novawallet/Common/Substrate/Types/Treasury/Treasury+Calls.swift
@@ -19,6 +19,10 @@ extension Treasury {
         CallCodingPath(moduleName: "Treasury", callName: "spend")
     }
 
+    static var spendLocalCallPath: CallCodingPath {
+        CallCodingPath(moduleName: "Treasury", callName: "spend_local")
+    }
+
     struct SpendCall: Decodable {
         @StringCodable var amount: BigUInt
         let beneficiary: MultiAddress


### PR DESCRIPTION
New Kusama runtime introduce spend via xcm option and previously call to spend assets local has been renamed to spend_local. We now need to support both old version of spend and spend_local.

Note: we don't currently support new version that spends something via xcm in this PR