### PR TITLE
Swap pair and quote calculation for Hydra swaps

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		0C1BE1A02A46F1F00010933C /* ScientificStringParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1BE19F2A46F1F00010933C /* ScientificStringParsing.swift */; };
 		0C1BE1A22A46F93B0010933C /* BigUInt+Scientific.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1BE1A12A46F93B0010933C /* BigUInt+Scientific.swift */; };
 		0C1BE1A62A47FC240010933C /* MultistakingSyncServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1BE1A52A47FC240010933C /* MultistakingSyncServiceFactory.swift */; };
+		0C1CCC3F2B5F864400A6EA17 /* HydraOmnipoolOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1CCC3E2B5F864400A6EA17 /* HydraOmnipoolOperationFactory.swift */; };
 		0C1FE4F42A52EE51003769E7 /* AssetSearchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1FE4F32A52EE51003769E7 /* AssetSearchBuilder.swift */; };
 		0C1FE4F62A52F137003769E7 /* AssetSearchBuilderResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1FE4F52A52F137003769E7 /* AssetSearchBuilderResult.swift */; };
 		0C21D77C2AB42A3500EB2DBD /* ScreenOpenService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C21D77B2AB42A3500EB2DBD /* ScreenOpenService.swift */; };
@@ -4316,6 +4317,7 @@
 		0C1BE19F2A46F1F00010933C /* ScientificStringParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScientificStringParsing.swift; sourceTree = "<group>"; };
 		0C1BE1A12A46F93B0010933C /* BigUInt+Scientific.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BigUInt+Scientific.swift"; sourceTree = "<group>"; };
 		0C1BE1A52A47FC240010933C /* MultistakingSyncServiceFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultistakingSyncServiceFactory.swift; sourceTree = "<group>"; };
+		0C1CCC3E2B5F864400A6EA17 /* HydraOmnipoolOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolOperationFactory.swift; sourceTree = "<group>"; };
 		0C1FE4F32A52EE51003769E7 /* AssetSearchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetSearchBuilder.swift; sourceTree = "<group>"; };
 		0C1FE4F52A52F137003769E7 /* AssetSearchBuilderResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetSearchBuilderResult.swift; sourceTree = "<group>"; };
 		0C21D77B2AB42A3500EB2DBD /* ScreenOpenService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenOpenService.swift; sourceTree = "<group>"; };
@@ -8676,6 +8678,7 @@
 		0C0CB3802AC5459200EAC516 /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				0C1CCC3D2B5F862D00A6EA17 /* HydraDx */,
 				0C0CB3832AC561CA00EAC516 /* AssetHub */,
 				0C0CB3812AC545A800EAC516 /* AssetConversionExtrinsicService.swift */,
 				0CD352962ACAFADA00B3E446 /* AssetConversionOperationFactory.swift */,
@@ -8771,6 +8774,14 @@
 				0C13D3252A82753F0054BB6F /* StartStakingFeeIdFactory.swift */,
 			);
 			path = ExtrinsicProxy;
+			sourceTree = "<group>";
+		};
+		0C1CCC3D2B5F862D00A6EA17 /* HydraDx */ = {
+			isa = PBXGroup;
+			children = (
+				0C1CCC3E2B5F864400A6EA17 /* HydraOmnipoolOperationFactory.swift */,
+			);
+			path = HydraDx;
 			sourceTree = "<group>";
 		};
 		0C1FE4F22A52EDD5003769E7 /* Model */ = {
@@ -23900,6 +23911,7 @@
 				C6E220DA6AD9A938083179CB /* AddDelegationInteractor.swift in Sources */,
 				8E74A13BA73160F88B2B0948 /* AddDelegationViewController.swift in Sources */,
 				CEED39FF1C586C00B56B1F0C /* AddDelegationViewLayout.swift in Sources */,
+				0C1CCC3F2B5F864400A6EA17 /* HydraOmnipoolOperationFactory.swift in Sources */,
 				7D3D51706CD51AA9101DCE42 /* AddDelegationViewFactory.swift in Sources */,
 				D938B2F0F1F17649A78BB5BC /* GovernanceDelegateInfoProtocols.swift in Sources */,
 				5ECC5F9E55FBC5CF2DD8664C /* GovernanceDelegateInfoWireframe.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -360,6 +360,8 @@
 		0CCCDF822B64C19D00473D42 /* HydraDx+Storages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF812B64C19C00473D42 /* HydraDx+Storages.swift */; };
 		0CCCDF842B64C63D00473D42 /* HydraDxTokenConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF832B64C63D00473D42 /* HydraDxTokenConverter.swift */; };
 		0CCCDF862B64CCC100473D42 /* HydraDxSwapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF852B64CCC100473D42 /* HydraDxSwapTests.swift */; };
+		0CCCDF882B660E8700473D42 /* HydraOmnipoolQuoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF872B660E8700473D42 /* HydraOmnipoolQuoteService.swift */; };
+		0CCCDF8A2B661D5300473D42 /* HydraOmnipoolQuoteRemoteState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF892B661D5300473D42 /* HydraOmnipoolQuoteRemoteState.swift */; };
 		0CCE25212A44306200286709 /* TransactionHistoryPhishingFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCE25202A44306200286709 /* TransactionHistoryPhishingFilter.swift */; };
 		0CD1F4D100ED82D137AB9834 /* ParaStkStakeSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2F1EEBF48485F02BF690A4 /* ParaStkStakeSetupViewController.swift */; };
 		0CD352932ACAD7A500B3E446 /* AssetHubExtrinsicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD352922ACAD7A500B3E446 /* AssetHubExtrinsicService.swift */; };
@@ -4597,6 +4599,8 @@
 		0CCCDF812B64C19C00473D42 /* HydraDx+Storages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HydraDx+Storages.swift"; sourceTree = "<group>"; };
 		0CCCDF832B64C63D00473D42 /* HydraDxTokenConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraDxTokenConverter.swift; sourceTree = "<group>"; };
 		0CCCDF852B64CCC100473D42 /* HydraDxSwapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraDxSwapTests.swift; sourceTree = "<group>"; };
+		0CCCDF872B660E8700473D42 /* HydraOmnipoolQuoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolQuoteService.swift; sourceTree = "<group>"; };
+		0CCCDF892B661D5300473D42 /* HydraOmnipoolQuoteRemoteState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolQuoteRemoteState.swift; sourceTree = "<group>"; };
 		0CCE25202A44306200286709 /* TransactionHistoryPhishingFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryPhishingFilter.swift; sourceTree = "<group>"; };
 		0CD352922ACAD7A500B3E446 /* AssetHubExtrinsicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetHubExtrinsicService.swift; sourceTree = "<group>"; };
 		0CD352942ACAF59900B3E446 /* BigRational.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigRational.swift; sourceTree = "<group>"; };
@@ -8793,6 +8797,8 @@
 			children = (
 				0C1CCC3E2B5F864400A6EA17 /* HydraOmnipoolOperationFactory.swift */,
 				0CCCDF832B64C63D00473D42 /* HydraDxTokenConverter.swift */,
+				0CCCDF872B660E8700473D42 /* HydraOmnipoolQuoteService.swift */,
+				0CCCDF892B661D5300473D42 /* HydraOmnipoolQuoteRemoteState.swift */,
 			);
 			path = HydraDx;
 			sourceTree = "<group>";
@@ -20413,6 +20419,7 @@
 				883DB17E297A521900EFB7D8 /* GovernanceDelegatesOrder.swift in Sources */,
 				7728E58D2A123B42007901E0 /* SearchOperationFactory.swift in Sources */,
 				8490141A24A92F6D008F705E /* OnboardingMainProtocol.swift in Sources */,
+				0CCCDF882B660E8700473D42 /* HydraOmnipoolQuoteService.swift in Sources */,
 				84DBEA47265E98C300FDF73C /* AmountInputResult.swift in Sources */,
 				848E6BDD2762142300C91022 /* StakingStatusView.swift in Sources */,
 				84276687297AB22B0063E08E /* TableViewCellPosition.swift in Sources */,
@@ -21443,6 +21450,7 @@
 				8482F62F280C618B0006C3A0 /* DAppAuthSettingsTableCell.swift in Sources */,
 				846E5013277999FC0049B659 /* DAppAuthViewModel.swift in Sources */,
 				84FB298426393D0900BE0FCD /* YourValidatorListViewModelFactory.swift in Sources */,
+				0CCCDF8A2B661D5300473D42 /* HydraOmnipoolQuoteRemoteState.swift in Sources */,
 				842E9E942A2A277D00759972 /* StakingDashboardLocalStorageSubscriber.swift in Sources */,
 				8489A6D827FDA51C0040C066 /* AccountLocalSubscriptionHandler.swift in Sources */,
 				0CB64E602B00AD83008F268F /* GetTokenOptionsWireframe.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -354,6 +354,11 @@
 		0CCA245D2AC6918800AEF23D /* XcmV3Junction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCA245C2AC6918800AEF23D /* XcmV3Junction.swift */; };
 		0CCA245F2AC6974200AEF23D /* XcmV3Multilocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCA245E2AC6974200AEF23D /* XcmV3Multilocation.swift */; };
 		0CCA24652AC6B51200AEF23D /* AssetHubSwapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCA24642AC6B51200AEF23D /* AssetHubSwapTests.swift */; };
+		0CCCDF762B64B80500473D42 /* StorageKeysOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF752B64B80500473D42 /* StorageKeysOperationFactory.swift */; };
+		0CCCDF7E2B64BE5300473D42 /* HydraDx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF7D2B64BE5300473D42 /* HydraDx.swift */; };
+		0CCCDF802B64BE7C00473D42 /* HydraDx+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF7F2B64BE7C00473D42 /* HydraDx+Constants.swift */; };
+		0CCCDF822B64C19D00473D42 /* HydraDx+Storages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF812B64C19C00473D42 /* HydraDx+Storages.swift */; };
+		0CCCDF842B64C63D00473D42 /* HydraDxTokenConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF832B64C63D00473D42 /* HydraDxTokenConverter.swift */; };
 		0CCE25212A44306200286709 /* TransactionHistoryPhishingFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCE25202A44306200286709 /* TransactionHistoryPhishingFilter.swift */; };
 		0CD1F4D100ED82D137AB9834 /* ParaStkStakeSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2F1EEBF48485F02BF690A4 /* ParaStkStakeSetupViewController.swift */; };
 		0CD352932ACAD7A500B3E446 /* AssetHubExtrinsicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD352922ACAD7A500B3E446 /* AssetHubExtrinsicService.swift */; };
@@ -4585,6 +4590,11 @@
 		0CCA245C2AC6918800AEF23D /* XcmV3Junction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmV3Junction.swift; sourceTree = "<group>"; };
 		0CCA245E2AC6974200AEF23D /* XcmV3Multilocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmV3Multilocation.swift; sourceTree = "<group>"; };
 		0CCA24642AC6B51200AEF23D /* AssetHubSwapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetHubSwapTests.swift; sourceTree = "<group>"; };
+		0CCCDF752B64B80500473D42 /* StorageKeysOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageKeysOperationFactory.swift; sourceTree = "<group>"; };
+		0CCCDF7D2B64BE5300473D42 /* HydraDx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraDx.swift; sourceTree = "<group>"; };
+		0CCCDF7F2B64BE7C00473D42 /* HydraDx+Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HydraDx+Constants.swift"; sourceTree = "<group>"; };
+		0CCCDF812B64C19C00473D42 /* HydraDx+Storages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HydraDx+Storages.swift"; sourceTree = "<group>"; };
+		0CCCDF832B64C63D00473D42 /* HydraDxTokenConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraDxTokenConverter.swift; sourceTree = "<group>"; };
 		0CCE25202A44306200286709 /* TransactionHistoryPhishingFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryPhishingFilter.swift; sourceTree = "<group>"; };
 		0CD352922ACAD7A500B3E446 /* AssetHubExtrinsicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetHubExtrinsicService.swift; sourceTree = "<group>"; };
 		0CD352942ACAF59900B3E446 /* BigRational.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigRational.swift; sourceTree = "<group>"; };
@@ -8780,6 +8790,7 @@
 			isa = PBXGroup;
 			children = (
 				0C1CCC3E2B5F864400A6EA17 /* HydraOmnipoolOperationFactory.swift */,
+				0CCCDF832B64C63D00473D42 /* HydraDxTokenConverter.swift */,
 			);
 			path = HydraDx;
 			sourceTree = "<group>";
@@ -9342,6 +9353,16 @@
 				0CCA245E2AC6974200AEF23D /* XcmV3Multilocation.swift */,
 			);
 			path = V3;
+			sourceTree = "<group>";
+		};
+		0CCCDF7C2B64BE3D00473D42 /* HydraDx */ = {
+			isa = PBXGroup;
+			children = (
+				0CCCDF7D2B64BE5300473D42 /* HydraDx.swift */,
+				0CCCDF7F2B64BE7C00473D42 /* HydraDx+Constants.swift */,
+				0CCCDF812B64C19C00473D42 /* HydraDx+Storages.swift */,
+			);
+			path = HydraDx;
 			sourceTree = "<group>";
 		};
 		0CD352992ACD3E3500B3E446 /* Assets */ = {
@@ -11888,6 +11909,7 @@
 		8438E1DC24C18F11001BDB13 /* Types */ = {
 			isa = PBXGroup;
 			children = (
+				0CCCDF7C2B64BE3D00473D42 /* HydraDx */,
 				0C0E0AA12B3F01EE00865F10 /* Uniques */,
 				0C0E0A9E2B3F011E00865F10 /* BalancesPallet */,
 				773BA0762B15F50700929BD4 /* Proxy */,
@@ -14393,6 +14415,7 @@
 				8824D423290324260022D778 /* PrettyPrintedJSONOperationFactory.swift */,
 				0C37AFBC2B55732100009ECA /* NMapKeyEncodingOperation.swift */,
 				0C37AFC22B5796DD00009ECA /* StateCallOperationFactory.swift */,
+				0CCCDF752B64B80500473D42 /* StorageKeysOperationFactory.swift */,
 			);
 			path = Operation;
 			sourceTree = "<group>";
@@ -20708,6 +20731,7 @@
 				8430AAE126022CA1005B1066 /* BaseStakingState.swift in Sources */,
 				8490141124A92F6D008F705E /* OnboardingMainViewController.swift in Sources */,
 				D9D163642744F60D00681C1F /* ExternalContribution.swift in Sources */,
+				0CCCDF842B64C63D00473D42 /* HydraDxTokenConverter.swift in Sources */,
 				0C8102232B5A922B00F75BF9 /* ProxyValidationFactory.swift in Sources */,
 				84155DED2539817200A27058 /* ApplicationService.swift in Sources */,
 				84403D7F25E91BC100494FD4 /* SuperIdentity.swift in Sources */,
@@ -21535,6 +21559,7 @@
 				84329ECE28322E150020BC1C /* BlockTimeOperationFactory.swift in Sources */,
 				8428765B24ADDE0200D91AD8 /* SettingsWireframe.swift in Sources */,
 				84D2F19D2771E5610040C680 /* ExtrinsicBuilder+Signing.swift in Sources */,
+				0CCCDF822B64C19D00473D42 /* HydraDx+Storages.swift in Sources */,
 				8430AAFB260230C5005B1066 /* ValidatorState.swift in Sources */,
 				8424308D265B1814003E07EC /* CrowdloanOperationFactory.swift in Sources */,
 				77EFFC8D2A6EECFD009E28F8 /* StakingAmountViewModelFactory.swift in Sources */,
@@ -22247,6 +22272,7 @@
 				0C17BD992A42F1BE004AF9E7 /* MoneyPresentable.swift in Sources */,
 				844CB57226F9EB2000396E13 /* RuntimeCodingService.swift in Sources */,
 				84B73AD8279C2EDA0071AE16 /* AssetAccountSubscription.swift in Sources */,
+				0CCCDF7E2B64BE5300473D42 /* HydraDx.swift in Sources */,
 				843910B2253ED4D100E3C217 /* CDChainStorageItem+CoreDataDecodable.swift in Sources */,
 				844DBC64274D2BD6009F8351 /* ModalPickerClosureContext.swift in Sources */,
 				8451720D298C473500489EF1 /* GovernanceSelectableTrackView.swift in Sources */,
@@ -22571,6 +22597,7 @@
 				84F76ED829006BC400D7206C /* DiscreteGradientSlider+Style.swift in Sources */,
 				841E6AFE25EC12DE0007DDFE /* SelectedValidatorInfo.swift in Sources */,
 				F4E17FC52721814D00FE36D3 /* MoonbeamVerifiedResponse.swift in Sources */,
+				0CCCDF762B64B80500473D42 /* StorageKeysOperationFactory.swift in Sources */,
 				8499FECC27BF8F4A00712589 /* NftModelMapper.swift in Sources */,
 				842E9E962A2A279800759972 /* StakingDashboardLocalStorageHandler.swift in Sources */,
 				C89D156BA8B690E8E4DE19ED /* ExportSeedProtocols.swift in Sources */,
@@ -23153,6 +23180,7 @@
 				84C98A5C29A158D700F5328B /* DelegateVotedReferendaParams.swift in Sources */,
 				5E621A350A6DDD78597CC9E5 /* CrowdloanYourContributionsWireframe.swift in Sources */,
 				0C3205E02A896C7E002EB914 /* EvmTransactionPrice.swift in Sources */,
+				0CCCDF802B64BE7C00473D42 /* HydraDx+Constants.swift in Sources */,
 				716F0819BAB14322E34E416C /* CrowdloanYourContributionsPresenter.swift in Sources */,
 				F0675F495766D07473B065F7 /* CrowdloanYourContributionsInteractor.swift in Sources */,
 				845B080D2918D4F8005785D3 /* Democracy+Call.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -362,6 +362,7 @@
 		0CCCDF862B64CCC100473D42 /* HydraDxSwapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF852B64CCC100473D42 /* HydraDxSwapTests.swift */; };
 		0CCCDF882B660E8700473D42 /* HydraOmnipoolQuoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF872B660E8700473D42 /* HydraOmnipoolQuoteService.swift */; };
 		0CCCDF8A2B661D5300473D42 /* HydraOmnipoolQuoteRemoteState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF892B661D5300473D42 /* HydraOmnipoolQuoteRemoteState.swift */; };
+		0CCCDF8C2B67BCA000473D42 /* ChainModelFetchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF8B2B67BCA000473D42 /* ChainModelFetchError.swift */; };
 		0CCE25212A44306200286709 /* TransactionHistoryPhishingFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCE25202A44306200286709 /* TransactionHistoryPhishingFilter.swift */; };
 		0CD1F4D100ED82D137AB9834 /* ParaStkStakeSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2F1EEBF48485F02BF690A4 /* ParaStkStakeSetupViewController.swift */; };
 		0CD352932ACAD7A500B3E446 /* AssetHubExtrinsicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD352922ACAD7A500B3E446 /* AssetHubExtrinsicService.swift */; };
@@ -4601,6 +4602,7 @@
 		0CCCDF852B64CCC100473D42 /* HydraDxSwapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraDxSwapTests.swift; sourceTree = "<group>"; };
 		0CCCDF872B660E8700473D42 /* HydraOmnipoolQuoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolQuoteService.swift; sourceTree = "<group>"; };
 		0CCCDF892B661D5300473D42 /* HydraOmnipoolQuoteRemoteState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolQuoteRemoteState.swift; sourceTree = "<group>"; };
+		0CCCDF8B2B67BCA000473D42 /* ChainModelFetchError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainModelFetchError.swift; sourceTree = "<group>"; };
 		0CCE25202A44306200286709 /* TransactionHistoryPhishingFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryPhishingFilter.swift; sourceTree = "<group>"; };
 		0CD352922ACAD7A500B3E446 /* AssetHubExtrinsicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetHubExtrinsicService.swift; sourceTree = "<group>"; };
 		0CD352942ACAF59900B3E446 /* BigRational.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigRational.swift; sourceTree = "<group>"; };
@@ -16033,6 +16035,7 @@
 				0C9525EA2A7B7F5000BD724D /* ChainModel+Additional.swift */,
 				0C79C8982A7BE46A00B171E3 /* AssetModel+Staking.swift */,
 				0C6941CA2B203F3300A7CF6D /* ChainSyncMode.swift */,
+				0CCCDF8B2B67BCA000473D42 /* ChainModelFetchError.swift */,
 			);
 			path = LocalChain;
 			sourceTree = "<group>";
@@ -24129,6 +24132,7 @@
 				D8CB6639857FE917719EF0AF /* WalletConnectSessionsViewController.swift in Sources */,
 				F06129946DFEC9B7F282EB46 /* WalletConnectSessionsViewLayout.swift in Sources */,
 				84B24FAA2A2F243700F9BF59 /* BlurredCollectionViewCell.swift in Sources */,
+				0CCCDF8C2B67BCA000473D42 /* ChainModelFetchError.swift in Sources */,
 				6DC454C4BA27C98987F5DC52 /* WalletConnectSessionsViewFactory.swift in Sources */,
 				F332FA8C330A16C3894B6542 /* WalletConnectSessionDetailsProtocols.swift in Sources */,
 				D0AD3C44BBFD6A9F9FDEC933 /* WalletConnectSessionDetailsWireframe.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -359,6 +359,7 @@
 		0CCCDF802B64BE7C00473D42 /* HydraDx+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF7F2B64BE7C00473D42 /* HydraDx+Constants.swift */; };
 		0CCCDF822B64C19D00473D42 /* HydraDx+Storages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF812B64C19C00473D42 /* HydraDx+Storages.swift */; };
 		0CCCDF842B64C63D00473D42 /* HydraDxTokenConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF832B64C63D00473D42 /* HydraDxTokenConverter.swift */; };
+		0CCCDF862B64CCC100473D42 /* HydraDxSwapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCDF852B64CCC100473D42 /* HydraDxSwapTests.swift */; };
 		0CCE25212A44306200286709 /* TransactionHistoryPhishingFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCE25202A44306200286709 /* TransactionHistoryPhishingFilter.swift */; };
 		0CD1F4D100ED82D137AB9834 /* ParaStkStakeSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2F1EEBF48485F02BF690A4 /* ParaStkStakeSetupViewController.swift */; };
 		0CD352932ACAD7A500B3E446 /* AssetHubExtrinsicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD352922ACAD7A500B3E446 /* AssetHubExtrinsicService.swift */; };
@@ -4595,6 +4596,7 @@
 		0CCCDF7F2B64BE7C00473D42 /* HydraDx+Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HydraDx+Constants.swift"; sourceTree = "<group>"; };
 		0CCCDF812B64C19C00473D42 /* HydraDx+Storages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HydraDx+Storages.swift"; sourceTree = "<group>"; };
 		0CCCDF832B64C63D00473D42 /* HydraDxTokenConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraDxTokenConverter.swift; sourceTree = "<group>"; };
+		0CCCDF852B64CCC100473D42 /* HydraDxSwapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraDxSwapTests.swift; sourceTree = "<group>"; };
 		0CCE25202A44306200286709 /* TransactionHistoryPhishingFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryPhishingFilter.swift; sourceTree = "<group>"; };
 		0CD352922ACAD7A500B3E446 /* AssetHubExtrinsicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetHubExtrinsicService.swift; sourceTree = "<group>"; };
 		0CD352942ACAF59900B3E446 /* BigRational.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigRational.swift; sourceTree = "<group>"; };
@@ -11902,6 +11904,7 @@
 				0C8AF7B52B36C75400005AC9 /* Pdc20OperationTests.swift */,
 				0CAC03032B4D0C0100DDEC3A /* WalletRemoteQueryFactoryTests.swift */,
 				0C992C422B54F5D900ACC129 /* EraStakersPagedSearchOperationFactoryTests.swift */,
+				0CCCDF852B64CCC100473D42 /* HydraDxSwapTests.swift */,
 			);
 			path = novawalletIntegrationTests;
 			sourceTree = "<group>";
@@ -20325,6 +20328,7 @@
 				84532D5F28E4210E00EF4ADC /* ConvictionVotesFetchTests.swift in Sources */,
 				0C992C432B54F5D900ACC129 /* EraStakersPagedSearchOperationFactoryTests.swift in Sources */,
 				0C3205C22A868236002EB914 /* EvmGasPriceIntegrationTests.swift in Sources */,
+				0CCCDF862B64CCC100473D42 /* HydraDxSwapTests.swift in Sources */,
 				84C3420F2831A67200156569 /* BlockTimeEstimationServiceTests.swift in Sources */,
 				84FACB6A25F5759C00F32ED4 /* AccountCreationHelper.swift in Sources */,
 				77DC54872B1FF31800C7E45A /* UserDataStorageTestFacade.swift in Sources */,

--- a/novawallet/Common/Model/BigRational.swift
+++ b/novawallet/Common/Model/BigRational.swift
@@ -10,9 +10,28 @@ struct BigRational: Hashable {
     }
 }
 
+extension BigUInt {
+    func sub(rational: BigRational) -> BigRational? {
+        let numerator = self * rational.denominator
+
+        guard numerator >= rational.numerator else {
+            return nil
+        }
+
+        return BigRational(
+            numerator: numerator - rational.numerator,
+            denominator: rational.denominator
+        )
+    }
+}
+
 extension BigRational {
     static func percent(of numerator: BigUInt) -> BigRational {
         .init(numerator: numerator, denominator: 100)
+    }
+
+    static func permill(of numerator: BigUInt) -> BigRational {
+        .init(numerator: numerator, denominator: 1_000_000)
     }
 }
 

--- a/novawallet/Common/Model/BigRational.swift
+++ b/novawallet/Common/Model/BigRational.swift
@@ -30,7 +30,7 @@ extension BigRational {
         .init(numerator: numerator, denominator: 100)
     }
 
-    static func permill(of numerator: BigUInt) -> BigRational {
+    static func permillPercent(of numerator: BigUInt) -> BigRational {
         .init(numerator: numerator, denominator: 1_000_000)
     }
 }

--- a/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModelFetchError.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModelFetchError.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum ChainModelFetchError: Error {
+    case noAsset(assetId: AssetModel.Id)
+}

--- a/novawallet/Common/Model/KnownChainIds.swift
+++ b/novawallet/Common/Model/KnownChainIds.swift
@@ -26,6 +26,7 @@ enum KnowChainId {
     static let rococo = "a84b46a3e602245284bb9a72c4abd58ee979aa7a5d7f8c4dfdddfaaf0665a4ae"
     static let westend = "e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e"
     static let westmint = "67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9"
+    static let hydra = "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d"
 
     static var kiltOnEnviroment: String {
         #if F_DEV

--- a/novawallet/Common/Operation/StorageDecodingOperation+Init.swift
+++ b/novawallet/Common/Operation/StorageDecodingOperation+Init.swift
@@ -80,3 +80,23 @@ extension PrimitiveConstantOperation {
         return CompoundOperationWrapper(targetOperation: mappingOperation, dependencies: fetchWrapper.allOperations)
     }
 }
+
+extension StorageConstantOperation {
+    static func operation(
+        path: ConstantCodingPath,
+        dependingOn factoryOperation: BaseOperation<RuntimeCoderFactoryProtocol>,
+        fallbackValue: T? = nil
+    ) -> BaseOperation<T> {
+        let operation = StorageConstantOperation(path: path, fallbackValue: fallbackValue)
+
+        operation.configurationBlock = {
+            do {
+                operation.codingFactory = try factoryOperation.extractNoCancellableResultData()
+            } catch {
+                operation.result = .failure(error)
+            }
+        }
+
+        return operation
+    }
+}

--- a/novawallet/Common/Operation/StorageKeysOperationFactory.swift
+++ b/novawallet/Common/Operation/StorageKeysOperationFactory.swift
@@ -1,0 +1,97 @@
+import Foundation
+import RobinHood
+import SubstrateSdk
+
+protocol StorageKeysOperationFactoryProtocol {
+    func createKeysFetchWrapper<T: JSONListConvertible>(
+        for keyPrefixRequest: RemoteStorageRequestProtocol,
+        codingFactoryClosure: @escaping () throws -> RuntimeCoderFactoryProtocol,
+        connection: JSONRPCEngine
+    ) -> CompoundOperationWrapper<[T]>
+}
+
+extension StorageKeysOperationFactoryProtocol {
+    func createKeysFetchWrapper<T: JSONListConvertible>(
+        by storagePath: StorageCodingPath,
+        runtimeService: RuntimeCodingServiceProtocol,
+        connection: JSONRPCEngine
+    ) -> CompoundOperationWrapper<[T]> {
+        let request = UnkeyedRemoteStorageRequest(storagePath: storagePath)
+
+        let codingFactoryOperation = runtimeService.fetchCoderFactoryOperation()
+
+        let fetchWrapper: CompoundOperationWrapper<[T]> = createKeysFetchWrapper(
+            for: request,
+            codingFactoryClosure: { try codingFactoryOperation.extractNoCancellableResultData() },
+            connection: connection
+        )
+
+        fetchWrapper.addDependency(operations: [codingFactoryOperation])
+
+        return fetchWrapper.insertingHead(operations: [codingFactoryOperation])
+    }
+
+    func createKeysFetchWrapper<T: JSONListConvertible>(
+        by storagePath: StorageCodingPath,
+        codingFactoryClosure: @escaping () throws -> RuntimeCoderFactoryProtocol,
+        connection: JSONRPCEngine
+    ) -> CompoundOperationWrapper<[T]> {
+        let request = UnkeyedRemoteStorageRequest(storagePath: storagePath)
+
+        return createKeysFetchWrapper(
+            for: request,
+            codingFactoryClosure: codingFactoryClosure,
+            connection: connection
+        )
+    }
+}
+
+final class StorageKeysOperationFactory {
+    let operationQueue: OperationQueue
+
+    init(operationQueue: OperationQueue) {
+        self.operationQueue = operationQueue
+    }
+}
+
+extension StorageKeysOperationFactory: StorageKeysOperationFactoryProtocol {
+    func createKeysFetchWrapper<T: JSONListConvertible>(
+        for keyPrefixRequest: RemoteStorageRequestProtocol,
+        codingFactoryClosure: @escaping () throws -> RuntimeCoderFactoryProtocol,
+        connection: JSONRPCEngine
+    ) -> CompoundOperationWrapper<[T]> {
+        let prefixEncodingWrapper = keyPrefixRequest.createKeyEncodingWrapper(
+            using: StorageKeyFactory(),
+            codingFactoryClosure: codingFactoryClosure
+        )
+
+        let keysFetchOperation = StorageKeysQueryService(
+            connection: connection,
+            operationManager: OperationManager(operationQueue: operationQueue),
+            prefixKeyClosure: { try prefixEncodingWrapper.targetOperation.extractNoCancellableResultData() },
+            mapper: AnyMapper(mapper: IdentityMapper())
+        ).longrunOperation()
+
+        keysFetchOperation.addDependency(prefixEncodingWrapper.targetOperation)
+
+        let decodingOperation = StorageKeyDecodingOperation<T>(
+            path: keyPrefixRequest.storagePath
+        )
+
+        decodingOperation.configurationBlock = {
+            do {
+                decodingOperation.codingFactory = try codingFactoryClosure()
+                decodingOperation.dataList = try keysFetchOperation.extractNoCancellableResultData()
+            } catch {
+                decodingOperation.result = .failure(error)
+            }
+        }
+
+        decodingOperation.addDependency(keysFetchOperation)
+
+        return CompoundOperationWrapper(
+            targetOperation: decodingOperation,
+            dependencies: prefixEncodingWrapper.allOperations + [keysFetchOperation]
+        )
+    }
+}

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraDx+Constants.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraDx+Constants.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension HydraDx {
+    static var hubAssetIdPath: ConstantCodingPath {
+        ConstantCodingPath(moduleName: Self.omniPoolModule, constantName: "HubAssetId")
+    }
+}

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraDx+Constants.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraDx+Constants.swift
@@ -4,4 +4,12 @@ extension HydraDx {
     static var hubAssetIdPath: ConstantCodingPath {
         ConstantCodingPath(moduleName: Self.omniPoolModule, constantName: "HubAssetId")
     }
+
+    static var assetFeeParametersPath: ConstantCodingPath {
+        ConstantCodingPath(moduleName: "DynamicFees", constantName: "AssetFeeParameters")
+    }
+
+    static var protocolFeeParametersPath: ConstantCodingPath {
+        ConstantCodingPath(moduleName: "DynamicFees", constantName: "ProtocolFeeParameters")
+    }
 }

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraDx+Storages.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraDx+Storages.swift
@@ -4,4 +4,8 @@ extension HydraDx {
     static var omnipoolAssets: StorageCodingPath {
         StorageCodingPath(moduleName: Self.omniPoolModule, itemName: "Assets")
     }
+
+    static var dynamicFees: StorageCodingPath {
+        StorageCodingPath(moduleName: "DynamicFees", itemName: "AssetFee")
+    }
 }

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraDx+Storages.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraDx+Storages.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension HydraDx {
+    static var omnipoolAssets: StorageCodingPath {
+        StorageCodingPath(moduleName: Self.omniPoolModule, itemName: "Assets")
+    }
+}

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraDx.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraDx.swift
@@ -1,0 +1,23 @@
+import Foundation
+import BigInt
+import SubstrateSdk
+
+enum HydraDx {
+    typealias OmniPoolAssetId = BigUInt
+    static let omniPoolModule = "Omnipool"
+
+    struct AssetsKey: JSONListConvertible {
+        let assetId: OmniPoolAssetId
+
+        init(jsonList: [JSON], context: [CodingUserInfoKey: Any]?) throws {
+            guard jsonList.count == 1 else {
+                throw CommonError.dataCorruption
+            }
+
+            assetId = try jsonList[0].map(
+                to: StringScaleMapper<OmniPoolAssetId>.self,
+                with: context
+            ).value
+        }
+    }
+}

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraDx.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraDx.swift
@@ -22,10 +22,14 @@ enum HydraDx {
     }
 
     struct AssetState: Decodable {
+        struct Tradable: Decodable {
+            @StringCodable var bits: UInt8
+        }
+
         @StringCodable var hubReserve: BigUInt
         @StringCodable var shares: BigUInt
         @StringCodable var protocolShares: BigUInt
-        @StringCodable var tradable: UInt8
+        let tradable: Tradable
     }
 
     struct FeeParameters: Decodable {

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraDx.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraDx.swift
@@ -28,6 +28,15 @@ enum HydraDx {
         @StringCodable var tradable: UInt8
     }
 
+    struct FeeParameters: Decodable {
+        @StringCodable var minFee: BigUInt
+    }
+
+    struct FeeEntry: Decodable {
+        @StringCodable var assetFee: BigUInt
+        @StringCodable var protocolFee: BigUInt
+    }
+
     static func getPoolAccountId(for size: Int) throws -> AccountId {
         guard let accountIdPrefix = "modlomnipool".data(using: .utf8) else {
             throw CommonError.dataCorruption

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraDx.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraDx.swift
@@ -20,4 +20,21 @@ enum HydraDx {
             ).value
         }
     }
+    
+    struct AssetState: Decodable {
+        @StringCodable var hubReserve: BigUInt
+        @StringCodable var shares: BigUInt
+        @StringCodable var protocolShares: BigUInt
+        @StringCodable var tradable: UInt8
+    }
+
+    static func getPoolAccountId(for size: Int) throws -> AccountId {
+        guard let accountIdPrefix = "modlomnipool".data(using: .utf8) else {
+            throw CommonError.dataCorruption
+        }
+
+        let zeroAccountId = AccountId.zeroAccountId(of: size)
+
+        return (accountIdPrefix + zeroAccountId).prefix(size)
+    }
 }

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraDx.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraDx.swift
@@ -20,7 +20,7 @@ enum HydraDx {
             ).value
         }
     }
-    
+
     struct AssetState: Decodable {
         @StringCodable var hubReserve: BigUInt
         @StringCodable var shares: BigUInt

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraDxTokenConverter.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraDxTokenConverter.swift
@@ -1,0 +1,41 @@
+import Foundation
+import SubstrateSdk
+
+extension HydraDx {
+    struct LocalRemoteAssetId {
+        let localAssetId: ChainAssetId
+        let remoteAssetId: HydraDx.OmniPoolAssetId
+    }
+}
+
+enum HydraDxTokenConverter {
+    static let nativeRemoteAssetId = HydraDx.OmniPoolAssetId(0)
+
+    static func convertToRemote(
+        chainAsset: ChainAsset,
+        codingFactory: RuntimeCoderFactoryProtocol
+    ) throws -> HydraDx.LocalRemoteAssetId? {
+        guard
+            let storageInfo = try? AssetStorageInfo.extract(
+                from: chainAsset.asset,
+                codingFactory: codingFactory
+            ) else {
+            return nil
+        }
+
+        switch storageInfo {
+        case .native:
+            return .init(localAssetId: chainAsset.chainAssetId, remoteAssetId: nativeRemoteAssetId)
+        case let .orml(info):
+            let context = codingFactory.createRuntimeJsonContext()
+            let remoteId = try info.currencyId.map(
+                to: StringScaleMapper<HydraDx.OmniPoolAssetId>.self,
+                with: context.toRawContext()
+            ).value
+
+            return .init(localAssetId: chainAsset.chainAssetId, remoteAssetId: remoteId)
+        default:
+            return nil
+        }
+    }
+}

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraDxTokenConverter.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraDxTokenConverter.swift
@@ -2,10 +2,19 @@ import Foundation
 import SubstrateSdk
 
 extension HydraDx {
-    struct LocalRemoteAssetId {
+    struct LocalRemoteAssetId: Equatable {
         let localAssetId: ChainAssetId
         let remoteAssetId: HydraDx.OmniPoolAssetId
     }
+
+    struct SwapPair {
+        let assetIn: LocalRemoteAssetId
+        let assetOut: LocalRemoteAssetId
+    }
+}
+
+enum HydraDxTokenConverterError: Error {
+    case unexpectedAsset(ChainAsset)
 }
 
 enum HydraDxTokenConverter {
@@ -14,14 +23,11 @@ enum HydraDxTokenConverter {
     static func convertToRemote(
         chainAsset: ChainAsset,
         codingFactory: RuntimeCoderFactoryProtocol
-    ) throws -> HydraDx.LocalRemoteAssetId? {
-        guard
-            let storageInfo = try? AssetStorageInfo.extract(
-                from: chainAsset.asset,
-                codingFactory: codingFactory
-            ) else {
-            return nil
-        }
+    ) throws -> HydraDx.LocalRemoteAssetId {
+        let storageInfo = try AssetStorageInfo.extract(
+            from: chainAsset.asset,
+            codingFactory: codingFactory
+        )
 
         switch storageInfo {
         case .native:
@@ -35,7 +41,7 @@ enum HydraDxTokenConverter {
 
             return .init(localAssetId: chainAsset.chainAssetId, remoteAssetId: remoteId)
         default:
-            return nil
+            throw HydraDxTokenConverterError.unexpectedAsset(chainAsset)
         }
     }
 }

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolOperationFactory.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolOperationFactory.swift
@@ -1,13 +1,14 @@
 import Foundation
 import RobinHood
 import SubstrateSdk
+import BigInt
 
 final class HydraOmnipoolOperationFactory {
     let chain: ChainModel
     let runtimeService: RuntimeCodingServiceProtocol
     let connection: JSONRPCEngine
     let operationQueue: OperationQueue
-    
+
     init(
         chain: ChainModel,
         runtimeService: RuntimeCodingServiceProtocol,
@@ -19,20 +20,116 @@ final class HydraOmnipoolOperationFactory {
         self.connection = connection
         self.operationQueue = operationQueue
     }
+
+    private func fetchAllRemoteAssets() -> CompoundOperationWrapper<Set<HydraDx.OmniPoolAssetId>> {
+        let codingFactoryOperation = runtimeService.fetchCoderFactoryOperation()
+
+        let hubAssetIdOperation = PrimitiveConstantOperation<HydraDx.OmniPoolAssetId>.operation(
+            for: HydraDx.hubAssetIdPath,
+            dependingOn: codingFactoryOperation
+        )
+
+        hubAssetIdOperation.addDependency(codingFactoryOperation)
+
+        let keysFactory = StorageKeysOperationFactory(operationQueue: operationQueue)
+        let assetsFetchWrapper: CompoundOperationWrapper<[HydraDx.AssetsKey]> = keysFactory.createKeysFetchWrapper(
+            by: HydraDx.omnipoolAssets,
+            codingFactoryClosure: { try codingFactoryOperation.extractNoCancellableResultData() },
+            connection: connection
+        )
+
+        assetsFetchWrapper.targetOperation.addDependency(codingFactoryOperation)
+
+        let mapOperation = ClosureOperation<Set<HydraDx.OmniPoolAssetId>> {
+            let allAssets = try assetsFetchWrapper.targetOperation.extractNoCancellableResultData()
+            let hubAssetId = try hubAssetIdOperation.extractNoCancellableResultData()
+
+            let filteredAssets = allAssets.compactMap { $0.assetId != hubAssetId ? $0.assetId : nil }
+
+            return Set(filteredAssets)
+        }
+
+        mapOperation.addDependency(hubAssetIdOperation)
+        mapOperation.addDependency(assetsFetchWrapper.targetOperation)
+
+        return assetsFetchWrapper
+            .insertingHead(operations: [codingFactoryOperation, hubAssetIdOperation])
+            .insertingTail(operation: mapOperation)
+    }
+
+    func fetchAllAssets() -> CompoundOperationWrapper<Set<ChainAssetId>> {
+        let remoteWrapper = fetchAllRemoteAssets()
+
+        let codingFactoryOperation = runtimeService.fetchCoderFactoryOperation()
+
+        let allLocalAssets = chain.assets.map { ChainAsset(chain: chain, asset: $0) }
+        let localAssetsOperation = ClosureOperation<Set<ChainAssetId>> {
+            let codingFactory = try codingFactoryOperation.extractNoCancellableResultData()
+            let localRemoteAssets = allLocalAssets.reduce(
+                into: [HydraDx.OmniPoolAssetId: ChainAssetId]()
+            ) { accum, chainAsset in
+                guard let pair = try? HydraDxTokenConverter.convertToRemote(
+                    chainAsset: chainAsset,
+                    codingFactory: codingFactory
+                ) else {
+                    return
+                }
+
+                accum[pair.remoteAssetId] = pair.localAssetId
+            }
+
+            let remoteAssets = try remoteWrapper.targetOperation.extractNoCancellableResultData()
+
+            return Set(remoteAssets.compactMap { localRemoteAssets[$0] })
+        }
+
+        localAssetsOperation.addDependency(codingFactoryOperation)
+        localAssetsOperation.addDependency(remoteWrapper.targetOperation)
+
+        return remoteWrapper
+            .insertingHead(operations: [codingFactoryOperation])
+            .insertingTail(operation: localAssetsOperation)
+    }
 }
 
 extension HydraOmnipoolOperationFactory: AssetConversionOperationFactoryProtocol {
     func availableDirections() -> CompoundOperationWrapper<[ChainAssetId: Set<ChainAssetId>]> {
-        CompoundOperationWrapper.createWithError(CommonError.dataCorruption)
+        let allAssetsWrapper = fetchAllAssets()
+
+        let mappingOperation = ClosureOperation<[ChainAssetId: Set<ChainAssetId>]> {
+            let allAssets = try allAssetsWrapper.targetOperation.extractNoCancellableResultData()
+
+            return allAssets.reduce(into: [ChainAssetId: Set<ChainAssetId>]()) { accum, chainAssetId in
+                accum[chainAssetId] = allAssets.subtracting([chainAssetId])
+            }
+        }
+
+        mappingOperation.addDependency(allAssetsWrapper.targetOperation)
+
+        return allAssetsWrapper.insertingTail(operation: mappingOperation)
     }
-    
+
     func availableDirectionsForAsset(
         _ chainAssetId: ChainAssetId
     ) -> CompoundOperationWrapper<Set<ChainAssetId>> {
-        CompoundOperationWrapper.createWithError(CommonError.dataCorruption)
+        let allAssetsWrapper = fetchAllAssets()
+
+        let mappingOperation = ClosureOperation<Set<ChainAssetId>> {
+            let allAssets = try allAssetsWrapper.targetOperation.extractNoCancellableResultData()
+
+            guard allAssets.contains(chainAssetId) else {
+                return []
+            }
+
+            return allAssets.subtracting([chainAssetId])
+        }
+
+        mappingOperation.addDependency(allAssetsWrapper.targetOperation)
+
+        return allAssetsWrapper.insertingTail(operation: mappingOperation)
     }
-    
-    func quote(for args: AssetConversion.QuoteArgs) -> CompoundOperationWrapper<AssetConversion.Quote> {
+
+    func quote(for _: AssetConversion.QuoteArgs) -> CompoundOperationWrapper<AssetConversion.Quote> {
         CompoundOperationWrapper.createWithError(CommonError.dataCorruption)
     }
 }

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolOperationFactory.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolOperationFactory.swift
@@ -1,0 +1,38 @@
+import Foundation
+import RobinHood
+import SubstrateSdk
+
+final class HydraOmnipoolOperationFactory {
+    let chain: ChainModel
+    let runtimeService: RuntimeCodingServiceProtocol
+    let connection: JSONRPCEngine
+    let operationQueue: OperationQueue
+    
+    init(
+        chain: ChainModel,
+        runtimeService: RuntimeCodingServiceProtocol,
+        connection: JSONRPCEngine,
+        operationQueue: OperationQueue
+    ) {
+        self.chain = chain
+        self.runtimeService = runtimeService
+        self.connection = connection
+        self.operationQueue = operationQueue
+    }
+}
+
+extension HydraOmnipoolOperationFactory: AssetConversionOperationFactoryProtocol {
+    func availableDirections() -> CompoundOperationWrapper<[ChainAssetId: Set<ChainAssetId>]> {
+        CompoundOperationWrapper.createWithError(CommonError.dataCorruption)
+    }
+    
+    func availableDirectionsForAsset(
+        _ chainAssetId: ChainAssetId
+    ) -> CompoundOperationWrapper<Set<ChainAssetId>> {
+        CompoundOperationWrapper.createWithError(CommonError.dataCorruption)
+    }
+    
+    func quote(for args: AssetConversion.QuoteArgs) -> CompoundOperationWrapper<AssetConversion.Quote> {
+        CompoundOperationWrapper.createWithError(CommonError.dataCorruption)
+    }
+}

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolOperationFactory.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolOperationFactory.swift
@@ -38,7 +38,7 @@ final class HydraOmnipoolOperationFactory {
             connection: connection
         )
 
-        assetsFetchWrapper.targetOperation.addDependency(codingFactoryOperation)
+        assetsFetchWrapper.addDependency(operations: [codingFactoryOperation])
 
         let mapOperation = ClosureOperation<Set<HydraDx.OmniPoolAssetId>> {
             let allAssets = try assetsFetchWrapper.targetOperation.extractNoCancellableResultData()

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolOperationFactory.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolOperationFactory.swift
@@ -9,6 +9,9 @@ final class HydraOmnipoolOperationFactory {
     let connection: JSONRPCEngine
     let operationQueue: OperationQueue
 
+    private var quoteStateService: HydraOmnipoolQuoteService?
+    private var mutex = NSLock()
+
     init(
         chain: ChainModel,
         runtimeService: RuntimeCodingServiceProtocol,
@@ -65,15 +68,13 @@ final class HydraOmnipoolOperationFactory {
         let allLocalAssets = chain.assets.map { ChainAsset(chain: chain, asset: $0) }
         let localAssetsOperation = ClosureOperation<Set<ChainAssetId>> {
             let codingFactory = try codingFactoryOperation.extractNoCancellableResultData()
-            let localRemoteAssets = allLocalAssets.reduce(
+            let localRemoteAssets = try allLocalAssets.reduce(
                 into: [HydraDx.OmniPoolAssetId: ChainAssetId]()
             ) { accum, chainAsset in
-                guard let pair = try? HydraDxTokenConverter.convertToRemote(
+                let pair = try HydraDxTokenConverter.convertToRemote(
                     chainAsset: chainAsset,
                     codingFactory: codingFactory
-                ) else {
-                    return
-                }
+                )
 
                 accum[pair.remoteAssetId] = pair.localAssetId
             }
@@ -89,6 +90,219 @@ final class HydraOmnipoolOperationFactory {
         return remoteWrapper
             .insertingHead(operations: [codingFactoryOperation])
             .insertingTail(operation: localAssetsOperation)
+    }
+
+    private func getTokensPairWrapper(
+        for assetIn: ChainAssetId,
+        assetOut: ChainAssetId
+    ) -> CompoundOperationWrapper<HydraDx.SwapPair> {
+        guard let chainAssetIn = chain.asset(for: assetIn.assetId).map({ ChainAsset(chain: chain, asset: $0) }) else {
+            return CompoundOperationWrapper.createWithError(
+                ChainModelFetchError.noAsset(assetId: assetIn.assetId)
+            )
+        }
+
+        guard let chainAssetOut = chain.asset(for: assetOut.assetId).map({ ChainAsset(chain: chain, asset: $0) }) else {
+            return CompoundOperationWrapper.createWithError(
+                ChainModelFetchError.noAsset(assetId: assetOut.assetId)
+            )
+        }
+
+        let coderFactoryOperation = runtimeService.fetchCoderFactoryOperation()
+
+        let parsingOperation = ClosureOperation<HydraDx.SwapPair> {
+            let codingFactory = try coderFactoryOperation.extractNoCancellableResultData()
+
+            let localRemoteIn = try HydraDxTokenConverter.convertToRemote(
+                chainAsset: chainAssetIn,
+                codingFactory: codingFactory
+            )
+
+            let localRemoteOut = try HydraDxTokenConverter.convertToRemote(
+                chainAsset: chainAssetOut,
+                codingFactory: codingFactory
+            )
+
+            return HydraDx.SwapPair(assetIn: localRemoteIn, assetOut: localRemoteOut)
+        }
+
+        parsingOperation.addDependency(coderFactoryOperation)
+
+        return CompoundOperationWrapper(targetOperation: parsingOperation, dependencies: [coderFactoryOperation])
+    }
+
+    private func getQuoteStateService(for swap: HydraDx.SwapPair) -> HydraOmnipoolQuoteService {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        if
+            let currentService = quoteStateService,
+            currentService.assetIn == swap.assetIn,
+            currentService.assetOut == swap.assetOut {
+            return currentService
+        }
+
+        let newService = HydraOmnipoolQuoteService(
+            chain: chain,
+            assetIn: swap.assetIn,
+            assetOut: swap.assetOut,
+            connection: connection,
+            runtimeProvider: runtimeService,
+            operationQueue: operationQueue,
+            workQueue: .global()
+        )
+
+        quoteStateService?.throttle()
+
+        quoteStateService = newService
+        quoteStateService?.setup()
+
+        return newService
+    }
+
+    private func createQuoteStateWrapper(
+        dependingOn swapPairOperation: BaseOperation<HydraDx.SwapPair>
+    ) -> CompoundOperationWrapper<HydraDx.QuoteRemoteState> {
+        OperationCombiningService<HydraDx.QuoteRemoteState>.compoundNonOptionalWrapper(
+            operationManager: OperationManager(operationQueue: operationQueue)
+        ) {
+            let swapPair = try swapPairOperation.extractNoCancellableResultData()
+
+            let quoteService = self.getQuoteStateService(for: swapPair)
+
+            let operation = quoteService.createFetchOperation()
+
+            return CompoundOperationWrapper(targetOperation: operation)
+        }
+    }
+
+    private func createDefaultFeeWrapper() -> CompoundOperationWrapper<HydraDx.FeeEntry> {
+        let coderFactoryOperation = runtimeService.fetchCoderFactoryOperation()
+
+        let assetFeeOperation = StorageConstantOperation<HydraDx.FeeParameters>.operation(
+            path: HydraDx.assetFeeParametersPath,
+            dependingOn: coderFactoryOperation
+        )
+
+        assetFeeOperation.addDependency(coderFactoryOperation)
+
+        let protocolFeeOperation = StorageConstantOperation<HydraDx.FeeParameters>.operation(
+            path: HydraDx.protocolFeeParametersPath,
+            dependingOn: coderFactoryOperation
+        )
+
+        protocolFeeOperation.addDependency(coderFactoryOperation)
+
+        let mergeOperation = ClosureOperation<HydraDx.FeeEntry> {
+            let assetFee = try assetFeeOperation.extractNoCancellableResultData().minFee
+            let protocolFee = try protocolFeeOperation.extractNoCancellableResultData().minFee
+
+            return HydraDx.FeeEntry(assetFee: assetFee, protocolFee: protocolFee)
+        }
+
+        mergeOperation.addDependency(assetFeeOperation)
+        mergeOperation.addDependency(protocolFeeOperation)
+
+        return CompoundOperationWrapper(
+            targetOperation: mergeOperation,
+            dependencies: [coderFactoryOperation, assetFeeOperation, protocolFeeOperation]
+        )
+    }
+
+    private func calculateSellQuote(
+        for args: AssetConversion.QuoteArgs,
+        remoteState: HydraDx.QuoteRemoteState,
+        defaultFee: HydraDx.FeeEntry
+    ) throws -> AssetConversion.Quote {
+        guard let assetInState = remoteState.assetInState else {
+            throw AssetConversionOperationError.remoteAssetNotFound(args.assetIn)
+        }
+
+        guard let assetOutState = remoteState.assetOutState else {
+            throw AssetConversionOperationError.remoteAssetNotFound(args.assetOut)
+        }
+
+        let assetFee = BigRational.permill(
+            of: remoteState.assetOutFee?.assetFee ?? defaultFee.assetFee
+        )
+
+        let protocolFee = BigRational.permill(
+            of: remoteState.assetInFee?.protocolFee ?? defaultFee.protocolFee
+        )
+
+        let inHubReserve = assetInState.hubReserve
+        let inReserve = remoteState.assetInBalance ?? 0
+        let deltaHubReserveIn = (args.amount * inHubReserve) / (inReserve + args.amount)
+
+        let protocolFeeAmount = protocolFee.mul(value: deltaHubReserveIn)
+        let deltaHubReserveOut = deltaHubReserveIn - protocolFeeAmount
+
+        let outReserveHp = remoteState.assetOutBalance ?? 0
+        let outHubReserveHp = assetOutState.hubReserve
+
+        let deltaReserveOut = (deltaHubReserveOut * outReserveHp) / (outHubReserveHp + deltaHubReserveOut)
+
+        guard let amountOut = BigUInt(100).sub(rational: assetFee)?.mul(value: deltaReserveOut) else {
+            throw AssetConversionOperationError.runtimeError("Fee too big")
+        }
+
+        return .init(args: args, amount: amountOut)
+    }
+
+    private func calculateBuyQuote(
+        for args: AssetConversion.QuoteArgs,
+        remoteState: HydraDx.QuoteRemoteState,
+        defaultFee: HydraDx.FeeEntry
+    ) throws -> AssetConversion.Quote {
+        guard let assetInState = remoteState.assetInState else {
+            throw AssetConversionOperationError.remoteAssetNotFound(args.assetIn)
+        }
+
+        guard let assetOutState = remoteState.assetOutState else {
+            throw AssetConversionOperationError.remoteAssetNotFound(args.assetOut)
+        }
+
+        let assetFee = BigRational.permill(
+            of: remoteState.assetOutFee?.assetFee ?? defaultFee.assetFee
+        )
+
+        let protocolFee = BigRational.permill(
+            of: remoteState.assetInFee?.protocolFee ?? defaultFee.protocolFee
+        )
+
+        let outReserve = remoteState.assetOutBalance ?? 0
+        guard let outReserveNoFee = BigUInt(100).sub(rational: assetFee)?.mul(value: outReserve) else {
+            throw AssetConversionOperationError.runtimeError("Asset fee too big")
+        }
+
+        guard outReserveNoFee > args.amount else {
+            throw AssetConversionOperationError.quoteCalcFailed
+        }
+
+        let outHubReserve = assetOutState.hubReserve
+        let deltaHubReserveOut = (outHubReserve * args.amount) / (outReserveNoFee - args.amount) + 1
+
+        guard protocolFee.denominator > protocolFee.numerator else {
+            throw AssetConversionOperationError.runtimeError("Protocol fee too big")
+        }
+
+        // deltaHubReserveOut = (1 - protocolFee) * deltaHubReserveIn
+        let deltaHubReserveIn = (deltaHubReserveOut * protocolFee.denominator) /
+            (protocolFee.denominator - protocolFee.numerator)
+
+        let inReserveHp = remoteState.assetInBalance ?? 0
+        let inHubReserveHp = assetInState.hubReserve
+
+        guard inHubReserveHp > deltaHubReserveIn else {
+            throw AssetConversionOperationError.quoteCalcFailed
+        }
+
+        let amountIn = (inReserveHp * deltaHubReserveIn) / (inHubReserveHp - deltaHubReserveIn) + 1
+
+        return .init(args: args, amount: amountIn)
     }
 }
 
@@ -129,7 +343,40 @@ extension HydraOmnipoolOperationFactory: AssetConversionOperationFactoryProtocol
         return allAssetsWrapper.insertingTail(operation: mappingOperation)
     }
 
-    func quote(for _: AssetConversion.QuoteArgs) -> CompoundOperationWrapper<AssetConversion.Quote> {
-        CompoundOperationWrapper.createWithError(CommonError.dataCorruption)
+    func quote(for args: AssetConversion.QuoteArgs) -> CompoundOperationWrapper<AssetConversion.Quote> {
+        let swapPairWrapper = getTokensPairWrapper(for: args.assetIn, assetOut: args.assetOut)
+        let quoteStateWrapper = createQuoteStateWrapper(dependingOn: swapPairWrapper.targetOperation)
+
+        quoteStateWrapper.addDependency(operations: [swapPairWrapper.targetOperation])
+
+        let defaultFeeWrapper = createDefaultFeeWrapper()
+
+        let calculateOperation = ClosureOperation<AssetConversion.Quote> {
+            let quoteState = try quoteStateWrapper.targetOperation.extractNoCancellableResultData()
+            let defaultFee = try defaultFeeWrapper.targetOperation.extractNoCancellableResultData()
+
+            switch args.direction {
+            case .sell:
+                return try self.calculateSellQuote(
+                    for: args,
+                    remoteState: quoteState,
+                    defaultFee: defaultFee
+                )
+            case .buy:
+                return try self.calculateBuyQuote(
+                    for: args,
+                    remoteState: quoteState,
+                    defaultFee: defaultFee
+                )
+            }
+        }
+
+        calculateOperation.addDependency(defaultFeeWrapper.targetOperation)
+        calculateOperation.addDependency(quoteStateWrapper.targetOperation)
+
+        let dependencies = swapPairWrapper.allOperations + quoteStateWrapper.allOperations +
+            defaultFeeWrapper.allOperations
+
+        return CompoundOperationWrapper(targetOperation: calculateOperation, dependencies: dependencies)
     }
 }

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolOperationFactory.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolOperationFactory.swift
@@ -225,11 +225,11 @@ final class HydraOmnipoolOperationFactory {
             throw AssetConversionOperationError.remoteAssetNotFound(args.assetOut)
         }
 
-        let assetFee = BigRational.permill(
+        let assetFee = BigRational.permillPercent(
             of: remoteState.assetOutFee?.assetFee ?? defaultFee.assetFee
         )
 
-        let protocolFee = BigRational.permill(
+        let protocolFee = BigRational.permillPercent(
             of: remoteState.assetInFee?.protocolFee ?? defaultFee.protocolFee
         )
 
@@ -245,7 +245,7 @@ final class HydraOmnipoolOperationFactory {
 
         let deltaReserveOut = (deltaHubReserveOut * outReserveHp) / (outHubReserveHp + deltaHubReserveOut)
 
-        guard let amountOut = BigUInt(100).sub(rational: assetFee)?.mul(value: deltaReserveOut) else {
+        guard let amountOut = BigUInt(1).sub(rational: assetFee)?.mul(value: deltaReserveOut) else {
             throw AssetConversionOperationError.runtimeError("Fee too big")
         }
 
@@ -265,16 +265,16 @@ final class HydraOmnipoolOperationFactory {
             throw AssetConversionOperationError.remoteAssetNotFound(args.assetOut)
         }
 
-        let assetFee = BigRational.permill(
+        let assetFee = BigRational.permillPercent(
             of: remoteState.assetOutFee?.assetFee ?? defaultFee.assetFee
         )
 
-        let protocolFee = BigRational.permill(
+        let protocolFee = BigRational.permillPercent(
             of: remoteState.assetInFee?.protocolFee ?? defaultFee.protocolFee
         )
 
         let outReserve = remoteState.assetOutBalance ?? 0
-        guard let outReserveNoFee = BigUInt(100).sub(rational: assetFee)?.mul(value: outReserve) else {
+        guard let outReserveNoFee = BigUInt(1).sub(rational: assetFee)?.mul(value: outReserve) else {
             throw AssetConversionOperationError.runtimeError("Asset fee too big")
         }
 

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteRemoteState.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteRemoteState.swift
@@ -3,7 +3,7 @@ import SubstrateSdk
 import BigInt
 
 extension HydraDx {
-    struct QuoteRemoteState: BatchStorageSubscriptionResult {
+    struct QuoteRemoteStateChange: BatchStorageSubscriptionResult {
         enum Key: String {
             case assetInState
             case assetOutState
@@ -14,18 +14,81 @@ extension HydraDx {
             case assetInFee
             case assetOutFee
         }
-    }
-    
-    let assetInState: UncertainStorage<HydraDx.AssetState>
-    let assetOutState: UncertainStorage<HydraDx.AssetState>
-    let assetInBalance: UncertainStorage<BigUInt>
-    let assetOutBalance: UncertainStorage<BigUInt>
-    let assetInFee: UncertainStorage<BigUInt>
-    let assetOutFee: UncertainStorage<BigUInt>
 
-    init(
-        values: [BatchStorageSubscriptionResultValue],
-        blockHashJson: JSON,
-        context: [CodingUserInfoKey: Any]?
-    ) throws {}
+        let assetInState: UncertainStorage<HydraDx.AssetState?>
+        let assetOutState: UncertainStorage<HydraDx.AssetState?>
+        let assetInBalance: UncertainStorage<BigUInt?>
+        let assetOutBalance: UncertainStorage<BigUInt?>
+        let assetInFee: UncertainStorage<BigUInt?>
+        let assetOutFee: UncertainStorage<BigUInt?>
+
+        init(
+            values: [BatchStorageSubscriptionResultValue],
+            blockHashJson _: JSON,
+            context: [CodingUserInfoKey: Any]?
+        ) throws {
+            assetInState = try UncertainStorage(
+                values: values,
+                mappingKey: Key.assetInState.rawValue,
+                context: context
+            )
+
+            assetOutState = try UncertainStorage(
+                values: values,
+                mappingKey: Key.assetOutState.rawValue,
+                context: context
+            )
+
+            assetInBalance = try Self.getBalanceStorage(
+                for: values,
+                nativeKey: Key.assetInNativeBalance,
+                ormlKey: Key.assetInOrmlBalance,
+                context: context
+            )
+
+            assetOutBalance = try Self.getBalanceStorage(
+                for: values,
+                nativeKey: Key.assetOutNativeBalance,
+                ormlKey: Key.assetOutOrmlBalance,
+                context: context
+            )
+
+            assetInFee = try UncertainStorage<StringScaleMapper<BigUInt>?>(
+                values: values,
+                mappingKey: Key.assetInFee.rawValue,
+                context: context
+            ).map { $0?.value }
+
+            assetOutFee = try UncertainStorage<StringScaleMapper<BigUInt>?>(
+                values: values,
+                mappingKey: Key.assetOutFee.rawValue,
+                context: context
+            ).map { $0?.value }
+        }
+
+        static func getBalanceStorage(
+            for values: [BatchStorageSubscriptionResultValue],
+            nativeKey: Key,
+            ormlKey: Key,
+            context: [CodingUserInfoKey: Any]?
+        ) throws -> UncertainStorage<BigUInt?> {
+            let nativeBalance = try UncertainStorage<AccountInfo?>(
+                values: values,
+                mappingKey: nativeKey.rawValue,
+                context: context
+            ).map { $0?.data.free }
+
+            if let balance = nativeBalance.value {
+                return .defined(balance)
+            }
+
+            let ormlBalance = try UncertainStorage<OrmlAccount?>(
+                values: values,
+                mappingKey: ormlKey.rawValue,
+                context: context
+            ).map { $0?.free }
+
+            return ormlBalance
+        }
+    }
 }

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteRemoteState.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteRemoteState.swift
@@ -1,0 +1,31 @@
+import Foundation
+import SubstrateSdk
+import BigInt
+
+extension HydraDx {
+    struct QuoteRemoteState: BatchStorageSubscriptionResult {
+        enum Key: String {
+            case assetInState
+            case assetOutState
+            case assetInNativeBalance
+            case assetInOrmlBalance
+            case assetOutNativeBalance
+            case assetOutOrmlBalance
+            case assetInFee
+            case assetOutFee
+        }
+    }
+    
+    let assetInState: UncertainStorage<HydraDx.AssetState>
+    let assetOutState: UncertainStorage<HydraDx.AssetState>
+    let assetInBalance: UncertainStorage<BigUInt>
+    let assetOutBalance: UncertainStorage<BigUInt>
+    let assetInFee: UncertainStorage<BigUInt>
+    let assetOutFee: UncertainStorage<BigUInt>
+
+    init(
+        values: [BatchStorageSubscriptionResultValue],
+        blockHashJson: JSON,
+        context: [CodingUserInfoKey: Any]?
+    ) throws {}
+}

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteRemoteState.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteRemoteState.swift
@@ -8,8 +8,8 @@ extension HydraDx {
         let assetOutState: HydraDx.AssetState?
         let assetInBalance: BigUInt?
         let assetOutBalance: BigUInt?
-        let assetInFee: BigUInt?
-        let assetOutFee: BigUInt?
+        let assetInFee: FeeEntry?
+        let assetOutFee: FeeEntry?
         let blockHash: Data?
 
         func merging(newStateChange: QuoteRemoteStateChange) -> QuoteRemoteState {
@@ -41,8 +41,8 @@ extension HydraDx {
         let assetOutState: UncertainStorage<HydraDx.AssetState?>
         let assetInBalance: UncertainStorage<BigUInt?>
         let assetOutBalance: UncertainStorage<BigUInt?>
-        let assetInFee: UncertainStorage<BigUInt?>
-        let assetOutFee: UncertainStorage<BigUInt?>
+        let assetInFee: UncertainStorage<FeeEntry?>
+        let assetOutFee: UncertainStorage<FeeEntry?>
         let blockHash: Data?
 
         init(
@@ -50,8 +50,8 @@ extension HydraDx {
             assetOutState: UncertainStorage<HydraDx.AssetState?>,
             assetInBalance: UncertainStorage<BigUInt?>,
             assetOutBalance: UncertainStorage<BigUInt?>,
-            assetInFee: UncertainStorage<BigUInt?>,
-            assetOutFee: UncertainStorage<BigUInt?>,
+            assetInFee: UncertainStorage<FeeEntry?>,
+            assetOutFee: UncertainStorage<FeeEntry?>,
             blockHash: Data?
         ) {
             self.assetInState = assetInState
@@ -94,17 +94,17 @@ extension HydraDx {
                 context: context
             )
 
-            assetInFee = try UncertainStorage<StringScaleMapper<BigUInt>?>(
+            assetInFee = try UncertainStorage<FeeEntry?>(
                 values: values,
                 mappingKey: Key.assetInFee.rawValue,
                 context: context
-            ).map { $0?.value }
+            )
 
-            assetOutFee = try UncertainStorage<StringScaleMapper<BigUInt>?>(
+            assetOutFee = try UncertainStorage<FeeEntry?>(
                 values: values,
                 mappingKey: Key.assetOutFee.rawValue,
                 context: context
-            ).map { $0?.value }
+            )
 
             blockHash = try blockHashJson.map(to: Data?.self, with: context)
         }

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteService.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteService.swift
@@ -197,7 +197,7 @@ final class HydraOmnipoolQuoteService: ObservableSyncService {
 
         let assetOutFeeRequest = getFeeRequest(
             for: assetOut,
-            mappingKey: HydraDx.QuoteRemoteStateChange.Key.assetInFee
+            mappingKey: HydraDx.QuoteRemoteStateChange.Key.assetOutFee
         )
 
         subscription = CallbackBatchStorageSubscription(

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteService.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteService.swift
@@ -12,7 +12,7 @@ enum HydraOmnipoolQuoteServiceError: Error {
 
 final class HydraOmnipoolQuoteService: ObservableSyncService {
     let chain: ChainModel
-    let runtimeProvider: RuntimeProviderProtocol
+    let runtimeProvider: RuntimeCodingServiceProtocol
     let connection: JSONRPCEngine
     let assetIn: HydraDx.LocalRemoteAssetId
     let assetOut: HydraDx.LocalRemoteAssetId
@@ -27,7 +27,7 @@ final class HydraOmnipoolQuoteService: ObservableSyncService {
         assetIn: HydraDx.LocalRemoteAssetId,
         assetOut: HydraDx.LocalRemoteAssetId,
         connection: JSONRPCEngine,
-        runtimeProvider: RuntimeProviderProtocol,
+        runtimeProvider: RuntimeCodingServiceProtocol,
         operationQueue: OperationQueue,
         workQueue: DispatchQueue,
         retryStrategy: ReconnectionStrategyProtocol = ExponentialReconnection(),

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteService.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteService.swift
@@ -1,0 +1,160 @@
+import Foundation
+import SubstrateSdk
+
+final class HydraOmnipoolQuoteService {
+    let chain: ChainModel
+    let runtimeProvider: RuntimeProviderProtocol
+    let connection: JSONRPCEngine
+    let assetIn: HydraDx.LocalRemoteAssetId
+    let assetOut: HydraDx.LocalRemoteAssetId
+    let operationQueue: OperationQueue
+    let workQueue: DispatchQueue
+
+    private var subscription: CallbackBatchStorageSubscription<HydraDx.QuoteRemoteState>?
+
+    init(
+        chain: ChainModel,
+        assetIn: HydraDx.LocalRemoteAssetId,
+        assetOut: HydraDx.LocalRemoteAssetId,
+        connection: JSONRPCEngine,
+        runtimeProvider: RuntimeProviderProtocol,
+        operationQueue: OperationQueue,
+        workQueue: DispatchQueue
+    ) {
+        self.chain = chain
+        self.assetIn = assetIn
+        self.assetOut = assetOut
+        self.connection = connection
+        self.runtimeProvider = runtimeProvider
+        self.operationQueue = operationQueue
+        self.workQueue = workQueue
+    }
+
+    deinit {
+        subscription?.unsubscribe()
+    }
+
+    private func getBalanceRequest(
+        for accountId: AccountId,
+        assetId: HydraDx.LocalRemoteAssetId,
+        mappingKeyClosure: (Bool) -> HydraDx.QuoteRemoteState.Key
+    ) -> BatchStorageSubscriptionRequest {
+        if assetId.localAssetId == chain.utilityChainAssetId() {
+            return .init(
+                innerRequest: MapSubscriptionRequest(
+                    storagePath: StorageCodingPath.account,
+                    localKey: "",
+                    keyParamClosure: {
+                        BytesCodable(wrappedValue: accountId)
+                    }
+                ),
+                mappingKey: mappingKeyClosure(true).rawValue
+            )
+        } else {
+            return .init(
+                innerRequest: DoubleMapSubscriptionRequest(
+                    storagePath: StorageCodingPath.ormlTokenAccount,
+                    localKey: "",
+                    keyParamClosure: {
+                        (BytesCodable(wrappedValue: accountId), StringScaleMapper(value: assetId.remoteAssetId))
+                    },
+                    param1Encoder: nil,
+                    param2Encoder: nil
+                ),
+                mappingKey: mappingKeyClosure(false).rawValue
+            )
+        }
+    }
+
+    private func getFeeRequest(
+        for assetId: HydraDx.LocalRemoteAssetId,
+        mappingKey: HydraDx.QuoteRemoteState.Key
+    ) -> BatchStorageSubscriptionRequest {
+        .init(
+            innerRequest: MapSubscriptionRequest(
+                storagePath: HydraDx.dynamicFees,
+                localKey: "",
+                keyParamClosure: {
+                    StringScaleMapper(value: assetId.remoteAssetId)
+                }
+            ),
+            mappingKey: mappingKey.rawValue
+        )
+    }
+
+    private func getAssetStateRequest(
+        for assetId: HydraDx.LocalRemoteAssetId,
+        mappingKey: HydraDx.QuoteRemoteState.Key
+    ) -> BatchStorageSubscriptionRequest {
+        .init(
+            innerRequest: MapSubscriptionRequest(
+                storagePath: HydraDx.omnipoolAssets,
+                localKey: "",
+                keyParamClosure: { StringScaleMapper(value: assetId.remoteAssetId) }
+            ),
+            mappingKey: mappingKey.rawValue
+        )
+    }
+}
+
+extension HydraOmnipoolQuoteService {
+    func setup() throws {
+        let assetInStateRequest = getAssetStateRequest(
+            for: assetIn,
+            mappingKey: HydraDx.QuoteRemoteState.Key.assetInState
+        )
+
+        let assetOutStateRequest = getAssetStateRequest(
+            for: assetOut,
+            mappingKey: HydraDx.QuoteRemoteState.Key.assetOutState
+        )
+
+        let poolAccountId = try HydraDx.getPoolAccountId(for: chain.accountIdSize)
+
+        let assetInBalanceRequest = getBalanceRequest(
+            for: poolAccountId,
+            assetId: assetIn,
+            mappingKeyClosure: {
+                $0 ? HydraDx.QuoteRemoteState.Key.assetInNativeBalance :
+                    HydraDx.QuoteRemoteState.Key.assetInOrmlBalance
+            }
+        )
+        let assetOutBalanceRequest = getBalanceRequest(
+            for: poolAccountId,
+            assetId: assetOut,
+            mappingKeyClosure: {
+                $0 ? HydraDx.QuoteRemoteState.Key.assetOutNativeBalance :
+                    HydraDx.QuoteRemoteState.Key.assetOutOrmlBalance
+            }
+        )
+
+        let assetInFeeRequest = getFeeRequest(
+            for: assetIn,
+            mappingKey: HydraDx.QuoteRemoteState.Key.assetInFee
+        )
+
+        let assetOutFeeRequest = getFeeRequest(
+            for: assetOut,
+            mappingKey: HydraDx.QuoteRemoteState.Key.assetInFee
+        )
+
+        subscription = CallbackBatchStorageSubscription(
+            requests: [
+                assetInStateRequest,
+                assetOutStateRequest,
+                assetInBalanceRequest,
+                assetOutBalanceRequest,
+                assetInFeeRequest,
+                assetOutFeeRequest
+            ],
+            connection: connection,
+            runtimeService: runtimeProvider,
+            repository: nil,
+            operationQueue: operationQueue,
+            callbackQueue: workQueue
+        ) { [weak self] _ in
+        }
+
+        subscription?.subscribe()
+    }
+}

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteService.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraOmnipoolQuoteService.swift
@@ -10,7 +10,7 @@ final class HydraOmnipoolQuoteService {
     let operationQueue: OperationQueue
     let workQueue: DispatchQueue
 
-    private var subscription: CallbackBatchStorageSubscription<HydraDx.QuoteRemoteState>?
+    private var subscription: CallbackBatchStorageSubscription<HydraDx.QuoteRemoteStateChange>?
 
     init(
         chain: ChainModel,
@@ -37,7 +37,7 @@ final class HydraOmnipoolQuoteService {
     private func getBalanceRequest(
         for accountId: AccountId,
         assetId: HydraDx.LocalRemoteAssetId,
-        mappingKeyClosure: (Bool) -> HydraDx.QuoteRemoteState.Key
+        mappingKeyClosure: (Bool) -> HydraDx.QuoteRemoteStateChange.Key
     ) -> BatchStorageSubscriptionRequest {
         if assetId.localAssetId == chain.utilityChainAssetId() {
             return .init(
@@ -68,7 +68,7 @@ final class HydraOmnipoolQuoteService {
 
     private func getFeeRequest(
         for assetId: HydraDx.LocalRemoteAssetId,
-        mappingKey: HydraDx.QuoteRemoteState.Key
+        mappingKey: HydraDx.QuoteRemoteStateChange.Key
     ) -> BatchStorageSubscriptionRequest {
         .init(
             innerRequest: MapSubscriptionRequest(
@@ -84,7 +84,7 @@ final class HydraOmnipoolQuoteService {
 
     private func getAssetStateRequest(
         for assetId: HydraDx.LocalRemoteAssetId,
-        mappingKey: HydraDx.QuoteRemoteState.Key
+        mappingKey: HydraDx.QuoteRemoteStateChange.Key
     ) -> BatchStorageSubscriptionRequest {
         .init(
             innerRequest: MapSubscriptionRequest(
@@ -101,12 +101,12 @@ extension HydraOmnipoolQuoteService {
     func setup() throws {
         let assetInStateRequest = getAssetStateRequest(
             for: assetIn,
-            mappingKey: HydraDx.QuoteRemoteState.Key.assetInState
+            mappingKey: HydraDx.QuoteRemoteStateChange.Key.assetInState
         )
 
         let assetOutStateRequest = getAssetStateRequest(
             for: assetOut,
-            mappingKey: HydraDx.QuoteRemoteState.Key.assetOutState
+            mappingKey: HydraDx.QuoteRemoteStateChange.Key.assetOutState
         )
 
         let poolAccountId = try HydraDx.getPoolAccountId(for: chain.accountIdSize)
@@ -115,27 +115,27 @@ extension HydraOmnipoolQuoteService {
             for: poolAccountId,
             assetId: assetIn,
             mappingKeyClosure: {
-                $0 ? HydraDx.QuoteRemoteState.Key.assetInNativeBalance :
-                    HydraDx.QuoteRemoteState.Key.assetInOrmlBalance
+                $0 ? HydraDx.QuoteRemoteStateChange.Key.assetInNativeBalance :
+                    HydraDx.QuoteRemoteStateChange.Key.assetInOrmlBalance
             }
         )
         let assetOutBalanceRequest = getBalanceRequest(
             for: poolAccountId,
             assetId: assetOut,
             mappingKeyClosure: {
-                $0 ? HydraDx.QuoteRemoteState.Key.assetOutNativeBalance :
-                    HydraDx.QuoteRemoteState.Key.assetOutOrmlBalance
+                $0 ? HydraDx.QuoteRemoteStateChange.Key.assetOutNativeBalance :
+                    HydraDx.QuoteRemoteStateChange.Key.assetOutOrmlBalance
             }
         )
 
         let assetInFeeRequest = getFeeRequest(
             for: assetIn,
-            mappingKey: HydraDx.QuoteRemoteState.Key.assetInFee
+            mappingKey: HydraDx.QuoteRemoteStateChange.Key.assetInFee
         )
 
         let assetOutFeeRequest = getFeeRequest(
             for: assetOut,
-            mappingKey: HydraDx.QuoteRemoteState.Key.assetInFee
+            mappingKey: HydraDx.QuoteRemoteStateChange.Key.assetInFee
         )
 
         subscription = CallbackBatchStorageSubscription(

--- a/novawalletIntegrationTests/HydraDxSwapTests.swift
+++ b/novawalletIntegrationTests/HydraDxSwapTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import novawallet
+import BigInt
+import RobinHood
+
+final class HydraDxSwapTests: XCTestCase {
+    func testAllAvailableDirections() {
+        do {
+            let directions = try performAvailableDirectionsFetch(
+                for: KnowChainId.hydra,
+                assetId: nil
+            )
+            
+            Logger.shared.info("Directions: \(directions)")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func testHydraAssetDirections() {
+        do {
+            let directions = try performAvailableDirectionsFetch(
+                for: KnowChainId.hydra,
+                assetId: 0
+            )
+            
+            Logger.shared.info("Directions: \(directions)")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    private func performAvailableDirectionsFetch(
+        for chainId: ChainModel.Id,
+        assetId: AssetModel.Id?
+    ) throws -> [ChainAssetId: Set<ChainAssetId>] {
+        let storageFacade = SubstrateStorageTestFacade()
+        let chainRegistry = ChainRegistryFacade.setupForIntegrationTest(with: storageFacade)
+        
+        guard
+            let chain = chainRegistry.getChain(for: chainId),
+            let connection = chainRegistry.getConnection(for: chainId),
+            let runtimeService = chainRegistry.getRuntimeProvider(for: chainId) else {
+            throw ChainRegistryError.noChain(chainId)
+        }
+        
+        let operationQueue = OperationQueue()
+        
+        let operationFactory = HydraOmnipoolOperationFactory(
+            chain: chain,
+            runtimeService: runtimeService,
+            connection: connection,
+            operationQueue: operationQueue
+        )
+        
+        if let assetId = assetId {
+            let chainAssetId = ChainAssetId(chainId: chainId, assetId: assetId)
+            let wrapper = operationFactory.availableDirectionsForAsset(chainAssetId)
+            
+            operationQueue.addOperations(wrapper.allOperations, waitUntilFinished: true)
+            
+            let directions = try wrapper.targetOperation.extractNoCancellableResultData()
+            
+            return [chainAssetId: directions]
+        } else {
+            let wrapper = operationFactory.availableDirections()
+            
+            operationQueue.addOperations(wrapper.allOperations, waitUntilFinished: true)
+            
+            return try wrapper.targetOperation.extractNoCancellableResultData()
+        }
+    }
+}


### PR DESCRIPTION
Implementation details:

- omnipool pallet is used for swaps, it assumes that any token can be traded with other via special hub token. We don't want a user to swap the hub token - it must be manually filtered out.
- we are using subscription for onchain parameters to calculate the quote. For this purpose ```HydraOmnipoolQuoteService``` is introduced and cached in the operation factory. Later interactor can track the state of the service and initiate quote recalculation without need to update it every block as we do for AssetHub swaps.
- quote is manually calculated because Hydra doesn't have rpc as we use for the Asset Hub. That's why we need to manually do the math in the ```calculateSellQuote``` and ```calculateBuyQuote``` functions.