### PR TITLE
Fix hydra swaps

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		0C38B5032B7A86CE00882A8B /* TokensPallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38B5022B7A86CE00882A8B /* TokensPallet.swift */; };
 		0C38B5052B7B22F000882A8B /* ExtrinsicExtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38B5042B7B22F000882A8B /* ExtrinsicExtraction.swift */; };
 		0C38B5072B7B3B4B00882A8B /* HydraOmnipool+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38B5062B7B3B4B00882A8B /* HydraOmnipool+Events.swift */; };
+		0C38B5092B7CB96800882A8B /* MaxCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38B5082B7CB96800882A8B /* MaxCounter.swift */; };
 		0C3C49D32AAF3D9900F0F274 /* NSPredicate+StakingDashboardItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3C49D22AAF3D9900F0F274 /* NSPredicate+StakingDashboardItem.swift */; };
 		0C40520C2A53DC4100B3E6EC /* OverlayBlurBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C40520B2A53DC4100B3E6EC /* OverlayBlurBackgroundView.swift */; };
 		0C463FC82A58126A003E71C9 /* UIView+MotionEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C463FC72A58126A003E71C9 /* UIView+MotionEffect.swift */; };
@@ -4508,6 +4509,7 @@
 		0C38B5022B7A86CE00882A8B /* TokensPallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokensPallet.swift; sourceTree = "<group>"; };
 		0C38B5042B7B22F000882A8B /* ExtrinsicExtraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrinsicExtraction.swift; sourceTree = "<group>"; };
 		0C38B5062B7B3B4B00882A8B /* HydraOmnipool+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HydraOmnipool+Events.swift"; sourceTree = "<group>"; };
+		0C38B5082B7CB96800882A8B /* MaxCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaxCounter.swift; sourceTree = "<group>"; };
 		0C3C49D22AAF3D9900F0F274 /* NSPredicate+StakingDashboardItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPredicate+StakingDashboardItem.swift"; sourceTree = "<group>"; };
 		0C40520B2A53DC4100B3E6EC /* OverlayBlurBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayBlurBackgroundView.swift; sourceTree = "<group>"; };
 		0C432D57ACFA53F42E574CBD /* TokensManageViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokensManageViewController.swift; sourceTree = "<group>"; };
@@ -14709,6 +14711,7 @@
 				0CEB4ED02AF14B8B0048FD84 /* SubmoduleNavigationStrategy.swift */,
 				0CEB4ED42AF20EB90048FD84 /* CancellableCallHelper.swift */,
 				0CA719782B768ABC000B086E /* JsonStringify.swift */,
+				0C38B5082B7CB96800882A8B /* MaxCounter.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -23009,6 +23012,7 @@
 				AE89720825F12143008EC414 /* ValidatorInfoViewModel.swift in Sources */,
 				8499FE7327BE305100712589 /* JSONListConvertible.swift in Sources */,
 				845B821726EF7FED00D25C72 /* SelectedWalletSettings.swift in Sources */,
+				0C38B5092B7CB96800882A8B /* MaxCounter.swift in Sources */,
 				84DC3CE12795DEBF0038E2ED /* SubqueryHistoryOperationFactory.swift in Sources */,
 				848FFE9A25E6E0E400652AA5 /* Staking+Validator.swift in Sources */,
 				8498430926592E5D006BBB9F /* CrowdloansViewModel.swift in Sources */,

--- a/novawallet/Common/Helpers/MaxCounter.swift
+++ b/novawallet/Common/Helpers/MaxCounter.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct MaxCounter {
+    let maxCount: Int
+
+    private var counter: Int = 0
+
+    init(maxCount: Int) {
+        self.maxCount = maxCount
+    }
+
+    mutating func incrementCounterIfPossible() -> Bool {
+        if counter < maxCount {
+            counter += 1
+
+            return true
+        } else {
+            return false
+        }
+    }
+
+    mutating func resetCounter() {
+        counter = 0
+    }
+}
+
+extension MaxCounter {
+    static func feeCorrection() -> MaxCounter {
+        MaxCounter(maxCount: 2)
+    }
+}

--- a/novawallet/Common/Helpers/MaxCounter.swift
+++ b/novawallet/Common/Helpers/MaxCounter.swift
@@ -26,6 +26,6 @@ struct MaxCounter {
 
 extension MaxCounter {
     static func feeCorrection() -> MaxCounter {
-        MaxCounter(maxCount: 2)
+        MaxCounter(maxCount: 3)
     }
 }

--- a/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+AssetHubSwapMatching.swift
+++ b/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+AssetHubSwapMatching.swift
@@ -142,6 +142,10 @@ extension ExtrinsicProcessor {
             return nil
         }
 
+        guard mappingResult.callSender == accountId else {
+            return nil
+        }
+
         let customFee = try findFeeInCustomAsset(
             in: eventRecords,
             codingFactory: codingFactory

--- a/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+HydraSwapMatching.swift
+++ b/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+HydraSwapMatching.swift
@@ -229,6 +229,10 @@ extension ExtrinsicProcessor {
             return nil
         }
 
+        guard mappingResult.callSender == accountId else {
+            return nil
+        }
+
         guard
             let isSuccess = matchStatus(
                 for: extrinsicIndex,

--- a/novawallet/Modules/Swaps/Setup/SwapSetupPresenter.swift
+++ b/novawallet/Modules/Swaps/Setup/SwapSetupPresenter.swift
@@ -32,6 +32,12 @@ final class SwapSetupPresenter: SwapBasePresenter {
         !quoteResult.hasError() && quoteArgs != nil
     }
 
+    /*
+     *  We might have cases when quote recalcution triggers fee recalculation and vice versa
+     *  and we want to bound such triggers to avoid deadlock.
+     */
+    private var maxCorrectionCounter = MaxCounter.feeCorrection()
+
     init(
         initState: SwapSetupInitState,
         interactor: SwapSetupInteractorInputProtocol,
@@ -202,8 +208,15 @@ final class SwapSetupPresenter: SwapBasePresenter {
             providePayAmountInputViewModel()
             providePayInputPriceViewModel()
 
-            // as fee changes the max amount we might also refresh the quote
-            refreshQuote(direction: quoteArgs?.direction ?? .sell, forceUpdate: false)
+            /*
+             * As fee changes the max amount we might also refresh the quote but make sure
+             * no deadlock.
+             */
+            if maxCorrectionCounter.incrementCounterIfPossible() {
+                refreshQuote(direction: quoteArgs?.direction ?? .sell, forceUpdate: false)
+            } else {
+                maxCorrectionCounter.resetCounter()
+            }
         }
 
         provideButtonState()
@@ -772,6 +785,8 @@ extension SwapSetupPresenter: SwapSetupPresenterProtocol {
     }
 
     func selectMaxPayAmount() {
+        maxCorrectionCounter.resetCounter()
+
         applySwapMax()
     }
 


### PR DESCRIPTION
- Currently HydraDX runtime has an issue that if fee is paid in custom asset then we need to leave at least ED in that custom asset otherwise extrinsic fails;

- Also introduced a counter to prevent quote -> fee -> quote ... -> fee ... deadlock when rate changes fast on the exchange;