### PR TITLE
Kodadot Asset Hub NFT support

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -299,6 +299,7 @@
 		0C90C6C02B4DAB440084B5C2 /* NestedExtrinsicCallMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C90C6BF2B4DAB440084B5C2 /* NestedExtrinsicCallMapper.swift */; };
 		0C90C6C22B4FA9FB0084B5C2 /* WalletsUpdateMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C90C6C12B4FA9FB0084B5C2 /* WalletsUpdateMediator.swift */; };
 		0C90C6C42B503D990084B5C2 /* WalletUpdateMediatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C90C6C32B503D990084B5C2 /* WalletUpdateMediatorTests.swift */; };
+		0C93FB2A2B85E26A009EE2DD /* NFTClearService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C93FB292B85E26A009EE2DD /* NFTClearService.swift */; };
 		0C9525E32A7AAB2A00BD724D /* StakingTimeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9525E22A7AAB2A00BD724D /* StakingTimeModel.swift */; };
 		0C9525E52A7AF82B00BD724D /* DirectStakingMinStakeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9525E42A7AF82B00BD724D /* DirectStakingMinStakeBuilder.swift */; };
 		0C9525E72A7AFA2C00BD724D /* ValueResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9525E62A7AFA2C00BD724D /* ValueResolver.swift */; };
@@ -4647,6 +4648,7 @@
 		0C90C6BF2B4DAB440084B5C2 /* NestedExtrinsicCallMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedExtrinsicCallMapper.swift; sourceTree = "<group>"; };
 		0C90C6C12B4FA9FB0084B5C2 /* WalletsUpdateMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletsUpdateMediator.swift; sourceTree = "<group>"; };
 		0C90C6C32B503D990084B5C2 /* WalletUpdateMediatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletUpdateMediatorTests.swift; sourceTree = "<group>"; };
+		0C93FB292B85E26A009EE2DD /* NFTClearService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFTClearService.swift; sourceTree = "<group>"; };
 		0C9525E22A7AAB2A00BD724D /* StakingTimeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingTimeModel.swift; sourceTree = "<group>"; };
 		0C9525E42A7AF82B00BD724D /* DirectStakingMinStakeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectStakingMinStakeBuilder.swift; sourceTree = "<group>"; };
 		0C9525E62A7AFA2C00BD724D /* ValueResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueResolver.swift; sourceTree = "<group>"; };
@@ -15389,6 +15391,7 @@
 				8499FEDD27C0AB0200712589 /* NftSource.swift */,
 				8499FEE127C0AF4700712589 /* ChainModel+Nft.swift */,
 				843E9B3527C8B915009C143A /* NftFileDownloadService.swift */,
+				0C93FB292B85E26A009EE2DD /* NFTClearService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -22428,6 +22431,7 @@
 				8459A9CC2746A1E9000D6278 /* CrowdloanOffchainSubscriptionHandler.swift in Sources */,
 				84D331AF2519E8080078D044 /* TriangularedView+Style.swift in Sources */,
 				0C13D2F52A7D2B440054BB6F /* DirectStakingRecommendationMediator.swift in Sources */,
+				0C93FB2A2B85E26A009EE2DD /* NFTClearService.swift in Sources */,
 				84C74365251E4D60009576C6 /* SigningWrapperProtocol.swift in Sources */,
 				88AF35DE28C21D28003730DA /* LocksSubscription.swift in Sources */,
 				8434B5FE298D2CC900FACF4C /* GovernanceBaseEditDelegationProtocols.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -174,6 +174,11 @@
 		0C38B5052B7B22F000882A8B /* ExtrinsicExtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38B5042B7B22F000882A8B /* ExtrinsicExtraction.swift */; };
 		0C38B5072B7B3B4B00882A8B /* HydraOmnipool+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38B5062B7B3B4B00882A8B /* HydraOmnipool+Events.swift */; };
 		0C38B5092B7CB96800882A8B /* MaxCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38B5082B7CB96800882A8B /* MaxCounter.swift */; };
+		0C38B50C2B7DC40600882A8B /* KodaDotNft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38B50B2B7DC40600882A8B /* KodaDotNft.swift */; };
+		0C38B50E2B7DC42500882A8B /* KodaDotNftOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38B50D2B7DC42500882A8B /* KodaDotNftOperationFactory.swift */; };
+		0C38B5102B7DCADF00882A8B /* KodaDotNftSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38B50F2B7DCADF00882A8B /* KodaDotNftSyncService.swift */; };
+		0C38B5122B7DCB4400882A8B /* KodaDotNftModelConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38B5112B7DCB4400882A8B /* KodaDotNftModelConverter.swift */; };
+		0C38B5142B7DCFBB00882A8B /* KodaDotDetailsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38B5132B7DCFBB00882A8B /* KodaDotDetailsInteractor.swift */; };
 		0C3C49D32AAF3D9900F0F274 /* NSPredicate+StakingDashboardItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3C49D22AAF3D9900F0F274 /* NSPredicate+StakingDashboardItem.swift */; };
 		0C40520C2A53DC4100B3E6EC /* OverlayBlurBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C40520B2A53DC4100B3E6EC /* OverlayBlurBackgroundView.swift */; };
 		0C463FC82A58126A003E71C9 /* UIView+MotionEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C463FC72A58126A003E71C9 /* UIView+MotionEffect.swift */; };
@@ -4510,6 +4515,11 @@
 		0C38B5042B7B22F000882A8B /* ExtrinsicExtraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrinsicExtraction.swift; sourceTree = "<group>"; };
 		0C38B5062B7B3B4B00882A8B /* HydraOmnipool+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HydraOmnipool+Events.swift"; sourceTree = "<group>"; };
 		0C38B5082B7CB96800882A8B /* MaxCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaxCounter.swift; sourceTree = "<group>"; };
+		0C38B50B2B7DC40600882A8B /* KodaDotNft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KodaDotNft.swift; sourceTree = "<group>"; };
+		0C38B50D2B7DC42500882A8B /* KodaDotNftOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KodaDotNftOperationFactory.swift; sourceTree = "<group>"; };
+		0C38B50F2B7DCADF00882A8B /* KodaDotNftSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KodaDotNftSyncService.swift; sourceTree = "<group>"; };
+		0C38B5112B7DCB4400882A8B /* KodaDotNftModelConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KodaDotNftModelConverter.swift; sourceTree = "<group>"; };
+		0C38B5132B7DCFBB00882A8B /* KodaDotDetailsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KodaDotDetailsInteractor.swift; sourceTree = "<group>"; };
 		0C3C49D22AAF3D9900F0F274 /* NSPredicate+StakingDashboardItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPredicate+StakingDashboardItem.swift"; sourceTree = "<group>"; };
 		0C40520B2A53DC4100B3E6EC /* OverlayBlurBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayBlurBackgroundView.swift; sourceTree = "<group>"; };
 		0C432D57ACFA53F42E574CBD /* TokensManageViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokensManageViewController.swift; sourceTree = "<group>"; };
@@ -9169,6 +9179,17 @@
 				0C38B5022B7A86CE00882A8B /* TokensPallet.swift */,
 			);
 			path = TokensPallet;
+			sourceTree = "<group>";
+		};
+		0C38B50A2B7DC3F500882A8B /* KodaDot */ = {
+			isa = PBXGroup;
+			children = (
+				0C38B50B2B7DC40600882A8B /* KodaDotNft.swift */,
+				0C38B50D2B7DC42500882A8B /* KodaDotNftOperationFactory.swift */,
+				0C38B50F2B7DCADF00882A8B /* KodaDotNftSyncService.swift */,
+				0C38B5112B7DCB4400882A8B /* KodaDotNftModelConverter.swift */,
+			);
+			path = KodaDot;
 			sourceTree = "<group>";
 		};
 		0C3C49D12AAF3D5900F0F274 /* Predicate */ = {
@@ -15350,6 +15371,7 @@
 		8499FED027BFA30800712589 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				0C38B50A2B7DC3F500882A8B /* KodaDot */,
 				0C8AF7B02B36A86900005AC9 /* Pdc20 */,
 				84E8AC7327BB972500402635 /* RMRK */,
 				8499FE7727BE547C00712589 /* Uniques */,
@@ -19613,6 +19635,7 @@
 				84AE7AB627D3AC4B00495267 /* RMRKV1DetailsInteractor.swift */,
 				84AE7ABA27D411CE00495267 /* RMRKV2DetailsInteractor.swift */,
 				0C8AF7BE2B3A9E0600005AC9 /* Pdc20DetailsInteractor.swift */,
+				0C38B5132B7DCFBB00882A8B /* KodaDotDetailsInteractor.swift */,
 			);
 			path = NftDetails;
 			sourceTree = "<group>";
@@ -21131,6 +21154,7 @@
 				84E9A05028F000AB00551DC4 /* ReferendumMetadataLocal.swift in Sources */,
 				84821E84275F93C700ADC8D2 /* TitleMultiValueView+Style.swift in Sources */,
 				84DA03D12758AA6800E8B326 /* BaseAccountImportWireframe.swift in Sources */,
+				0C38B50E2B7DC42500882A8B /* KodaDotNftOperationFactory.swift in Sources */,
 				84E8BA1F29FFB38600FD9F40 /* EthereumOperationFactory.swift in Sources */,
 				F4C201822728678400B0F3D0 /* ExtrinsicStatus.swift in Sources */,
 				842BDB1E278C1CB100AB4B5A /* DAppBrowserStateMachine.swift in Sources */,
@@ -22351,6 +22375,7 @@
 				848F5FE1298911B80058CD74 /* SubqueryDelegationsOperationFactory.swift in Sources */,
 				84BB3CF8267D276D00676FFE /* CrowdloanTableViewCell.swift in Sources */,
 				0C962F8A2AA8614500C0B551 /* TransactionHistoryLocalFilterFactory.swift in Sources */,
+				0C38B5142B7DCFBB00882A8B /* KodaDotDetailsInteractor.swift in Sources */,
 				844AE53C2861B3BC0020ECBC /* XcmTransferService.swift in Sources */,
 				2A9F8D52274E4EC4003720E0 /* AccountCreateViewController.swift in Sources */,
 				84113B91255B2CA0009BD21A /* MainTransitionHelper.swift in Sources */,
@@ -22911,6 +22936,7 @@
 				84EBAB06265DC24C0015E446 /* CrowdloanContributionViewModelFactory.swift in Sources */,
 				84CA68DF26BEAA0F003B9453 /* ChainModelMapper.swift in Sources */,
 				846A682C274693F700D1A47A /* CrowdloanExternalContributionSource.swift in Sources */,
+				0C38B50C2B7DC40600882A8B /* KodaDotNft.swift in Sources */,
 				AEAC690026EA729300346599 /* CoingeckoPriceData.swift in Sources */,
 				84C34204283124C600156569 /* StakingParachainWireframe.swift in Sources */,
 				0C59E8D12AA5FAC5001E11F3 /* PooledAssetBalance.swift in Sources */,
@@ -23070,6 +23096,7 @@
 				88F34FD428FFE64400712BDE /* ReferendumDAppCellView.swift in Sources */,
 				0CA7821C2B03D0A9003F562A /* ExtrinsicProcessor+AssetHubSwapMatching.swift in Sources */,
 				8430AB1226023C9F005B1066 /* PendingBondedState.swift in Sources */,
+				0C38B5102B7DCADF00882A8B /* KodaDotNftSyncService.swift in Sources */,
 				88421059289BBA8D00306F2C /* CurrencyViewFactory.swift in Sources */,
 				84F76ED829006BC400D7206C /* DiscreteGradientSlider+Style.swift in Sources */,
 				841E6AFE25EC12DE0007DDFE /* SelectedValidatorInfo.swift in Sources */,
@@ -24368,6 +24395,7 @@
 				6D603098CCF0B65AA726AD38 /* GovernanceUnlockConfirmViewController.swift in Sources */,
 				7DB7E81CC2F880E4736DE062 /* GovernanceUnlockConfirmViewLayout.swift in Sources */,
 				84B8AA8D29FA41F600347A37 /* WalletConnectStateNewMessage.swift in Sources */,
+				0C38B5122B7DCB4400882A8B /* KodaDotNftModelConverter.swift in Sources */,
 				D5BB3A36DB9ADD25EE43109F /* GovernanceUnlockConfirmViewFactory.swift in Sources */,
 				65CD159259A06EC3E92FD4B0 /* AssetDetailsProtocols.swift in Sources */,
 				AE87017F784657CBEBF49C45 /* AssetDetailsWireframe.swift in Sources */,

--- a/novawallet/Common/DataProvider/NftLocalSubscriptionFactory.swift
+++ b/novawallet/Common/DataProvider/NftLocalSubscriptionFactory.swift
@@ -42,7 +42,7 @@ final class NftLocalSubscriptionFactory: SubstrateLocalSubscriptionFactory,
         type: NftType
     ) -> AnyDataProviderRepository<NftModel> {
         let mapper = AnyCoreDataMapper(NftModelMapper())
-        let filter = NSPredicate.nfts(for: [(chain.chainId, ownerId)], type: type.rawValue)
+        let filter = NSPredicate.nfts(for: [(chain.chainId, ownerId)], type: type)
         let sortDescriptor = NSSortDescriptor.nftsByCreationDesc
         let repository = storageFacade.createRepository(
             filter: filter,
@@ -178,6 +178,13 @@ final class NftLocalSubscriptionFactory: SubstrateLocalSubscriptionFactory,
 
         let dataSource = NftStreamableSource(syncServices: syncServices)
 
+        /**
+         *  We can now have cases:
+         *  1) When we don't sync nfts (don't have source for it) but want to display it from cache (rmrk v1).
+         *  2) Don't have source for nfts and don't want to display them from cache (uniques).
+         *  Probably we want to remove such nfts from cache and don't provide source for them in future.
+         */
+
         let mapper = AnyCoreDataMapper(NftModelMapper())
         let observable = CoreDataContextObservable(
             service: storageFacade.databaseService,
@@ -200,7 +207,7 @@ final class NftLocalSubscriptionFactory: SubstrateLocalSubscriptionFactory,
         }
 
         let filterOptions = nftOptions.map { ($0.chain.chainId, $0.ownerId) }
-        let filter = NSPredicate.nfts(for: filterOptions)
+        let filter = NSPredicate.nfts(for: filterOptions, types: NftType.notIntersectingTypes)
         let sortDescriptor = NSSortDescriptor.nftsByCreationDesc
         let repository = storageFacade.createRepository(
             filter: filter,

--- a/novawallet/Common/DataProvider/NftLocalSubscriptionFactory.swift
+++ b/novawallet/Common/DataProvider/NftLocalSubscriptionFactory.swift
@@ -107,6 +107,17 @@ final class NftLocalSubscriptionFactory: SubstrateLocalSubscriptionFactory,
         )
     }
 
+    private func createKodaDotService(for chain: ChainModel, ownerId: AccountId) -> NftSyncServiceProtocol {
+        let repository = createSyncRepository(for: chain, ownerId: ownerId, type: .kodadot)
+
+        return KodaDotNftSyncService(
+            ownerId: ownerId,
+            chain: chain,
+            repository: repository,
+            operationQueue: operationQueue
+        )
+    }
+
     private func createService(
         for chain: ChainModel,
         ownerId: AccountId,
@@ -121,6 +132,8 @@ final class NftLocalSubscriptionFactory: SubstrateLocalSubscriptionFactory,
             return createRMRKV2Service(for: chain, ownerId: ownerId)
         case .pdc20:
             return createPdc20Service(for: chain, ownerId: ownerId)
+        case .kodadot:
+            return createKodaDotService(for: chain, ownerId: ownerId)
         }
     }
 

--- a/novawallet/Common/DataProvider/NftLocalSubscriptionFactory.swift
+++ b/novawallet/Common/DataProvider/NftLocalSubscriptionFactory.swift
@@ -107,10 +107,15 @@ final class NftLocalSubscriptionFactory: SubstrateLocalSubscriptionFactory,
         )
     }
 
-    private func createKodaDotService(for chain: ChainModel, ownerId: AccountId) -> NftSyncServiceProtocol {
+    private func createKodaDotService(for chain: ChainModel, ownerId: AccountId) -> NftSyncServiceProtocol? {
+        guard let apiUrl = KodaDotAssetHubApi.apiForChain(chain.chainId) else {
+            return nil
+        }
+
         let repository = createSyncRepository(for: chain, ownerId: ownerId, type: .kodadot)
 
         return KodaDotNftSyncService(
+            api: apiUrl,
             ownerId: ownerId,
             chain: chain,
             repository: repository,
@@ -122,7 +127,7 @@ final class NftLocalSubscriptionFactory: SubstrateLocalSubscriptionFactory,
         for chain: ChainModel,
         ownerId: AccountId,
         type: NftType
-    ) -> NftSyncServiceProtocol {
+    ) -> NftSyncServiceProtocol? {
         switch type {
         case .uniques:
             return createUniquesService(for: chain, ownerId: ownerId)
@@ -167,7 +172,7 @@ final class NftLocalSubscriptionFactory: SubstrateLocalSubscriptionFactory,
 
         let nftOptions = createNftOptions(for: wallet, chains: chains)
 
-        let syncServices = nftOptions.map { option in
+        let syncServices = nftOptions.compactMap { option in
             createService(for: option.chain, ownerId: option.ownerId, type: option.type)
         }
 

--- a/novawallet/Common/Extension/Foundation/Predicate/NSPredicate+Filter.swift
+++ b/novawallet/Common/Extension/Foundation/Predicate/NSPredicate+Filter.swift
@@ -217,16 +217,23 @@ extension NSPredicate {
         return NSCompoundPredicate(andPredicateWithSubpredicates: [chainPredicate, ownerPredicate])
     }
 
-    static func nfts(for type: UInt16) -> NSPredicate {
-        NSPredicate(format: "%K == %d", #keyPath(CDNft.type), type)
-    }
-
     static func nfts(for chainAccounts: [(ChainModel.Id, AccountId)]) -> NSPredicate {
         let predicates = chainAccounts.map { nfts(for: $0.0, ownerId: $0.1) }
         return NSCompoundPredicate(orPredicateWithSubpredicates: predicates)
     }
 
-    static func nfts(for chainAccounts: [(ChainModel.Id, AccountId)], type: UInt16) -> NSPredicate {
+    static func nfts(for type: NftType) -> NSPredicate {
+        NSPredicate(format: "%K == %d", #keyPath(CDNft.type), type.rawValue)
+    }
+
+    static func nfts(for chainAccounts: [(ChainModel.Id, AccountId)], types: Set<NftType>) -> NSPredicate {
+        let chainAccountPredicate = nfts(for: chainAccounts)
+        let orPredicates = types.map { nfts(for: $0) }
+        let typesPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: orPredicates)
+        return NSCompoundPredicate(andPredicateWithSubpredicates: [chainAccountPredicate, typesPredicate])
+    }
+
+    static func nfts(for chainAccounts: [(ChainModel.Id, AccountId)], type: NftType) -> NSPredicate {
         let chainAccountPredicate = nfts(for: chainAccounts)
         let typePredicate = nfts(for: type)
         return NSCompoundPredicate(andPredicateWithSubpredicates: [chainAccountPredicate, typePredicate])

--- a/novawallet/Common/Extension/Foundation/Predicate/NSPredicate+Filter.swift
+++ b/novawallet/Common/Extension/Foundation/Predicate/NSPredicate+Filter.swift
@@ -226,6 +226,11 @@ extension NSPredicate {
         NSPredicate(format: "%K == %d", #keyPath(CDNft.type), type.rawValue)
     }
 
+    static func nftsForTypes(_ types: Set<NftType>) -> NSPredicate {
+        let orPredicates = types.map { nfts(for: $0) }
+        return NSCompoundPredicate(orPredicateWithSubpredicates: orPredicates)
+    }
+
     static func nfts(for chainAccounts: [(ChainModel.Id, AccountId)], types: Set<NftType>) -> NSPredicate {
         let chainAccountPredicate = nfts(for: chainAccounts)
         let orPredicates = types.map { nfts(for: $0) }

--- a/novawallet/Common/Network/DistributedStorage/DistributedUrlParser.swift
+++ b/novawallet/Common/Network/DistributedStorage/DistributedUrlParser.swift
@@ -33,7 +33,11 @@ final class DistributedUrlParser: DistributedUrlParserProtocol {
 
         switch DistributedStorageScheme(rawValue: scheme) {
         case .ipfs:
-            return .ipfs(hash: urlComponents.path)
+            if let host = urlComponents.host, host != "ipfs" {
+                return .ipfs(hash: (host as NSString).appendingPathComponent(urlComponents.path))
+            } else {
+                return .ipfs(hash: urlComponents.path)
+            }
         case .none:
             return nil
         }

--- a/novawallet/Common/Network/Files/FileDownloadOperation.swift
+++ b/novawallet/Common/Network/Files/FileDownloadOperation.swift
@@ -45,7 +45,17 @@ final class FileDownloadOperation: BaseOperation<URLResponse> {
         let dataTask = networkSession.downloadTask(with: remoteUrl) { tempUrl, response, networkError in
             do {
                 if let tempUrl = tempUrl {
-                    if !currentFileManager.fileExists(atPath: directoryUrl.path) {
+                    var isDirectory: ObjCBool = false
+                    let parentExists = currentFileManager.fileExists(
+                        atPath: directoryUrl.path,
+                        isDirectory: &isDirectory
+                    )
+
+                    if !parentExists || !isDirectory.boolValue {
+                        if parentExists {
+                            try currentFileManager.removeItem(at: directoryUrl)
+                        }
+
                         try currentFileManager.createDirectory(
                             at: directoryUrl,
                             withIntermediateDirectories: true,

--- a/novawallet/Modules/AssetList/ViewModel/AssetListViewModelFactory.swift
+++ b/novawallet/Modules/AssetList/ViewModel/AssetListViewModelFactory.swift
@@ -156,6 +156,12 @@ extension AssetListViewModelFactory: AssetListViewModelFactoryProtocol {
         let viewModels: [NftMediaViewModelProtocol] = nfts.filter { nft in
             nft.media != nil || nft.metadata != nil
         }.prefix(3).compactMap { nft in
+            if
+                let media = nft.media,
+                let gatewayImageUrl = nftDownloadService.imageUrl(from: media) {
+                return NftImageViewModel(url: gatewayImageUrl)
+            }
+
             if let media = nft.media, let url = URL(string: media) {
                 return NftImageViewModel(url: url)
             }

--- a/novawallet/Modules/Nft/Model/NftType.swift
+++ b/novawallet/Modules/Nft/Model/NftType.swift
@@ -5,4 +5,5 @@ enum NftType: UInt16, Equatable {
     case rmrkV1 // this type was deprecated but we keep him for cache purpose
     case rmrkV2
     case pdc20
+    case kodadot
 }

--- a/novawallet/Modules/Nft/Model/NftType.swift
+++ b/novawallet/Modules/Nft/Model/NftType.swift
@@ -1,9 +1,13 @@
 import Foundation
 
 enum NftType: UInt16, Equatable {
-    case uniques
+    case uniques // kodadot type now covers uniques
     case rmrkV1 // this type was deprecated but we keep him for cache purpose
     case rmrkV2
     case pdc20
     case kodadot
+
+    static var notIntersectingTypes: Set<NftType> {
+        [rmrkV1, rmrkV2, pdc20, kodadot]
+    }
 }

--- a/novawallet/Modules/Nft/Model/NftType.swift
+++ b/novawallet/Modules/Nft/Model/NftType.swift
@@ -7,7 +7,7 @@ enum NftType: UInt16, Equatable {
     case pdc20
     case kodadot
 
-    static var notIntersectingTypes: Set<NftType> {
-        [rmrkV1, rmrkV2, pdc20, kodadot]
+    static var excludedTypes: Set<NftType> {
+        [.uniques]
     }
 }

--- a/novawallet/Modules/Nft/NftDetails/KodaDotDetailsInteractor.swift
+++ b/novawallet/Modules/Nft/NftDetails/KodaDotDetailsInteractor.swift
@@ -1,0 +1,165 @@
+import Foundation
+import RobinHood
+
+final class KodaDotDetailsInteractor: NftDetailsInteractor {
+    let operationFactory: KodaDotNftOperationFactoryProtocol
+
+    let issuerCancellable = CancellableCallStore()
+    let collectionCancellable = CancellableCallStore()
+
+    init(
+        nftChainModel: NftChainModel,
+        nftMetadataService: NftFileDownloadServiceProtocol,
+        operationFactory: KodaDotNftOperationFactoryProtocol,
+        accountRepository: AnyDataProviderRepository<MetaAccountModel>,
+        operationQueue: OperationQueue
+    ) {
+        self.operationFactory = operationFactory
+
+        super.init(
+            nftChainModel: nftChainModel,
+            accountRepository: accountRepository,
+            nftMetadataService: nftMetadataService,
+            operationQueue: operationQueue
+        )
+    }
+
+    deinit {
+        issuerCancellable.cancel()
+        collectionCancellable.cancel()
+    }
+
+    private func provideInstanceDetails() {
+        if let image = nftChainModel.nft.media, let url = URL(string: image) {
+            let mediaViewModel = NftImageViewModel(url: url)
+
+            presenter?.didReceive(media: mediaViewModel)
+
+            provideInstanceMetadata(false)
+        } else {
+            provideInstanceMetadata(true)
+        }
+    }
+
+    private func provideCollection(from model: RMRKV2Collection) {
+        if
+            let issuer = model.issuer,
+            let issuerId = try? issuer.toAccountId(using: chain.chainFormat) {
+            if issuerOperation == nil {
+                issuerOperation = fetchDisplayAddress(for: issuerId, chain: chain) { [weak self] result in
+                    self?.issuerOperation = nil
+
+                    switch result {
+                    case let .success(displayAddress):
+                        self?.presenter?.didReceive(issuer: displayAddress)
+                    case let .failure(error):
+                        self?.presenter?.didReceive(error: error)
+                    }
+                }
+            }
+        } else {
+            presenter?.didReceive(issuer: nil)
+        }
+
+        if let metadata = model.metadata {
+            if collectionOperation == nil {
+                collectionOperation = nftMetadataService.downloadMetadata(
+                    for: metadata,
+                    dispatchQueue: .main
+                ) { [weak self] result in
+                    self?.collectionOperation = nil
+
+                    switch result {
+                    case let .success(json):
+                        let name = json.name?.stringValue ?? model.symbol
+
+                        let url: URL? = NftMediaAlias.list.compactMap { alias in
+                            if let imageReference = json.dictValue?[alias]?.stringValue {
+                                return self?.nftMetadataService.imageUrl(from: imageReference)
+                            } else {
+                                return nil
+                            }
+                        }.first
+
+                        let collection = NftDetailsCollection(name: name ?? "", imageUrl: url)
+                        self?.presenter?.didReceive(collection: collection)
+                    case let .failure(error):
+                        self?.presenter?.didReceive(error: error)
+                    }
+                }
+            }
+        } else {
+            let collection = NftDetailsCollection(name: model.symbol ?? "", imageUrl: nil)
+            presenter?.didReceive(collection: collection)
+        }
+    }
+
+    private func provideCollection() {
+        guard collectionOperation == nil, issuerOperation == nil else {
+            return
+        }
+
+        guard let collectionId = nftChainModel.nft.collectionId else {
+            presenter?.didReceive(collection: nil)
+            presenter?.didReceive(issuer: nil)
+            return
+        }
+
+        let fetchOperation = operationFactory.fetchCollection(for: collectionId)
+
+        collectionOperation = fetchOperation
+
+        fetchOperation.completionBlock = { [weak self] in
+            DispatchQueue.main.async {
+                self?.collectionOperation = nil
+
+                do {
+                    if let collection = try fetchOperation.extractNoCancellableResultData().first {
+                        self?.provideCollection(from: collection)
+                    } else {
+                        self?.presenter?.didReceive(collection: nil)
+                    }
+                } catch {
+                    self?.presenter?.didReceive(error: error)
+                }
+            }
+        }
+
+        operationQueue.addOperation(fetchOperation)
+    }
+
+    private func provideLabel() {
+        if
+            let snString = nftChainModel.nft.label,
+            let serialNumber = UInt32(snString),
+            let totalIssuance = nftChainModel.nft.issuanceTotal,
+            totalIssuance > 0 {
+            let label: NftDetailsLabel = .limited(
+                serialNumber: serialNumber,
+                totalIssuance: totalIssuance
+            )
+
+            presenter?.didReceive(label: label)
+        } else {
+            presenter?.didReceive(label: .unlimited)
+        }
+    }
+
+    private func load() {
+        provideOwner()
+        provideInstanceDetails()
+        provideCollection()
+        provideLabel()
+        providePrice()
+    }
+}
+
+extension KodaDotDetailsInteractor: NftDetailsInteractorInputProtocol {
+    func setup() {
+        load()
+    }
+
+    func refresh() {
+        load()
+    }
+}

--- a/novawallet/Modules/Nft/NftDetails/NftDetailsViewFactory.swift
+++ b/novawallet/Modules/Nft/NftDetails/NftDetailsViewFactory.swift
@@ -91,7 +91,7 @@ struct NftDetailsViewFactory {
         case .kodadot:
             return createKodaDotInteractor(
                 from: nftChainModel,
-                accountRepository: accountRepository,
+                accountRepository: AnyDataProviderRepository(accountRepository),
                 nftMetadataService: nftMetadataService,
                 operationQueue: operationQueue
             )

--- a/novawallet/Modules/Nft/NftDetails/NftDetailsViewFactory.swift
+++ b/novawallet/Modules/Nft/NftDetails/NftDetailsViewFactory.swift
@@ -166,10 +166,16 @@ struct NftDetailsViewFactory {
         nftMetadataService: NftFileDownloadServiceProtocol,
         operationQueue: OperationQueue
     ) -> KodaDotDetailsInteractor? {
-        KodaDotDetailsInteractor(
+        guard
+            nftChainModel.nft.type == NftType.kodadot.rawValue,
+            let apiUrl = KodaDotAssetHubApi.apiForChain(nftChainModel.chainAsset.chain.chainId) else {
+            return nil
+        }
+
+        return KodaDotDetailsInteractor(
             nftChainModel: nftChainModel,
             nftMetadataService: nftMetadataService,
-            operationFactory: KodaDotNftOperationFactory(url: KodaDotApi.url),
+            operationFactory: KodaDotNftOperationFactory(url: apiUrl),
             accountRepository: accountRepository,
             operationQueue: operationQueue
         )

--- a/novawallet/Modules/Nft/NftDetails/NftDetailsViewFactory.swift
+++ b/novawallet/Modules/Nft/NftDetails/NftDetailsViewFactory.swift
@@ -88,6 +88,13 @@ struct NftDetailsViewFactory {
                 nftMetadataService: nftMetadataService,
                 operationQueue: operationQueue
             )
+        case .kodadot:
+            return createKodaDotInteractor(
+                from: nftChainModel,
+                accountRepository: accountRepository,
+                nftMetadataService: nftMetadataService,
+                operationQueue: operationQueue
+            )
         case .none:
             return nil
         }
@@ -149,6 +156,21 @@ struct NftDetailsViewFactory {
             nftChainModel: nftChainModel,
             accountRepository: accountRepository,
             nftMetadataService: nftMetadataService,
+            operationQueue: operationQueue
+        )
+    }
+
+    private static func createKodaDotInteractor(
+        from nftChainModel: NftChainModel,
+        accountRepository: AnyDataProviderRepository<MetaAccountModel>,
+        nftMetadataService: NftFileDownloadServiceProtocol,
+        operationQueue: OperationQueue
+    ) -> KodaDotDetailsInteractor? {
+        KodaDotDetailsInteractor(
+            nftChainModel: nftChainModel,
+            nftMetadataService: nftMetadataService,
+            operationFactory: KodaDotNftOperationFactory(url: KodaDotApi.url),
+            accountRepository: accountRepository,
             operationQueue: operationQueue
         )
     }

--- a/novawallet/Modules/Nft/NftList/ViewModel/NftListViewModelFactory.swift
+++ b/novawallet/Modules/Nft/NftList/ViewModel/NftListViewModelFactory.swift
@@ -264,6 +264,37 @@ final class NftListViewModelFactory {
         return NftListStaticViewModel(name: name ?? "", label: label ?? "", media: mediaViewModel)
     }
 
+    private func createKodaDotViewModel(
+        from model: NftModel,
+        locale: Locale
+    ) -> NftListMetadataViewModelProtocol {
+        let name = model.name ?? model.instanceId ?? ""
+
+        let label: String
+
+        if
+            let snString = model.label,
+            let serialNumber = Int32(snString),
+            let totalIssuance = model.issuanceTotal,
+            totalIssuance > 0 {
+            label = createLimitedIssuanceLabel(from: serialNumber, totalNumber: totalIssuance, locale: locale)
+        } else {
+            label = createUnlimitedIssuanceLabel(for: locale)
+        }
+
+        let mediaViewModel: NftMediaViewModelProtocol?
+
+        if
+            let imageReference = model.media,
+            let imageUrl = nftDownloadService.imageUrl(from: imageReference) {
+            mediaViewModel = NftImageViewModel(url: imageUrl)
+        } else {
+            mediaViewModel = nil
+        }
+
+        return NftListStaticViewModel(name: name, label: label, media: mediaViewModel)
+    }
+
     private func createMedatadaViewModel(
         from model: NftChainModel,
         locale: Locale
@@ -278,7 +309,7 @@ final class NftListViewModelFactory {
         case .pdc20:
             return createPdc20Metadata(from: model.nft, locale: locale)
         case .kodadot:
-            return createRMRKV2Metadata(from: <#T##NftModel#>, locale: <#T##Locale#>)
+            return createKodaDotViewModel(from: model.nft, locale: locale)
         case .none:
             return createStaticMetadata(from: model.nft)
         }

--- a/novawallet/Modules/Nft/NftList/ViewModel/NftListViewModelFactory.swift
+++ b/novawallet/Modules/Nft/NftList/ViewModel/NftListViewModelFactory.swift
@@ -110,7 +110,7 @@ final class NftListViewModelFactory {
 
     private func createPrice(from model: NftChainModel, locale: Locale) -> BalanceViewModelProtocol? {
         switch NftType(rawValue: model.nft.type) {
-        case .rmrkV1, .rmrkV2, .uniques, .none:
+        case .rmrkV1, .rmrkV2, .uniques, .kodadot, .none:
             return createNonFungiblePrice(from: model, locale: locale)
         case .pdc20:
             return createFungiblePrice(from: model, locale: locale)
@@ -277,6 +277,8 @@ final class NftListViewModelFactory {
             return createRMRKV2Metadata(from: model.nft, locale: locale)
         case .pdc20:
             return createPdc20Metadata(from: model.nft, locale: locale)
+        case .kodadot:
+            return createRMRKV2Metadata(from: <#T##NftModel#>, locale: <#T##Locale#>)
         case .none:
             return createStaticMetadata(from: model.nft)
         }

--- a/novawallet/Modules/Nft/Services/ChainModel+Nft.swift
+++ b/novawallet/Modules/Nft/Services/ChainModel+Nft.swift
@@ -6,7 +6,9 @@ extension ChainModel {
         case KnowChainId.kusama:
             return [NftSource(chainId: chainId, type: .rmrkV2)]
         case KnowChainId.statemine:
-            return [NftSource(chainId: chainId, type: .uniques)]
+            return [
+                NftSource(chainId: chainId, type: .kodadot)
+            ]
         case KnowChainId.polkadot:
             return [NftSource(chainId: chainId, type: .pdc20)]
         case KnowChainId.statemint:

--- a/novawallet/Modules/Nft/Services/ChainModel+Nft.swift
+++ b/novawallet/Modules/Nft/Services/ChainModel+Nft.swift
@@ -9,6 +9,8 @@ extension ChainModel {
             return [NftSource(chainId: chainId, type: .uniques)]
         case KnowChainId.polkadot:
             return [NftSource(chainId: chainId, type: .pdc20)]
+        case KnowChainId.statemint:
+            return [NftSource(chainId: chainId, type: .kodadot)]
         default:
             return []
         }

--- a/novawallet/Modules/Nft/Services/KodaDot/KodaDotNft.swift
+++ b/novawallet/Modules/Nft/Services/KodaDot/KodaDotNft.swift
@@ -1,0 +1,39 @@
+import Foundation
+import BigInt
+import SubstrateSdk
+
+struct KodaDotNftResponse: Codable {
+    let nftEntities: [KodaDotNftRemoteModel]
+}
+
+struct KodaDotNftRemoteModel: Codable {
+    struct Collection: Codable {
+        enum CodingKeys: String, CodingKey {
+            case identifier = "id"
+            case max
+        }
+
+        let identifier: String
+        @OptionStringCodable var max: BigUInt?
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case identifier = "id"
+        case image
+        case metadata
+        case name
+        case price
+        case serialNumber = "sn"
+        case currentOwner
+        case collection
+    }
+
+    let identifier: String
+    let image: String?
+    let metadata: String?
+    let name: String?
+    let price: String?
+    let serialNumber: String?
+    let currentOwner: AccountAddress
+    let collection: Collection?
+}

--- a/novawallet/Modules/Nft/Services/KodaDot/KodaDotNft.swift
+++ b/novawallet/Modules/Nft/Services/KodaDot/KodaDotNft.swift
@@ -14,7 +14,7 @@ struct KodaDotNftRemoteModel: Codable {
         }
 
         let identifier: String
-        @OptionStringCodable var max: BigUInt?
+        let max: UInt?
     }
 
     enum CodingKeys: String, CodingKey {
@@ -36,4 +36,25 @@ struct KodaDotNftRemoteModel: Codable {
     let serialNumber: String?
     let currentOwner: AccountAddress
     let collection: Collection?
+}
+
+struct KodaDotNftMetadataResponse: Codable {
+    let metadataEntityById: KodaDotNftMetadataRemoteModel?
+}
+
+struct KodaDotNftMetadataRemoteModel: Codable {
+    let name: String?
+    let description: String?
+    let type: String?
+    let image: String?
+}
+
+struct KodaDotNftCollectionResponse: Codable {
+    let collectionEntityById: KodaDotNftCollectionRemoteModel?
+}
+
+struct KodaDotNftCollectionRemoteModel: Codable {
+    let name: String?
+    let image: String?
+    let issuer: String?
 }

--- a/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftModelConverter.swift
+++ b/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftModelConverter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BigInt
 
 enum KodaDotNftModelConverter {
     static func convert(response: KodaDotNftResponse, chain: ChainModel) throws -> [RemoteNftModel] {
@@ -14,8 +15,8 @@ enum KodaDotNftModelConverter {
                 ownerId: owner,
                 collectionId: entity.collection?.identifier,
                 instanceId: entity.identifier,
-                metadata: entity.metadata,
-                issuanceTotal: entity.collection.flatMap(\.max),
+                metadata: entity.metadata.flatMap { $0.data(using: .utf8) },
+                issuanceTotal: entity.collection?.max.flatMap { BigUInt($0) },
                 issuanceMyAmount: nil,
                 name: entity.name,
                 label: entity.serialNumber,

--- a/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftModelConverter.swift
+++ b/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftModelConverter.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum KodaDotNftModelConverter {
+    static func convert(response: KodaDotNftResponse, chain: ChainModel) throws -> [RemoteNftModel] {
+        try response.nftEntities.map { entity in
+            let owner = try entity.currentOwner.toAccountId(using: chain.chainFormat)
+
+            let identifier = NftModel.kodaDotIdentifier(for: chain.chainId, identifier: entity.identifier)
+
+            return RemoteNftModel(
+                identifier: identifier,
+                type: NftType.kodadot.rawValue,
+                chainId: chain.chainId,
+                ownerId: owner,
+                collectionId: entity.collection?.identifier,
+                instanceId: entity.identifier,
+                metadata: entity.metadata,
+                issuanceTotal: entity.collection.flatMap(\.max),
+                issuanceMyAmount: nil,
+                name: entity.name,
+                label: entity.serialNumber,
+                media: entity.image,
+                price: entity.price,
+                priceUnits: nil
+            )
+        }
+    }
+}

--- a/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftOperationFactory.swift
+++ b/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftOperationFactory.swift
@@ -7,8 +7,20 @@ protocol KodaDotNftOperationFactoryProtocol {
     func fetchCollection(for collectionId: String) -> CompoundOperationWrapper<KodaDotNftCollectionResponse>
 }
 
-enum KodaDotApi {
-    static let url = URL(string: "https://squid.subsquid.io/speck/graphql")!
+enum KodaDotAssetHubApi {
+    static let polkadotAssetHub = URL(string: "https://ahp.gql.api.kodadot.xyz")!
+    static let kusamaAssetHub = URL(string: "https://ahk.gql.api.kodadot.xyz")
+
+    static func apiForChain(_ chainId: ChainModel.Id) -> URL? {
+        switch chainId {
+        case KnowChainId.statemine:
+            return KodaDotAssetHubApi.kusamaAssetHub
+        case KnowChainId.statemint:
+            return KodaDotAssetHubApi.polkadotAssetHub
+        default:
+            return nil
+        }
+    }
 }
 
 final class KodaDotNftOperationFactory: SubqueryBaseOperationFactory {

--- a/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftOperationFactory.swift
+++ b/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftOperationFactory.swift
@@ -1,0 +1,43 @@
+import Foundation
+import RobinHood
+
+protocol KodaDotNftOperationFactoryProtocol {
+    func fetchNfts(for address: AccountAddress) -> CompoundOperationWrapper<KodaDotNftResponse>
+}
+
+enum KodaDotApi {
+    static let url = URL(string: "https://squid.subsquid.io/speck/graphql")!
+}
+
+final class KodaDotNftOperationFactory: SubqueryBaseOperationFactory {
+    // swiftlint:disable:next function_body_length
+    private func buildQuery(for address: AccountAddress) -> String {
+        """
+        {
+           nftEntities(where: {currentOwner_eq: "\(address)"}) {
+               id
+               image
+               metadata
+               name
+               price
+               sn
+               currentOwner
+               collection {
+                 id
+                 max
+                }
+            }
+        }
+        """
+    }
+}
+
+extension KodaDotNftOperationFactory: KodaDotNftOperationFactoryProtocol {
+    func fetchNfts(for address: AccountAddress) -> CompoundOperationWrapper<KodaDotNftResponse> {
+        let queryString = buildQuery(for: address)
+
+        let operation: BaseOperation<KodaDotNftResponse> = createOperation(for: queryString)
+
+        return CompoundOperationWrapper(targetOperation: operation)
+    }
+}

--- a/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftOperationFactory.swift
+++ b/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftOperationFactory.swift
@@ -3,6 +3,8 @@ import RobinHood
 
 protocol KodaDotNftOperationFactoryProtocol {
     func fetchNfts(for address: AccountAddress) -> CompoundOperationWrapper<KodaDotNftResponse>
+    func fetchMetadata(for metadataId: String) -> CompoundOperationWrapper<KodaDotNftMetadataResponse>
+    func fetchCollection(for collectionId: String) -> CompoundOperationWrapper<KodaDotNftCollectionResponse>
 }
 
 enum KodaDotApi {
@@ -10,8 +12,7 @@ enum KodaDotApi {
 }
 
 final class KodaDotNftOperationFactory: SubqueryBaseOperationFactory {
-    // swiftlint:disable:next function_body_length
-    private func buildQuery(for address: AccountAddress) -> String {
+    private func buildNftQuery(for address: AccountAddress) -> String {
         """
         {
            nftEntities(where: {currentOwner_eq: "\(address)"}) {
@@ -30,13 +31,54 @@ final class KodaDotNftOperationFactory: SubqueryBaseOperationFactory {
         }
         """
     }
+
+    private func buildMetadataQuery(for metadataId: String) -> String {
+        """
+        {
+            metadataEntityById(id: \"\(metadataId)\") {
+                image
+                name
+                type
+                description
+            }
+        }
+        """
+    }
+
+    private func buildCollectionQuery(for collectionId: String) -> String {
+        """
+        {
+            collectionEntityById(id: \"\(collectionId)\") {
+                name
+                image
+                issuer
+            }
+        }
+        """
+    }
 }
 
 extension KodaDotNftOperationFactory: KodaDotNftOperationFactoryProtocol {
     func fetchNfts(for address: AccountAddress) -> CompoundOperationWrapper<KodaDotNftResponse> {
-        let queryString = buildQuery(for: address)
+        let queryString = buildNftQuery(for: address)
 
         let operation: BaseOperation<KodaDotNftResponse> = createOperation(for: queryString)
+
+        return CompoundOperationWrapper(targetOperation: operation)
+    }
+
+    func fetchMetadata(for metadataId: String) -> CompoundOperationWrapper<KodaDotNftMetadataResponse> {
+        let queryString = buildMetadataQuery(for: metadataId)
+
+        let operation: BaseOperation<KodaDotNftMetadataResponse> = createOperation(for: queryString)
+
+        return CompoundOperationWrapper(targetOperation: operation)
+    }
+
+    func fetchCollection(for collectionId: String) -> CompoundOperationWrapper<KodaDotNftCollectionResponse> {
+        let queryString = buildCollectionQuery(for: collectionId)
+
+        let operation: BaseOperation<KodaDotNftCollectionResponse> = createOperation(for: queryString)
 
         return CompoundOperationWrapper(targetOperation: operation)
     }

--- a/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftSyncService.swift
+++ b/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftSyncService.swift
@@ -6,9 +6,10 @@ final class KodaDotNftSyncService: BaseNftSyncService {
     let ownerId: AccountId
     let chain: ChainModel
 
-    private let operationFactory = KodaDotNftOperationFactory(url: KodaDotApi.url)
+    private let operationFactory: KodaDotNftOperationFactoryProtocol
 
     init(
+        api: URL,
         ownerId: AccountId,
         chain: ChainModel,
         repository: AnyDataProviderRepository<NftModel>,
@@ -18,6 +19,7 @@ final class KodaDotNftSyncService: BaseNftSyncService {
     ) {
         self.ownerId = ownerId
         self.chain = chain
+        operationFactory = KodaDotNftOperationFactory(url: api)
 
         super.init(
             repository: repository,

--- a/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftSyncService.swift
+++ b/novawallet/Modules/Nft/Services/KodaDot/KodaDotNftSyncService.swift
@@ -2,15 +2,11 @@ import Foundation
 import SubstrateSdk
 import RobinHood
 
-enum Pdc20NftSyncServiceError: Error {
-    case unsupported(String)
-}
-
-final class Pdc20NftSyncService: BaseNftSyncService {
+final class KodaDotNftSyncService: BaseNftSyncService {
     let ownerId: AccountId
     let chain: ChainModel
 
-    private let operationFactory = Pdc20NftOperationFactory(url: Pdc20Api.url)
+    private let operationFactory = KodaDotNftOperationFactory(url: KodaDotApi.url)
 
     init(
         ownerId: AccountId,
@@ -32,22 +28,18 @@ final class Pdc20NftSyncService: BaseNftSyncService {
     }
 
     private func createRemoteFetchWrapper(
-        chain: ChainModel,
+        for chain: ChainModel,
         ownerId: AccountId
     ) -> CompoundOperationWrapper<[RemoteNftModel]> {
         do {
             let address = try ownerId.toAddress(using: chain.chainFormat)
 
-            guard let network = chain.pdc20Network else {
-                throw Pdc20NftSyncServiceError.unsupported(chain.name)
-            }
-
-            let fetchWrapper = operationFactory.fetchNfts(for: address, network: network)
+            let fetchWrapper = operationFactory.fetchNfts(for: address)
 
             let mapOperation = ClosureOperation<[RemoteNftModel]> {
                 let response = try fetchWrapper.targetOperation.extractNoCancellableResultData()
 
-                return try Pdc20NftModelConverter.convert(response: response, chain: chain)
+                return try KodaDotNftModelConverter.convert(response: response, chain: chain)
             }
 
             mapOperation.addDependency(fetchWrapper.targetOperation)
@@ -59,6 +51,6 @@ final class Pdc20NftSyncService: BaseNftSyncService {
     }
 
     override func createRemoteFetchWrapper() -> CompoundOperationWrapper<[RemoteNftModel]> {
-        createRemoteFetchWrapper(chain: chain, ownerId: ownerId)
+        createRemoteFetchWrapper(for: chain, ownerId: ownerId)
     }
 }

--- a/novawallet/Modules/Nft/Services/NFTClearService.swift
+++ b/novawallet/Modules/Nft/Services/NFTClearService.swift
@@ -1,0 +1,12 @@
+import Foundation
+import RobinHood
+
+/**
+ *  The service accepts a repository that is filtered by nfts types to exclude (see base service).
+ *  Then it returns empty remote list and base service undestands that local nfts must be removed.
+ */
+final class NFTClearService: BaseNftSyncService {
+    override func createRemoteFetchWrapper() -> CompoundOperationWrapper<[RemoteNftModel]> {
+        CompoundOperationWrapper.createWithResult([])
+    }
+}

--- a/novawallet/Modules/Nft/Services/NftFileDownloadService.swift
+++ b/novawallet/Modules/Nft/Services/NftFileDownloadService.swift
@@ -76,8 +76,24 @@ final class NftFileDownloadService {
         return CompoundOperationWrapper(targetOperation: decodingLocalOperation, dependencies: [localFetchOperation])
     }
 
+    private func createLocalPath(_ fileName: String) -> String? {
+        let localFilePath = (cacheBasePath as NSString).appendingPathComponent(fileName)
+
+        // don't allow empty filenames
+        let filePathComponentsCount = (localFilePath as NSString).pathComponents.count
+        let basePathComponentsCount = (cacheBasePath as NSString).pathComponents.count
+
+        guard filePathComponentsCount > basePathComponentsCount else {
+            return nil
+        }
+
+        return localFilePath
+    }
+
     private func createLoadMetadataWrapper(for ipfsHash: String) -> CompoundOperationWrapper<JSON> {
-        let localFilePath = (cacheBasePath as NSString).appendingPathComponent(ipfsHash)
+        guard let localFilePath = createLocalPath(ipfsHash) else {
+            return CompoundOperationWrapper.createWithError(CommonError.dataCorruption)
+        }
 
         let localCheckOperation = createLocalJsonWrapper(for: localFilePath)
 

--- a/novawallet/Modules/Nft/Services/Uniques/NftModel+Identifier.swift
+++ b/novawallet/Modules/Nft/Services/Uniques/NftModel+Identifier.swift
@@ -1,19 +1,23 @@
 import Foundation
 
 extension NftModel {
-    static func uniquesIdentifier(for chainId: String, classId: UInt32, instanceId: UInt32) -> String {
+    static func uniquesIdentifier(for chainId: ChainModel.Id, classId: UInt32, instanceId: UInt32) -> String {
         "unqs" + "-" + chainId + "-" + String(classId) + "-" + String(instanceId)
     }
 
-    static func rmrkv1Identifier(for chainId: String, identifier: String) -> String {
+    static func rmrkv1Identifier(for chainId: ChainModel.Id, identifier: String) -> String {
         "rmrkv1" + "-" + chainId + "-" + identifier
     }
 
-    static func rmrkv2Identifier(for chainId: String, identifier: String) -> String {
+    static func rmrkv2Identifier(for chainId: ChainModel.Id, identifier: String) -> String {
         "rmrkv2" + "-" + chainId + "-" + identifier
     }
 
-    static func pdc20Identifier(for chainId: String, token: String, address: String) -> String {
+    static func pdc20Identifier(for chainId: ChainModel.Id, token: String, address: String) -> String {
         "pdc20" + "-" + chainId + "-" + token + "-" + address
+    }
+
+    static func kodaDotIdentifier(for chainId: ChainModel.Id, identifier: String) -> String {
+        "kodadot" + "-" + chainId + "-" + identifier
     }
 }


### PR DESCRIPTION
- Add support of Kodadot NFTs from Kusama and Polkadot Asset Hubs: basically, from Uniques and NFT pallets
- As we had previously support for Uniques pallet on Kusama then there is no longer to sync/display such nfts as KodaDot now handles them. We now have NFTClearService to clear such excluded NFTs locally.

![nft-assets](https://github.com/novasamatech/nova-wallet-ios/assets/570634/48b03273-bf7a-49e4-83fb-3b8ad7b12658)

![nft-list](https://github.com/novasamatech/nova-wallet-ios/assets/570634/2e434295-e5ea-44dc-8de6-a9ce69127377)

![nft-details](https://github.com/novasamatech/nova-wallet-ios/assets/570634/98257569-ecb5-4741-a819-5a6d74ee8732)
