### PR TITLE
Cloud backup service orchestration

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -516,6 +516,7 @@
 		0CCDB2F92B75E21F007BC5D6 /* HydraStableswapQuoteParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCDB2F82B75E21F007BC5D6 /* HydraStableswapQuoteParams.swift */; };
 		0CCDB2FB2B75E938007BC5D6 /* HydraStableswapQuoteFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCDB2FA2B75E938007BC5D6 /* HydraStableswapQuoteFactory.swift */; };
 		0CCE25212A44306200286709 /* TransactionHistoryPhishingFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCE25202A44306200286709 /* TransactionHistoryPhishingFilter.swift */; };
+		0CCE3AAA2BF395DC00D55F03 /* CloudBackupUpdateApplicationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCE3AA92BF395DC00D55F03 /* CloudBackupUpdateApplicationFactory.swift */; };
 		0CD1F4D100ED82D137AB9834 /* ParaStkStakeSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2F1EEBF48485F02BF690A4 /* ParaStkStakeSetupViewController.swift */; };
 		0CD352932ACAD7A500B3E446 /* AssetHubExtrinsicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD352922ACAD7A500B3E446 /* AssetHubExtrinsicService.swift */; };
 		0CD352952ACAF59900B3E446 /* BigRational.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD352942ACAF59900B3E446 /* BigRational.swift */; };
@@ -5215,6 +5216,7 @@
 		0CCDB2F82B75E21F007BC5D6 /* HydraStableswapQuoteParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraStableswapQuoteParams.swift; sourceTree = "<group>"; };
 		0CCDB2FA2B75E938007BC5D6 /* HydraStableswapQuoteFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraStableswapQuoteFactory.swift; sourceTree = "<group>"; };
 		0CCE25202A44306200286709 /* TransactionHistoryPhishingFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryPhishingFilter.swift; sourceTree = "<group>"; };
+		0CCE3AA92BF395DC00D55F03 /* CloudBackupUpdateApplicationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupUpdateApplicationFactory.swift; sourceTree = "<group>"; };
 		0CD352922ACAD7A500B3E446 /* AssetHubExtrinsicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetHubExtrinsicService.swift; sourceTree = "<group>"; };
 		0CD352942ACAF59900B3E446 /* BigRational.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigRational.swift; sourceTree = "<group>"; };
 		0CD352962ACAFADA00B3E446 /* AssetConversionOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetConversionOperationFactory.swift; sourceTree = "<group>"; };
@@ -10406,6 +10408,7 @@
 				0CC0F82B2BB570C2002C49F6 /* CloudBackupOperationFactory.swift */,
 				0C7CF4CF2BD384190015DD45 /* CloudBackupUploadingOperationFactory.swift */,
 				0C6390902BF091610015D467 /* CloudBackupUpdateCalculationFactory.swift */,
+				0CCE3AA92BF395DC00D55F03 /* CloudBackupUpdateApplicationFactory.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -22903,6 +22906,7 @@
 				778D979D2A24D21B002BA681 /* AssetsOperationViewLayout.swift in Sources */,
 				84F1CB3C27CF42B80095D523 /* NftListItemWithPriceCell.swift in Sources */,
 				84EE2FAB289120AF00A98816 /* WalletManageInteractor.swift in Sources */,
+				0CCE3AAA2BF395DC00D55F03 /* CloudBackupUpdateApplicationFactory.swift in Sources */,
 				842876B424AE059700D91AD8 /* SocialMessage.swift in Sources */,
 				849014BC24AA87E4008F705E /* PinSetupInteractor.swift in Sources */,
 				8468119728E6C90F00BF54F1 /* VoteProtocols.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -517,6 +517,7 @@
 		0CCDB2FB2B75E938007BC5D6 /* HydraStableswapQuoteFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCDB2FA2B75E938007BC5D6 /* HydraStableswapQuoteFactory.swift */; };
 		0CCE25212A44306200286709 /* TransactionHistoryPhishingFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCE25202A44306200286709 /* TransactionHistoryPhishingFilter.swift */; };
 		0CCE3AAA2BF395DC00D55F03 /* CloudBackupUpdateApplicationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCE3AA92BF395DC00D55F03 /* CloudBackupUpdateApplicationFactory.swift */; };
+		0CCE3AAC2BF4762000D55F03 /* CloudBackupDiff+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCE3AAB2BF4762000D55F03 /* CloudBackupDiff+Helper.swift */; };
 		0CD1F4D100ED82D137AB9834 /* ParaStkStakeSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2F1EEBF48485F02BF690A4 /* ParaStkStakeSetupViewController.swift */; };
 		0CD352932ACAD7A500B3E446 /* AssetHubExtrinsicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD352922ACAD7A500B3E446 /* AssetHubExtrinsicService.swift */; };
 		0CD352952ACAF59900B3E446 /* BigRational.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD352942ACAF59900B3E446 /* BigRational.swift */; };
@@ -5217,6 +5218,7 @@
 		0CCDB2FA2B75E938007BC5D6 /* HydraStableswapQuoteFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraStableswapQuoteFactory.swift; sourceTree = "<group>"; };
 		0CCE25202A44306200286709 /* TransactionHistoryPhishingFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryPhishingFilter.swift; sourceTree = "<group>"; };
 		0CCE3AA92BF395DC00D55F03 /* CloudBackupUpdateApplicationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupUpdateApplicationFactory.swift; sourceTree = "<group>"; };
+		0CCE3AAB2BF4762000D55F03 /* CloudBackupDiff+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudBackupDiff+Helper.swift"; sourceTree = "<group>"; };
 		0CD352922ACAD7A500B3E446 /* AssetHubExtrinsicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetHubExtrinsicService.swift; sourceTree = "<group>"; };
 		0CD352942ACAF59900B3E446 /* BigRational.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigRational.swift; sourceTree = "<group>"; };
 		0CD352962ACAFADA00B3E446 /* AssetConversionOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetConversionOperationFactory.swift; sourceTree = "<group>"; };
@@ -9716,6 +9718,7 @@
 				0C6390922BF0931C0015D467 /* CloudBackupMetadataManaging.swift */,
 				0C6390962BF236AB0015D467 /* CloudBackupSyncState.swift */,
 				0C63909A2BF23E3A0015D467 /* NSPredicate+CloudBackup.swift */,
+				0CCE3AAB2BF4762000D55F03 /* CloudBackupDiff+Helper.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -24618,6 +24621,7 @@
 				84333BD7285682EC00C76A4F /* ValidatorsSelectionParams.swift in Sources */,
 				84C3F77B2601F08B00D47501 /* NominationViewModel.swift in Sources */,
 				846A2C4B2529F99400731018 /* AccountRepositoryFactory.swift in Sources */,
+				0CCE3AAC2BF4762000D55F03 /* CloudBackupDiff+Helper.swift in Sources */,
 				0C79C89E2A7BEF1200B171E3 /* NominationPoolRecommendationFactory.swift in Sources */,
 				0C85FF2A2B6D230100FC0014 /* AssetHubReQuoteService.swift in Sources */,
 				AE528E4D26852C380058935A /* ValidatorSearchViewModel.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -242,6 +242,11 @@
 		0C626D1D2A915E2F00CDAF4E /* StakingNominationPoolsStatics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C626D1C2A915E2F00CDAF4E /* StakingNominationPoolsStatics.swift */; };
 		0C626D1F2A92AA0F00CDAF4E /* NominationPoolsDataProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C626D1E2A92AA0F00CDAF4E /* NominationPoolsDataProviding.swift */; };
 		0C626D212A933A7D00CDAF4E /* StakingNPoolsViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C626D202A933A7D00CDAF4E /* StakingNPoolsViewModelFactory.swift */; };
+		0C6390892BF06C700015D467 /* CloudBackupSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6390882BF06C700015D467 /* CloudBackupSyncService.swift */; };
+		0C63908B2BF073C20015D467 /* CloudBackupUpdateMonitoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C63908A2BF073C20015D467 /* CloudBackupUpdateMonitoring.swift */; };
+		0C63908D2BF073D00015D467 /* ICloudBackupUpdateMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C63908C2BF073D00015D467 /* ICloudBackupUpdateMonitor.swift */; };
+		0C6390912BF091610015D467 /* CloudBackupUpdateCalculationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6390902BF091610015D467 /* CloudBackupUpdateCalculationFactory.swift */; };
+		0C6390932BF0931C0015D467 /* CloudBackupMetadataManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6390922BF0931C0015D467 /* CloudBackupMetadataManaging.swift */; };
 		0C66102B2A73816000E44634 /* StakingSharedStateFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102A2A73816000E44634 /* StakingSharedStateFactory.swift */; };
 		0C66102D2A73828800E44634 /* RelaychainStakingSharedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102C2A73828800E44634 /* RelaychainStakingSharedState.swift */; };
 		0C66102F2A78E9D700E44634 /* RelaychainStartStakingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102E2A78E9D700E44634 /* RelaychainStartStakingState.swift */; };
@@ -4921,6 +4926,11 @@
 		0C626D1C2A915E2F00CDAF4E /* StakingNominationPoolsStatics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingNominationPoolsStatics.swift; sourceTree = "<group>"; };
 		0C626D1E2A92AA0F00CDAF4E /* NominationPoolsDataProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NominationPoolsDataProviding.swift; sourceTree = "<group>"; };
 		0C626D202A933A7D00CDAF4E /* StakingNPoolsViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingNPoolsViewModelFactory.swift; sourceTree = "<group>"; };
+		0C6390882BF06C700015D467 /* CloudBackupSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupSyncService.swift; sourceTree = "<group>"; };
+		0C63908A2BF073C20015D467 /* CloudBackupUpdateMonitoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupUpdateMonitoring.swift; sourceTree = "<group>"; };
+		0C63908C2BF073D00015D467 /* ICloudBackupUpdateMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudBackupUpdateMonitor.swift; sourceTree = "<group>"; };
+		0C6390902BF091610015D467 /* CloudBackupUpdateCalculationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupUpdateCalculationFactory.swift; sourceTree = "<group>"; };
+		0C6390922BF0931C0015D467 /* CloudBackupMetadataManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupMetadataManaging.swift; sourceTree = "<group>"; };
 		0C66102A2A73816000E44634 /* StakingSharedStateFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingSharedStateFactory.swift; sourceTree = "<group>"; };
 		0C66102C2A73828800E44634 /* RelaychainStakingSharedState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaychainStakingSharedState.swift; sourceTree = "<group>"; };
 		0C66102E2A78E9D700E44634 /* RelaychainStartStakingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaychainStartStakingState.swift; sourceTree = "<group>"; };
@@ -9691,6 +9701,7 @@
 				0CED3A0D2BD17AD400B1E994 /* CloudBackupDiffing.swift */,
 				0C7CF4CB2BD374930015DD45 /* CloudBackupFileManaging.swift */,
 				0C7CF4CD2BD3784B0015DD45 /* CloudBackupCoding.swift */,
+				0C6390922BF0931C0015D467 /* CloudBackupMetadataManaging.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -10359,6 +10370,7 @@
 				0CA26D8C2BBBB5BA0086748F /* CloudBackupServiceFactoryProtocol.swift */,
 				0CED3A0B2BD1762D00B1E994 /* CloudBackupServiceFacadeProtocol.swift */,
 				0C7CF4C92BD36E480015DD45 /* CloudBackupServiceFacade.swift */,
+				0C6390882BF06C700015D467 /* CloudBackupSyncService.swift */,
 			);
 			path = CloudBackup;
 			sourceTree = "<group>";
@@ -10379,6 +10391,7 @@
 			children = (
 				0CC0F82B2BB570C2002C49F6 /* CloudBackupOperationFactory.swift */,
 				0C7CF4CF2BD384190015DD45 /* CloudBackupUploadingOperationFactory.swift */,
+				0C6390902BF091610015D467 /* CloudBackupUpdateCalculationFactory.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -10613,6 +10626,8 @@
 			children = (
 				0CF8176E2BC652D000CB9183 /* CloudBackupUploadMonitoring.swift */,
 				0CF817702BC6536F00CB9183 /* ICloudBackupUploadMonitor.swift */,
+				0C63908A2BF073C20015D467 /* CloudBackupUpdateMonitoring.swift */,
+				0C63908C2BF073D00015D467 /* ICloudBackupUpdateMonitor.swift */,
 			);
 			path = Monitor;
 			sourceTree = "<group>";
@@ -22544,6 +22559,7 @@
 				84AE7AAF27D38B1800495267 /* DrawableIconViewModel.swift in Sources */,
 				849976D027B3AC0100B14A6C /* MetamaskEvent.swift in Sources */,
 				0CE629DD2AA9B6BF00E250BD /* RewardDestinationViewModel.swift in Sources */,
+				0C63908D2BF073D00015D467 /* ICloudBackupUpdateMonitor.swift in Sources */,
 				849976BC27B25A6600B14A6C /* DAppTransportModel.swift in Sources */,
 				771901A42AE7E48800D9C918 /* SwapBaseProtocols.swift in Sources */,
 				84D2F1B32775A3220040C680 /* ExtrinsicJSONProcessor.swift in Sources */,
@@ -22685,6 +22701,7 @@
 				880CC0AA29E7F151008C7F65 /* EquilibriumLocksSubscription.swift in Sources */,
 				8490145324A93FD1008F705E /* NovaLoadingViewFactory.swift in Sources */,
 				8472976C260B1CAD009B86D0 /* InitiatedBondingConfirmInteractor.swift in Sources */,
+				0C6390912BF091610015D467 /* CloudBackupUpdateCalculationFactory.swift in Sources */,
 				887C450029AC7ED600950F98 /* DelegationReferendumVotersModel.swift in Sources */,
 				84EBC55F24F71D6A00459D15 /* UITableViewCell+ReorderColor.swift in Sources */,
 				84D8F17124D856D300AF43E9 /* SNAddressType+ViewModel.swift in Sources */,
@@ -23567,6 +23584,7 @@
 				8488D5DB298167D10019B388 /* GovernanceDelegateTypeView.swift in Sources */,
 				84CC726228AF8C7A003429E7 /* LedgerApplicationRequest.swift in Sources */,
 				849AFEBD26DCCE3A00B65924 /* SubqueryResponse.swift in Sources */,
+				0C6390892BF06C700015D467 /* CloudBackupSyncService.swift in Sources */,
 				84CFF1E426526FBC00DB7CF7 /* StakingBondMorePresenter.swift in Sources */,
 				842D1E7924D063FD00C30A7A /* TriangularedView.swift in Sources */,
 				AE2C84E925EF98D500986716 /* ValidatorInfoViewFactory.swift in Sources */,
@@ -23937,6 +23955,7 @@
 				84E63C1728FFC69A0093534A /* DiscreteGradientSlider.swift in Sources */,
 				84EC2D18276B9DBC009B0BE1 /* PolkadotExtensionAccount.swift in Sources */,
 				84FC190D29B7EE1600BCCAA5 /* MultiExtrinsicFeeProxy.swift in Sources */,
+				0C63908B2BF073C20015D467 /* CloudBackupUpdateMonitoring.swift in Sources */,
 				844C3E6F2A08E74D00C4305F /* BalanceCalculator.swift in Sources */,
 				8814774029B07B66001E98A1 /* DelegateGroupActionTitleControl.swift in Sources */,
 				F4E17FCF272182E800FE36D3 /* MoonbeamAgreeRemarkRequest.swift in Sources */,
@@ -24745,6 +24764,7 @@
 				0C59E8F82AA76833001E11F3 /* OperationDetailsContractProvider.swift in Sources */,
 				6BAF97802DB9C640515F47C7 /* StakingMainInteractor.swift in Sources */,
 				84BF12A128CFCD70007AA576 /* ParaStkYieldBoostStartError.swift in Sources */,
+				0C6390932BF0931C0015D467 /* CloudBackupMetadataManaging.swift in Sources */,
 				8466BB42263F501000E065A8 /* StakingUnbondConfirmViewModel.swift in Sources */,
 				0C3205E32A897B5A002EB914 /* ExtrinsicValidationProvider.swift in Sources */,
 				840D929F278D8D2E0007B979 /* DAppBrowserInteractorError.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -248,6 +248,9 @@
 		0C6390912BF091610015D467 /* CloudBackupUpdateCalculationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6390902BF091610015D467 /* CloudBackupUpdateCalculationFactory.swift */; };
 		0C6390932BF0931C0015D467 /* CloudBackupMetadataManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6390922BF0931C0015D467 /* CloudBackupMetadataManaging.swift */; };
 		0C6390952BF1FD4F0015D467 /* CloudBackupSyncFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6390942BF1FD4F0015D467 /* CloudBackupSyncFacade.swift */; };
+		0C6390972BF236AB0015D467 /* CloudBackupSyncState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6390962BF236AB0015D467 /* CloudBackupSyncState.swift */; };
+		0C6390992BF239240015D467 /* CloudBackupSyncFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6390982BF239240015D467 /* CloudBackupSyncFactory.swift */; };
+		0C63909B2BF23E3A0015D467 /* NSPredicate+CloudBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C63909A2BF23E3A0015D467 /* NSPredicate+CloudBackup.swift */; };
 		0C66102B2A73816000E44634 /* StakingSharedStateFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102A2A73816000E44634 /* StakingSharedStateFactory.swift */; };
 		0C66102D2A73828800E44634 /* RelaychainStakingSharedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102C2A73828800E44634 /* RelaychainStakingSharedState.swift */; };
 		0C66102F2A78E9D700E44634 /* RelaychainStartStakingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102E2A78E9D700E44634 /* RelaychainStartStakingState.swift */; };
@@ -4933,6 +4936,9 @@
 		0C6390902BF091610015D467 /* CloudBackupUpdateCalculationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupUpdateCalculationFactory.swift; sourceTree = "<group>"; };
 		0C6390922BF0931C0015D467 /* CloudBackupMetadataManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupMetadataManaging.swift; sourceTree = "<group>"; };
 		0C6390942BF1FD4F0015D467 /* CloudBackupSyncFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupSyncFacade.swift; sourceTree = "<group>"; };
+		0C6390962BF236AB0015D467 /* CloudBackupSyncState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupSyncState.swift; sourceTree = "<group>"; };
+		0C6390982BF239240015D467 /* CloudBackupSyncFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupSyncFactory.swift; sourceTree = "<group>"; };
+		0C63909A2BF23E3A0015D467 /* NSPredicate+CloudBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPredicate+CloudBackup.swift"; sourceTree = "<group>"; };
 		0C66102A2A73816000E44634 /* StakingSharedStateFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingSharedStateFactory.swift; sourceTree = "<group>"; };
 		0C66102C2A73828800E44634 /* RelaychainStakingSharedState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaychainStakingSharedState.swift; sourceTree = "<group>"; };
 		0C66102E2A78E9D700E44634 /* RelaychainStartStakingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaychainStartStakingState.swift; sourceTree = "<group>"; };
@@ -9704,6 +9710,8 @@
 				0C7CF4CB2BD374930015DD45 /* CloudBackupFileManaging.swift */,
 				0C7CF4CD2BD3784B0015DD45 /* CloudBackupCoding.swift */,
 				0C6390922BF0931C0015D467 /* CloudBackupMetadataManaging.swift */,
+				0C6390962BF236AB0015D467 /* CloudBackupSyncState.swift */,
+				0C63909A2BF23E3A0015D467 /* NSPredicate+CloudBackup.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -10374,6 +10382,7 @@
 				0C7CF4C92BD36E480015DD45 /* CloudBackupServiceFacade.swift */,
 				0C6390882BF06C700015D467 /* CloudBackupSyncService.swift */,
 				0C6390942BF1FD4F0015D467 /* CloudBackupSyncFacade.swift */,
+				0C6390982BF239240015D467 /* CloudBackupSyncFactory.swift */,
 			);
 			path = CloudBackup;
 			sourceTree = "<group>";
@@ -23381,6 +23390,7 @@
 				8448F7A42882E21E0080CEA9 /* SearchMatch.swift in Sources */,
 				84F4B2352A30D73900113DDD /* StakingDashboardSection.swift in Sources */,
 				845C40792702571200BFA50B /* StakingRemoteSubscriptionService.swift in Sources */,
+				0C6390992BF239240015D467 /* CloudBackupSyncFactory.swift in Sources */,
 				8468B86A24F63CBA00B76BC6 /* AddAccount+AccountImportInteractor.swift in Sources */,
 				0CD846302BDE61310026B5CA /* WalletImportOptionsWireframe.swift in Sources */,
 				0C9ECB5A2A4A9AB400BDCA73 /* AssetListAccountCell.swift in Sources */,
@@ -25307,6 +25317,7 @@
 				2B1E63AF98584341D670FB40 /* MoonbeamTermsViewController.swift in Sources */,
 				B1B0F4818510EB082ACA83AB /* MoonbeamTermsViewLayout.swift in Sources */,
 				0C85FF242B6CB28200FC0014 /* AssetHubExtrinsicConverter.swift in Sources */,
+				0C6390972BF236AB0015D467 /* CloudBackupSyncState.swift in Sources */,
 				77A6F5BA2A2E2AAD004AFD1A /* BuyAssetOperationWireframe.swift in Sources */,
 				84FBECFF2927797600FBEB83 /* AssetBalanceBatchBaseUpdatingService.swift in Sources */,
 				97F1D128D46B072D68940FC4 /* MoonbeamTermsViewFactory.swift in Sources */,
@@ -25535,6 +25546,7 @@
 				84EF8D3E288FDA2100265346 /* WalletListLocalStorageSubscriber.swift in Sources */,
 				0C9525E72A7AFA2C00BD724D /* ValueResolver.swift in Sources */,
 				84DD261429ACA9030032A598 /* VotersInfoOperationFactory.swift in Sources */,
+				0C63909B2BF23E3A0015D467 /* NSPredicate+CloudBackup.swift in Sources */,
 				11C6F4CD5B167DE4E9E7F654 /* DAppPhishingWireframe.swift in Sources */,
 				77DF40492B7FE7B700ABDB53 /* ChainNotificationSettingsViewLayout.swift in Sources */,
 				4014ED301AA53DA0B07B4221 /* DAppPhishingPresenter.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		0C63908D2BF073D00015D467 /* ICloudBackupUpdateMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C63908C2BF073D00015D467 /* ICloudBackupUpdateMonitor.swift */; };
 		0C6390912BF091610015D467 /* CloudBackupUpdateCalculationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6390902BF091610015D467 /* CloudBackupUpdateCalculationFactory.swift */; };
 		0C6390932BF0931C0015D467 /* CloudBackupMetadataManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6390922BF0931C0015D467 /* CloudBackupMetadataManaging.swift */; };
+		0C6390952BF1FD4F0015D467 /* CloudBackupSyncFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6390942BF1FD4F0015D467 /* CloudBackupSyncFacade.swift */; };
 		0C66102B2A73816000E44634 /* StakingSharedStateFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102A2A73816000E44634 /* StakingSharedStateFactory.swift */; };
 		0C66102D2A73828800E44634 /* RelaychainStakingSharedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102C2A73828800E44634 /* RelaychainStakingSharedState.swift */; };
 		0C66102F2A78E9D700E44634 /* RelaychainStartStakingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C66102E2A78E9D700E44634 /* RelaychainStartStakingState.swift */; };
@@ -4931,6 +4932,7 @@
 		0C63908C2BF073D00015D467 /* ICloudBackupUpdateMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudBackupUpdateMonitor.swift; sourceTree = "<group>"; };
 		0C6390902BF091610015D467 /* CloudBackupUpdateCalculationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupUpdateCalculationFactory.swift; sourceTree = "<group>"; };
 		0C6390922BF0931C0015D467 /* CloudBackupMetadataManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupMetadataManaging.swift; sourceTree = "<group>"; };
+		0C6390942BF1FD4F0015D467 /* CloudBackupSyncFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupSyncFacade.swift; sourceTree = "<group>"; };
 		0C66102A2A73816000E44634 /* StakingSharedStateFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingSharedStateFactory.swift; sourceTree = "<group>"; };
 		0C66102C2A73828800E44634 /* RelaychainStakingSharedState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaychainStakingSharedState.swift; sourceTree = "<group>"; };
 		0C66102E2A78E9D700E44634 /* RelaychainStartStakingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaychainStartStakingState.swift; sourceTree = "<group>"; };
@@ -10371,6 +10373,7 @@
 				0CED3A0B2BD1762D00B1E994 /* CloudBackupServiceFacadeProtocol.swift */,
 				0C7CF4C92BD36E480015DD45 /* CloudBackupServiceFacade.swift */,
 				0C6390882BF06C700015D467 /* CloudBackupSyncService.swift */,
+				0C6390942BF1FD4F0015D467 /* CloudBackupSyncFacade.swift */,
 			);
 			path = CloudBackup;
 			sourceTree = "<group>";
@@ -24528,6 +24531,7 @@
 				0C59E8D12AA5FAC5001E11F3 /* PooledAssetBalance.swift in Sources */,
 				84953F70293615D20033F47D /* AssetHistoryFactoryFacade.swift in Sources */,
 				84F13F1C26F2B8C2006725FF /* JSONRPCError+Presentable.swift in Sources */,
+				0C6390952BF1FD4F0015D467 /* CloudBackupSyncFacade.swift in Sources */,
 				84BAFCD226AF5EE700871E86 /* IconDetailsView.swift in Sources */,
 				0C495B9F2B452DA100B8D339 /* ProxyResolutionPathFinder.swift in Sources */,
 				841E5563282E9EF400C8438F /* ParachainStakingCommonData.swift in Sources */,

--- a/novawallet/Common/Extension/SettingsExtension.swift
+++ b/novawallet/Common/Extension/SettingsExtension.swift
@@ -19,6 +19,7 @@ enum SettingsKey: String {
     case notificationsEnabled
     case notificationsSetupSeen
     case lastCloudBackupTimestamp
+    case cloudBackupEnabled
 }
 
 extension SettingsManagerProtocol {
@@ -205,6 +206,16 @@ extension SettingsManagerProtocol {
         set {
             let stringValue = newValue.map { String($0) }
             set(value: stringValue, for: SettingsKey.lastCloudBackupTimestamp.rawValue)
+        }
+    }
+
+    var isCloudBackupEnabled: Bool {
+        get {
+            bool(for: SettingsKey.cloudBackupEnabled.rawValue) ?? false
+        }
+
+        set {
+            set(value: newValue, for: SettingsKey.cloudBackupEnabled.rawValue)
         }
     }
 }

--- a/novawallet/Common/Extension/SettingsExtension.swift
+++ b/novawallet/Common/Extension/SettingsExtension.swift
@@ -18,6 +18,7 @@ enum SettingsKey: String {
     case polkadotStakingPromoSeen
     case notificationsEnabled
     case notificationsSetupSeen
+    case lastCloudBackupTimestamp
 }
 
 extension SettingsManagerProtocol {
@@ -193,6 +194,16 @@ extension SettingsManagerProtocol {
 
         set {
             set(value: newValue, for: SettingsKey.notificationsSetupSeen.rawValue)
+        }
+    }
+    
+    var lastCloudBackupTimestampSeen: TimeInterval? {
+        get {
+            double(for: SettingsKey.lastCloudBackupTimestamp.rawValue)
+        }
+        
+        set {
+            set(value: newValue, for: SettingsKey.lastCloudBackupTimestamp.rawValue)
         }
     }
 }

--- a/novawallet/Common/Extension/SettingsExtension.swift
+++ b/novawallet/Common/Extension/SettingsExtension.swift
@@ -196,14 +196,15 @@ extension SettingsManagerProtocol {
             set(value: newValue, for: SettingsKey.notificationsSetupSeen.rawValue)
         }
     }
-    
-    var lastCloudBackupTimestampSeen: TimeInterval? {
+
+    var lastCloudBackupTimestampSeen: UInt64? {
         get {
-            double(for: SettingsKey.lastCloudBackupTimestamp.rawValue)
+            string(for: SettingsKey.lastCloudBackupTimestamp.rawValue).flatMap { UInt64($0) }
         }
-        
+
         set {
-            set(value: newValue, for: SettingsKey.lastCloudBackupTimestamp.rawValue)
+            let stringValue = newValue.map { String($0) }
+            set(value: stringValue, for: SettingsKey.lastCloudBackupTimestamp.rawValue)
         }
     }
 }

--- a/novawallet/Common/Model/KeystoreTag.swift
+++ b/novawallet/Common/Model/KeystoreTag.swift
@@ -11,6 +11,7 @@ enum KeystoreTag: String, CaseIterable {
 
 enum KeystoreTagV2: String, CaseIterable {
     case pincode
+    case cloudBackupPassword
 
     static func substrateSecretKeyTagForMetaId(
         _ metaId: String,

--- a/novawallet/Common/Services/CloudBackup/CloudBackupServiceFacade.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupServiceFacade.swift
@@ -254,10 +254,4 @@ extension CloudBackupServiceFacade: CloudBackupServiceFacadeProtocol {
             }
         }
     }
-
-    func syncUpdate(
-        _: CloudBackupSyncResult.Changes,
-        runCompletionIn _: DispatchQueue,
-        completionClosure _: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
-    ) {}
 }

--- a/novawallet/Common/Services/CloudBackup/CloudBackupServiceFacade.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupServiceFacade.swift
@@ -70,7 +70,7 @@ final class CloudBackupServiceFacade {
 }
 
 extension CloudBackupServiceFacade: CloudBackupServiceFacadeProtocol {
-    func enableBackup(
+    func createBackup(
         wallets: Set<MetaAccountModel>,
         keystore: KeystoreProtocol,
         password: String,
@@ -89,7 +89,6 @@ extension CloudBackupServiceFacade: CloudBackupServiceFacadeProtocol {
         let exporter = serviceFactory.createSecretsExporter(from: keystore)
         let encoder = serviceFactory.createCodingManager()
 
-        // TODO: Save modification date locally
         let modifiedAt = UInt64(Date().timeIntervalSince1970)
 
         let dataOperation = ClosureOperation<Data> {
@@ -255,4 +254,15 @@ extension CloudBackupServiceFacade: CloudBackupServiceFacadeProtocol {
             }
         }
     }
+
+    func enableBackup(
+        for _: String?,
+        runCompletionIn _: DispatchQueue,
+        completionClosure _: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
+    ) {}
+
+    func disableBackup(
+        runCompletionIn _: DispatchQueue,
+        completionClosure _: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
+    ) {}
 }

--- a/novawallet/Common/Services/CloudBackup/CloudBackupServiceFacade.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupServiceFacade.swift
@@ -255,13 +255,8 @@ extension CloudBackupServiceFacade: CloudBackupServiceFacadeProtocol {
         }
     }
 
-    func enableBackup(
-        for _: String?,
-        runCompletionIn _: DispatchQueue,
-        completionClosure _: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
-    ) {}
-
-    func disableBackup(
+    func syncUpdate(
+        _: CloudBackupSyncResult.Changes,
         runCompletionIn _: DispatchQueue,
         completionClosure _: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
     ) {}

--- a/novawallet/Common/Services/CloudBackup/CloudBackupServiceFacadeProtocol.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupServiceFacadeProtocol.swift
@@ -40,10 +40,4 @@ protocol CloudBackupServiceFacadeProtocol {
         runCompletionIn queue: DispatchQueue,
         completionClosure: @escaping (Result<Bool, CloudBackupServiceFacadeError>) -> Void
     )
-
-    func syncUpdate(
-        _ update: CloudBackupSyncResult.Changes,
-        runCompletionIn queue: DispatchQueue,
-        completionClosure: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
-    )
 }

--- a/novawallet/Common/Services/CloudBackup/CloudBackupServiceFacadeProtocol.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupServiceFacadeProtocol.swift
@@ -15,7 +15,7 @@ enum CloudBackupServiceFacadeError: Error {
 }
 
 protocol CloudBackupServiceFacadeProtocol {
-    func enableBackup(
+    func createBackup(
         wallets: Set<MetaAccountModel>,
         keystore: KeystoreProtocol,
         password: String,

--- a/novawallet/Common/Services/CloudBackup/CloudBackupServiceFacadeProtocol.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupServiceFacadeProtocol.swift
@@ -40,4 +40,10 @@ protocol CloudBackupServiceFacadeProtocol {
         runCompletionIn queue: DispatchQueue,
         completionClosure: @escaping (Result<Bool, CloudBackupServiceFacadeError>) -> Void
     )
+
+    func syncUpdate(
+        _ update: CloudBackupSyncResult.Changes,
+        runCompletionIn queue: DispatchQueue,
+        completionClosure: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
+    )
 }

--- a/novawallet/Common/Services/CloudBackup/CloudBackupServiceFactory.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupServiceFactory.swift
@@ -72,10 +72,18 @@ extension ICloudBackupServiceFactory: CloudBackupServiceFactoryProtocol {
         CloudBackupCoder()
     }
 
+    func createCryptoManager() -> CloudBackupCryptoManagerProtocol {
+        CloudBackupScryptSalsaCryptoManager()
+    }
+
+    func createDiffCalculator() -> CloudBackupDiffCalculating {
+        CloudBackupDiffCalculator(converter: CloudBackupFileModelConverter())
+    }
+
     func createSecretsExporter(from keychain: KeystoreProtocol) -> CloudBackupSecretsExporting {
         CloudBackupSecretsExporter(
             walletConverter: CloudBackupFileModelConverter(),
-            cryptoManager: CloudBackupScryptSalsaCryptoManager(),
+            cryptoManager: createCryptoManager(),
             keychain: keychain
         )
     }
@@ -83,7 +91,7 @@ extension ICloudBackupServiceFactory: CloudBackupServiceFactoryProtocol {
     func createSecretsImporter(to keychain: KeystoreProtocol) -> CloudBackupSecretsImporting {
         CloudBackupSecretsImporter(
             walletConverter: CloudBackupFileModelConverter(),
-            cryptoManager: CloudBackupScryptSalsaCryptoManager(),
+            cryptoManager: createCryptoManager(),
             validator: ICloudBackupValidator(),
             keychain: keychain
         )

--- a/novawallet/Common/Services/CloudBackup/CloudBackupServiceFactoryProtocol.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupServiceFactoryProtocol.swift
@@ -7,6 +7,8 @@ protocol CloudBackupServiceFactoryProtocol {
     func createOperationFactory() -> CloudBackupOperationFactoryProtocol
     func createFileManager() -> CloudBackupFileManaging
     func createCodingManager() -> CloudBackupCoding
+    func createCryptoManager() -> CloudBackupCryptoManagerProtocol
+    func createDiffCalculator() -> CloudBackupDiffCalculating
     func createSecretsExporter(from keychain: KeystoreProtocol) -> CloudBackupSecretsExporting
     func createSecretsImporter(to keychain: KeystoreProtocol) -> CloudBackupSecretsImporting
     func createUploadFactory() -> CloudBackupUploadFactoryProtocol

--- a/novawallet/Common/Services/CloudBackup/CloudBackupSyncFacade.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupSyncFacade.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 protocol CloudBackupSyncFacadeProtocol: ApplicationServiceProtocol {
-    var isCloudBackupEnabled: Bool { get }
-
     func enableBackup(
         for password: String?,
         runCompletionIn queue: DispatchQueue,
@@ -21,6 +19,8 @@ protocol CloudBackupSyncFacadeProtocol: ApplicationServiceProtocol {
     )
 
     func unsubscribeState(_ observer: AnyObject)
+
+    func syncUp()
 }
 
 final class CloudBackupSyncFacade {
@@ -115,10 +115,6 @@ final class CloudBackupSyncFacade {
 }
 
 extension CloudBackupSyncFacade: CloudBackupSyncFacadeProtocol {
-    var isCloudBackupEnabled: Bool {
-        syncMetadataManager.isBackupEnabled
-    }
-
     func enableBackup(
         for password: String?,
         runCompletionIn queue: DispatchQueue,
@@ -234,5 +230,9 @@ extension CloudBackupSyncFacade: CloudBackupSyncFacadeProtocol {
         clearSyncService()
 
         stateObservable.state = .disabled
+    }
+
+    func syncUp() {
+        syncService?.syncUp()
     }
 }

--- a/novawallet/Common/Services/CloudBackup/CloudBackupSyncFacade.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupSyncFacade.swift
@@ -4,53 +4,235 @@ protocol CloudBackupSyncFacadeProtocol: ApplicationServiceProtocol {
     var isCloudBackupEnabled: Bool { get }
 
     func enableBackup(
-        for password: String,
+        for password: String?,
         runCompletionIn queue: DispatchQueue,
-        completionClosure: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
+        completionClosure: @escaping (Result<Void, Error>) -> Void
     )
 
     func disableBackup(
         runCompletionIn queue: DispatchQueue,
-        completionClosure: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
+        completionClosure: @escaping (Result<Void, Error>) -> Void
     )
+
+    func subscribeState(
+        _ observer: AnyObject,
+        notifyingIn queue: DispatchQueue,
+        closure: @escaping (CloudBackupSyncState) -> Void
+    )
+
+    func unsubscribeState(_ observer: AnyObject)
 }
 
 final class CloudBackupSyncFacade {
-    let syncMetadataManaging: CloudBackupSyncMetadataManaging
-    let serviceFactory: CloudBackupServiceFactoryProtocol
-    let operationQueue: OperationQueue
+    let syncMetadataManager: CloudBackupSyncMetadataManaging
+    let fileManager: CloudBackupFileManaging
+    let syncFactory: CloudBackupSyncFactoryProtocol
+    let workingQueue: DispatchQueue
+    let logger: LoggerProtocol
 
-    private var syncService: SyncServiceProtocol?
+    private var syncService: CloudBackupSyncServiceProtocol?
     private var remoteMonitor: CloudBackupUpdateMonitoring?
 
+    private let mutex = NSLock()
+    private var stateObservable: Observable<CloudBackupSyncState> = .init(state: .disabled)
+
     init(
-        syncMetadataManaging: CloudBackupSyncMetadataManaging,
-        serviceFactory: CloudBackupServiceFactoryProtocol,
-        operationQueue: OperationQueue
+        syncFactory: CloudBackupSyncFactoryProtocol,
+        syncMetadataManager: CloudBackupSyncMetadataManaging,
+        fileManager: CloudBackupFileManaging,
+        workingQueue: DispatchQueue,
+        logger: LoggerProtocol
     ) {
-        self.syncMetadataManaging = syncMetadataManaging
-        self.serviceFactory = serviceFactory
-        self.operationQueue = operationQueue
+        self.syncMetadataManager = syncMetadataManager
+        self.fileManager = fileManager
+        self.syncFactory = syncFactory
+        self.workingQueue = workingQueue
+        self.logger = logger
+    }
+
+    private func handle(syncResult: CloudBackupSyncResult) {
+        guard syncMetadataManager.isBackupEnabled else {
+            return
+        }
+
+        stateObservable.state = .enabled(syncResult)
+    }
+
+    private func setupCloudSyncService(for remoteFileUrl: URL) {
+        syncService = syncFactory.createSyncService(for: remoteFileUrl)
+
+        syncService?.subscribeSyncResult(
+            self,
+            notifyingIn: workingQueue
+        ) { [weak self] result in
+            self?.mutex.lock()
+
+            defer {
+                self?.mutex.unlock()
+            }
+
+            self?.handle(syncResult: result)
+        }
+
+        syncService?.setup()
+    }
+
+    private func clearSyncService() {
+        remoteMonitor?.stop()
+        remoteMonitor = nil
+
+        syncService?.stopSyncUp()
+        syncService = nil
+    }
+
+    private func setupSyncServiceIfNeeded() {
+        guard remoteMonitor == nil else {
+            return
+        }
+
+        guard let remoteUrl = fileManager.getFileUrl() else {
+            stateObservable.state = .unavailable
+            return
+        }
+
+        stateObservable.state = .enabled(nil)
+
+        remoteMonitor = syncFactory.createRemoteUpdatesMonitor(for: remoteUrl.lastPathComponent)
+        remoteMonitor?.start { [weak self] _ in
+            self?.mutex.lock()
+
+            defer {
+                self?.mutex.unlock()
+            }
+
+            if let syncService = self?.syncService {
+                syncService.syncUp()
+            } else {
+                self?.setupCloudSyncService(for: remoteUrl)
+            }
+        }
     }
 }
 
 extension CloudBackupSyncFacade: CloudBackupSyncFacadeProtocol {
     var isCloudBackupEnabled: Bool {
-        syncMetadataManaging.isBackupEnabled
+        syncMetadataManager.isBackupEnabled
     }
 
     func enableBackup(
-        for _: String,
-        runCompletionIn _: DispatchQueue,
-        completionClosure _: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
-    ) {}
+        for password: String?,
+        runCompletionIn queue: DispatchQueue,
+        completionClosure: @escaping (Result<Void, Error>) -> Void
+    ) {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        do {
+            if let password {
+                try syncMetadataManager.savePassword(password)
+            }
+
+            guard !syncMetadataManager.isBackupEnabled else {
+                dispatchInQueueWhenPossible(queue) {
+                    completionClosure(.success(()))
+                }
+                return
+            }
+
+            syncMetadataManager.isBackupEnabled = true
+
+            setupSyncServiceIfNeeded()
+        } catch {
+            dispatchInQueueWhenPossible(queue) {
+                completionClosure(.failure(error))
+            }
+        }
+    }
 
     func disableBackup(
-        runCompletionIn _: DispatchQueue,
-        completionClosure _: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
-    ) {}
+        runCompletionIn queue: DispatchQueue,
+        completionClosure: @escaping (Result<Void, Error>) -> Void
+    ) {
+        mutex.lock()
 
-    func setup() {}
+        defer {
+            mutex.unlock()
+        }
 
-    func throttle() {}
+        guard syncMetadataManager.isBackupEnabled else {
+            dispatchInQueueWhenPossible(queue) {
+                completionClosure(.success(()))
+            }
+
+            return
+        }
+
+        clearSyncService()
+
+        stateObservable.state = .disabled
+
+        dispatchInQueueWhenPossible(queue) {
+            completionClosure(.success(()))
+        }
+    }
+
+    func subscribeState(
+        _ observer: AnyObject,
+        notifyingIn queue: DispatchQueue,
+        closure: @escaping (CloudBackupSyncState) -> Void
+    ) {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        stateObservable.addObserver(
+            with: observer,
+            sendStateOnSubscription: true,
+            queue: queue
+        ) { _, newState in
+            closure(newState)
+        }
+    }
+
+    func unsubscribeState(_ observer: AnyObject) {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        stateObservable.removeObserver(by: observer)
+    }
+
+    func setup() {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        guard syncMetadataManager.isBackupEnabled else {
+            stateObservable.state = .disabled
+            return
+        }
+
+        setupSyncServiceIfNeeded()
+    }
+
+    func throttle() {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        clearSyncService()
+
+        stateObservable.state = .disabled
+    }
 }

--- a/novawallet/Common/Services/CloudBackup/CloudBackupSyncFacade.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupSyncFacade.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+protocol CloudBackupSyncFacadeProtocol: ApplicationServiceProtocol {
+    var isCloudBackupEnabled: Bool { get }
+
+    func enableBackup(
+        for password: String,
+        runCompletionIn queue: DispatchQueue,
+        completionClosure: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
+    )
+
+    func disableBackup(
+        runCompletionIn queue: DispatchQueue,
+        completionClosure: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
+    )
+}
+
+final class CloudBackupSyncFacade {
+    let syncMetadataManaging: CloudBackupSyncMetadataManaging
+    let serviceFactory: CloudBackupServiceFactoryProtocol
+    let operationQueue: OperationQueue
+
+    private var syncService: SyncServiceProtocol?
+    private var remoteMonitor: CloudBackupUpdateMonitoring?
+
+    init(
+        syncMetadataManaging: CloudBackupSyncMetadataManaging,
+        serviceFactory: CloudBackupServiceFactoryProtocol,
+        operationQueue: OperationQueue
+    ) {
+        self.syncMetadataManaging = syncMetadataManaging
+        self.serviceFactory = serviceFactory
+        self.operationQueue = operationQueue
+    }
+}
+
+extension CloudBackupSyncFacade: CloudBackupSyncFacadeProtocol {
+    var isCloudBackupEnabled: Bool {
+        syncMetadataManaging.isBackupEnabled
+    }
+
+    func enableBackup(
+        for _: String,
+        runCompletionIn _: DispatchQueue,
+        completionClosure _: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
+    ) {}
+
+    func disableBackup(
+        runCompletionIn _: DispatchQueue,
+        completionClosure _: @escaping (Result<Void, CloudBackupServiceFacadeError>) -> Void
+    ) {}
+
+    func setup() {}
+
+    func throttle() {}
+}

--- a/novawallet/Common/Services/CloudBackup/CloudBackupSyncFactory.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupSyncFactory.swift
@@ -34,7 +34,7 @@ extension CloudBackupSyncFactory: CloudBackupSyncFactoryProtocol {
     func createSyncService(for remoteFileUrl: URL) -> CloudBackupSyncServiceProtocol {
         let updateCalculationFactory = CloudBackupUpdateCalculationFactory(
             syncMetadataManager: syncMetadataManaging,
-            walletsRepository: accountsRepositoryFactory.createMetaAccountRepository(
+            walletsRepository: accountsRepositoryFactory.createManagedMetaAccountRepository(
                 for: NSPredicate.cloudSyncableWallets,
                 sortDescriptors: []
             ),

--- a/novawallet/Common/Services/CloudBackup/CloudBackupSyncFactory.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupSyncFactory.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+protocol CloudBackupSyncFactoryProtocol {
+    func createSyncService(for remoteFileUrl: URL) -> CloudBackupSyncServiceProtocol
+    func createRemoteUpdatesMonitor(for filename: String) -> CloudBackupUpdateMonitoring
+}
+
+final class CloudBackupSyncFactory {
+    let syncMetadataManaging: CloudBackupSyncMetadataManaging
+    let accountsRepositoryFactory: AccountRepositoryFactoryProtocol
+    let serviceFactory: CloudBackupServiceFactoryProtocol
+    let operationQueue: OperationQueue
+    let notificationCenter: NotificationCenter
+    let logger: LoggerProtocol
+
+    init(
+        serviceFactory: CloudBackupServiceFactoryProtocol,
+        syncMetadataManaging: CloudBackupSyncMetadataManaging,
+        accountsRepositoryFactory: AccountRepositoryFactoryProtocol,
+        notificationCenter: NotificationCenter,
+        operationQueue: OperationQueue,
+        logger: LoggerProtocol
+    ) {
+        self.serviceFactory = serviceFactory
+        self.syncMetadataManaging = syncMetadataManaging
+        self.accountsRepositoryFactory = accountsRepositoryFactory
+        self.operationQueue = operationQueue
+        self.notificationCenter = notificationCenter
+        self.logger = logger
+    }
+}
+
+extension CloudBackupSyncFactory: CloudBackupSyncFactoryProtocol {
+    func createSyncService(for remoteFileUrl: URL) -> CloudBackupSyncServiceProtocol {
+        let updateCalculationFactory = CloudBackupUpdateCalculationFactory(
+            syncMetadataManager: syncMetadataManaging,
+            walletsRepository: accountsRepositoryFactory.createMetaAccountRepository(
+                for: NSPredicate.cloudSyncableWallets,
+                sortDescriptors: []
+            ),
+            backupOperationFactory: serviceFactory.createOperationFactory(),
+            decodingManager: serviceFactory.createCodingManager(),
+            cryptoManager: serviceFactory.createCryptoManager(),
+            diffManager: serviceFactory.createDiffCalculator()
+        )
+
+        return CloudBackupSyncService(
+            remoteFileUrl: remoteFileUrl,
+            updateCalculationFactory: updateCalculationFactory,
+            operationQueue: operationQueue
+        )
+    }
+
+    func createRemoteUpdatesMonitor(for filename: String) -> CloudBackupUpdateMonitoring {
+        let syncQueue = OperationQueue()
+        syncQueue.maxConcurrentOperationCount = 1
+
+        return ICloudBackupUpdateMonitor(
+            filename: filename,
+            operationQueue: syncQueue,
+            notificationCenter: notificationCenter,
+            logger: logger
+        )
+    }
+}

--- a/novawallet/Common/Services/CloudBackup/CloudBackupSyncService.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupSyncService.swift
@@ -66,7 +66,7 @@ final class CloudBackupSyncService: BaseSyncService, AnyCancellableCleaning {
     }
 }
 
-extension CloudBackupSyncService {
+extension CloudBackupSyncService: CloudBackupSyncServiceProtocol {
     func subscribeSyncResult(
         _ object: AnyObject,
         notifyingIn queue: DispatchQueue,

--- a/novawallet/Common/Services/CloudBackup/CloudBackupSyncService.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupSyncService.swift
@@ -1,0 +1,70 @@
+import Foundation
+import SoraKeystore
+import SubstrateSdk
+import RobinHood
+
+final class CloudBackupSyncService: BaseSyncService, AnyCancellableCleaning {
+    let keychain: KeystoreProtocol
+    let walletsRepository: AnyDataProviderRepository<MetaAccountModel>
+    let backupOperationFactory: CloudBackupOperationFactoryProtocol
+    let decodingManager: CloudBackupCoding
+    let diffManager: CloudBackupDiffCalculating
+    let remoteFileUrl: URL
+    
+    let workingQueue: DispatchQueue
+    let operationQueue: OperationQueue
+    
+    private var wrapper: CompoundOperationWrapper<CloudBackupDiff>
+
+    init(
+        remoteFileUrl: URL,
+        walletsRepository: AnyDataProviderRepository<MetaAccountModel>,
+        backupOperationFactory: CloudBackupOperationFactoryProtocol,
+        decodingManager: CloudBackupCoding,
+        diffManager: CloudBackupDiffCalculating,
+        operationQueue: OperationQueue,
+        workingQueue: DispatchQueue = DispatchQueue.global(),
+        retryStrategy: ReconnectionStrategyProtocol = ExponentialReconnection(),
+        logger: LoggerProtocol = Logger.shared
+    ) {
+        self.remoteFileUrl = remoteFileUrl
+        self.walletsRepository = walletsRepository
+        self.backupOperationFactory = backupOperationFactory
+        self.decodingManager = decodingManager
+        self.diffManager = diffManager
+        self.operationQueue = operationQueue
+        self.workingQueue = workingQueue
+        
+        super.init(retryStrategy: retryStrategy, logger: logger)
+    }
+
+    override func performSyncUp() {
+        let walletsOperation = walletsRepository.fetchAllOperation(with: RepositoryFetchOptions())
+        let remoteFileOperation = backupOperationFactory.createReadingOperation(for: remoteFileUrl)
+        
+        let decodingOperation = ClosureOperation<CloudBackup.PublicData?> {
+            let data = try remoteFileOperation.extractNoCancellableResultData()
+            
+            return try data.map { try self.decodingManager.decode(data: $0).publicData }
+        }
+        
+        decodingOperation.addDependency(remoteFileOperation)
+        
+        let diffOperation = ClosureOperation<CloudBackupDiff> {
+            let wallets = try walletsOperation.extractNoCancellableResultData()
+            
+            guard let publicData = try decodingOperation.extractNoCancellableResultData() else {
+                return []
+            }
+            
+            return diffManager.calculateBetween(
+                wallets: Set(wallets),
+                publicBackupInfo: publicData
+            )
+        }
+    }
+
+    override func stopSyncUp() {
+        clear(cancellable: &wrapper)
+    }
+}

--- a/novawallet/Common/Services/CloudBackup/Model/CloudBackupDiff+Helper.swift
+++ b/novawallet/Common/Services/CloudBackup/Model/CloudBackupDiff+Helper.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension CloudBackupDiff {
+    func getNewWallets() -> Set<MetaAccountModel> {
+        let newWallets = self.compactMap { change in
+            switch change {
+            case let .new(remote):
+                return remote
+            case .delete, .updatedChainAccounts, .updatedMetadata:
+                return nil
+            }
+        }
+        
+        return Set(newWallets)
+    }
+}

--- a/novawallet/Common/Services/CloudBackup/Model/CloudBackupDiff+Helper.swift
+++ b/novawallet/Common/Services/CloudBackup/Model/CloudBackupDiff+Helper.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 extension CloudBackupDiff {
-    func getNewWallets() -> Set<MetaAccountModel> {
-        let newWallets = self.compactMap { change in
+    func deriveNewWallets() -> Set<MetaAccountModel> {
+        let newWallets: [MetaAccountModel] = compactMap { change in
             switch change {
             case let .new(remote):
                 return remote
@@ -10,7 +10,7 @@ extension CloudBackupDiff {
                 return nil
             }
         }
-        
-        return Set(newWallets)
+
+        return Set<MetaAccountModel>(newWallets)
     }
 }

--- a/novawallet/Common/Services/CloudBackup/Model/CloudBackupDiffing.swift
+++ b/novawallet/Common/Services/CloudBackup/Model/CloudBackupDiffing.swift
@@ -17,11 +17,13 @@ enum CloudBackupChange: Equatable, Hashable {
     case updatedMetadata(local: MetaAccountModel, remote: MetaAccountModel)
 }
 
+typealias CloudBackupDiff = Set<CloudBackupChange>
+
 protocol CloudBackupDiffCalculating {
     func calculateBetween(
         wallets: Set<MetaAccountModel>,
         publicBackupInfo: CloudBackup.PublicData
-    ) throws -> Set<CloudBackupChange>
+    ) throws -> CloudBackupDiff
 }
 
 final class CloudBackupDiffCalculator {

--- a/novawallet/Common/Services/CloudBackup/Model/CloudBackupFileModel.swift
+++ b/novawallet/Common/Services/CloudBackup/Model/CloudBackupFileModel.swift
@@ -90,7 +90,7 @@ extension CloudBackup {
         let privateDate: PrivateData
     }
 
-    struct EncryptedFileModel: Codable {
+    struct EncryptedFileModel: Codable, Equatable {
         let publicData: CloudBackup.PublicData
         let privateData: String
     }

--- a/novawallet/Common/Services/CloudBackup/Model/CloudBackupMetadataManaging.swift
+++ b/novawallet/Common/Services/CloudBackup/Model/CloudBackupMetadataManaging.swift
@@ -2,19 +2,23 @@ import Foundation
 import SoraKeystore
 
 protocol CloudBackupSyncMetadataManaging {
-    func getLastSyncDate() -> Date?
-    func saveLastSyncDate(_ newDate: Date?)
+    func getLastSyncDate() -> UInt64?
+    func saveLastSyncDate(_ newDate: UInt64?)
     func hasLastSyncDate() -> Bool
-    
+
     func getPassword() throws -> String?
     func savePassword(_ newValue: String?) throws
     func hasPassword() throws -> Bool
 }
 
+enum CloudBackupSyncMetadataManagingError: Error {
+    case badArgument
+}
+
 final class CloudBackupSyncMetadataManager {
     let settings: SettingsManagerProtocol
     let keystore: KeystoreProtocol
-    
+
     init(settings: SettingsManagerProtocol, keystore: KeystoreProtocol) {
         self.settings = settings
         self.keystore = keystore
@@ -22,34 +26,39 @@ final class CloudBackupSyncMetadataManager {
 }
 
 extension CloudBackupSyncMetadataManager: CloudBackupSyncMetadataManaging {
-    func getLastSyncDate() -> Date? {
-        let timestamp = settings.lastCloudBackupTimestampSeen
-        
-        return timestamp.map { Date(timeIntervalSince1970: timestamp) }
+    func getLastSyncDate() -> UInt64? {
+        settings.lastCloudBackupTimestampSeen
     }
-    
-    func saveLastSyncDate(_ newDate: Date?) {
-        settings.lastCloudBackupTimestampSeen = newDate?.timeIntervalSince1970
+
+    func saveLastSyncDate(_ newDate: UInt64?) {
+        settings.lastCloudBackupTimestampSeen = newDate
     }
-    
+
     func hasLastSyncDate() -> Bool {
         settings.lastCloudBackupTimestampSeen != nil
     }
-    
+
     func getPassword() throws -> String? {
         guard let rawData = try keystore.loadIfKeyExists(KeystoreTagV2.cloudBackupPassword.rawValue) else {
             return nil
         }
-        
+
         return String(data: rawData, encoding: .utf8)
     }
-    
+
     func savePassword(_ newValue: String?) throws {
-        let rawData = newValue?.data(using: .utf8)
-        try keystore.saveKey(rawData, with: KeystoreTagV2.cloudBackupPassword.rawValue)
+        if let password = newValue {
+            guard let rawData = password.data(using: .utf8) else {
+                throw CloudBackupSyncMetadataManagingError.badArgument
+            }
+
+            try keystore.saveKey(rawData, with: KeystoreTagV2.cloudBackupPassword.rawValue)
+        } else {
+            try keystore.deleteKeyIfExists(for: KeystoreTagV2.cloudBackupPassword.rawValue)
+        }
     }
-    
-    func hasPassword() -> Bool {
+
+    func hasPassword() throws -> Bool {
         try keystore.checkKey(for: KeystoreTagV2.cloudBackupPassword.rawValue)
     }
 }

--- a/novawallet/Common/Services/CloudBackup/Model/CloudBackupMetadataManaging.swift
+++ b/novawallet/Common/Services/CloudBackup/Model/CloudBackupMetadataManaging.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SoraKeystore
+
+protocol CloudBackupSyncMetadataManaging {
+    func getLastSyncDate() -> Date?
+    func saveLastSyncDate(_ newDate: Date?)
+    func hasLastSyncDate() -> Bool
+    
+    func getPassword() throws -> String?
+    func savePassword(_ newValue: String?) throws
+    func hasPassword() throws -> Bool
+}
+
+final class CloudBackupSyncMetadataManager {
+    let settings: SettingsManagerProtocol
+    let keystore: KeystoreProtocol
+    
+    init(settings: SettingsManagerProtocol, keystore: KeystoreProtocol) {
+        self.settings = settings
+        self.keystore = keystore
+    }
+}
+
+extension CloudBackupSyncMetadataManager: CloudBackupSyncMetadataManaging {
+    func getLastSyncDate() -> Date? {
+        let timestamp = settings.lastCloudBackupTimestampSeen
+        
+        return timestamp.map { Date(timeIntervalSince1970: timestamp) }
+    }
+    
+    func saveLastSyncDate(_ newDate: Date?) {
+        settings.lastCloudBackupTimestampSeen = newDate?.timeIntervalSince1970
+    }
+    
+    func hasLastSyncDate() -> Bool {
+        settings.lastCloudBackupTimestampSeen != nil
+    }
+    
+    func getPassword() throws -> String? {
+        guard let rawData = try keystore.loadIfKeyExists(KeystoreTagV2.cloudBackupPassword.rawValue) else {
+            return nil
+        }
+        
+        return String(data: rawData, encoding: .utf8)
+    }
+    
+    func savePassword(_ newValue: String?) throws {
+        let rawData = newValue?.data(using: .utf8)
+        try keystore.saveKey(rawData, with: KeystoreTagV2.cloudBackupPassword.rawValue)
+    }
+    
+    func hasPassword() -> Bool {
+        try keystore.checkKey(for: KeystoreTagV2.cloudBackupPassword.rawValue)
+    }
+}

--- a/novawallet/Common/Services/CloudBackup/Model/CloudBackupMetadataManaging.swift
+++ b/novawallet/Common/Services/CloudBackup/Model/CloudBackupMetadataManaging.swift
@@ -9,6 +9,8 @@ protocol CloudBackupSyncMetadataManaging {
     func getPassword() throws -> String?
     func savePassword(_ newValue: String?) throws
     func hasPassword() throws -> Bool
+
+    var isBackupEnabled: Bool { get set }
 }
 
 enum CloudBackupSyncMetadataManagingError: Error {
@@ -26,6 +28,16 @@ final class CloudBackupSyncMetadataManager {
 }
 
 extension CloudBackupSyncMetadataManager: CloudBackupSyncMetadataManaging {
+    var isBackupEnabled: Bool {
+        get {
+            settings.isCloudBackupEnabled
+        }
+
+        set {
+            settings.isCloudBackupEnabled = newValue
+        }
+    }
+
     func getLastSyncDate() -> UInt64? {
         settings.lastCloudBackupTimestampSeen
     }

--- a/novawallet/Common/Services/CloudBackup/Model/CloudBackupMetadataManaging.swift
+++ b/novawallet/Common/Services/CloudBackup/Model/CloudBackupMetadataManaging.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SoraKeystore
 
-protocol CloudBackupSyncMetadataManaging {
+protocol CloudBackupSyncMetadataManaging: AnyObject {
     func getLastSyncDate() -> UInt64?
     func saveLastSyncDate(_ newDate: UInt64?)
     func hasLastSyncDate() -> Bool

--- a/novawallet/Common/Services/CloudBackup/Model/CloudBackupSyncState.swift
+++ b/novawallet/Common/Services/CloudBackup/Model/CloudBackupSyncState.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum CloudBackupSyncState: Equatable {
+    case disabled
+    case unavailable
+    case enabled(CloudBackupSyncResult?)
+}

--- a/novawallet/Common/Services/CloudBackup/Model/NSPredicate+CloudBackup.swift
+++ b/novawallet/Common/Services/CloudBackup/Model/NSPredicate+CloudBackup.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension NSPredicate {
+    static var cloudSyncableWallets: NSPredicate {
+        let excludedTypes = [MetaAccountModelType.proxied]
+
+        let excludedTypeValues = excludedTypes.map { NSNumber(value: $0.rawValue) }
+
+        return NSPredicate(
+            format: "NOT (%K IN %@)", #keyPath(CDMetaAccount.type),
+            excludedTypeValues
+        )
+    }
+}

--- a/novawallet/Common/Services/CloudBackup/Monitor/CloudBackupUpdateMonitoring.swift
+++ b/novawallet/Common/Services/CloudBackup/Monitor/CloudBackupUpdateMonitoring.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum CloudBackupUpdateMonitorError: Error {
+    case internalError(Error)
+}
+
+enum CloudBackupUpdateStatus {
+    case noFile
+    case downloaded
+    case notDownloaded
+}
+
+typealias CloudBackupUpdateMonitoringClosure = (Result<CloudBackupUpdateStatus, CloudBackupUpdateMonitorError>) -> Void
+
+protocol CloudBackupUpdateMonitoring {
+    func start(with closure: @escaping CloudBackupUpdateMonitoringClosure)
+
+    func stop()
+}

--- a/novawallet/Common/Services/CloudBackup/Monitor/CloudBackupUpdateMonitoring.swift
+++ b/novawallet/Common/Services/CloudBackup/Monitor/CloudBackupUpdateMonitoring.swift
@@ -8,6 +8,7 @@ enum CloudBackupUpdateStatus {
     case noFile
     case downloaded
     case notDownloaded
+    case unknown
 }
 
 typealias CloudBackupUpdateMonitoringClosure = (Result<CloudBackupUpdateStatus, CloudBackupUpdateMonitorError>) -> Void

--- a/novawallet/Common/Services/CloudBackup/Monitor/ICloudBackupUpdateMonitor.swift
+++ b/novawallet/Common/Services/CloudBackup/Monitor/ICloudBackupUpdateMonitor.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+final class ICloudBackupUpdateMonitor {
+    let notificationCenter: NotificationCenter
+    let filename: String
+    let operationQueue: OperationQueue
+    let logger: LoggerProtocol
+
+    private var monitor: NSMetadataQuery?
+
+    private var closure: CloudBackupUpdateMonitoringClosure?
+
+    init(
+        filename: String,
+        operationQueue: OperationQueue, // must be maxConcurrentOperation = 1
+        notificationCenter: NotificationCenter,
+        logger: LoggerProtocol
+    ) {
+        self.notificationCenter = notificationCenter
+        self.operationQueue = operationQueue
+        self.filename = filename
+        self.logger = logger
+    }
+    
+    @objc private func queryDidUpdate(_ notification: Notification) {
+        logger.debug("Query did update \(filename): \(notification)")
+
+        handle(notification: notification)
+    }
+
+    @objc private func queryDidCompleteGathering(_ notification: Notification) {
+        logger.debug("Query did complete gathering \(filename): \(notification)")
+
+        handle(notification: notification)
+    }
+
+    private func handle(notification _: Notification) {
+        guard
+            let monitor,
+            monitor.resultCount > 0,
+            let item = monitor.result(at: 0) as? NSMetadataItem else {
+            closure?(.success(.noFile))
+            logger.warning("No update metadata found for: \(filename)")
+            return
+        }
+
+        let status = item.value(forAttribute: NSMetadataUbiquitousItemDownloadingStatusKey)
+
+        logger.debug("Cloud backup status: \(String(describing: status))")
+        
+        switch status {
+        case nil, 
+            NSMetadataUbiquitousItemDownloadingStatusNotDownloaded,
+            NSMetadataUbiquitousItemDownloadingStatusDownloaded:
+            closure?(.success(.notDownloaded))
+        case NSMetadataUbiquitousItemDownloadingStatusCurrent:
+            closure?(.success(.downloaded))
+        }
+    }
+}
+
+extension ICloudBackupUpdateMonitor: CloudBackupUpdateMonitoring {
+    func start(with closure: @escaping CloudBackupUpdateMonitoringClosure) {
+        guard monitor == nil else {
+            return
+        }
+
+        self.closure = closure
+
+        let metadataQuery = NSMetadataQuery()
+        metadataQuery.predicate = NSPredicate(format: "%K == %@", NSMetadataItemFSNameKey, filename)
+        metadataQuery.searchScopes = [NSMetadataQueryUbiquitousDocumentsScope]
+
+        metadataQuery.operationQueue = operationQueue
+
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(queryDidUpdate(_:)),
+            name: .NSMetadataQueryDidUpdate,
+            object: metadataQuery
+        )
+
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(queryDidCompleteGathering(_:)),
+            name: .NSMetadataQueryDidFinishGathering,
+            object: metadataQuery
+        )
+
+        monitor = metadataQuery
+
+        operationQueue.addOperation {
+            metadataQuery.start()
+        }
+    }
+
+    func stop() {
+        monitor?.stop()
+        monitor = nil
+
+        closure = nil
+    }
+}

--- a/novawallet/Common/Services/CloudBackup/Monitor/ICloudBackupUpdateMonitor.swift
+++ b/novawallet/Common/Services/CloudBackup/Monitor/ICloudBackupUpdateMonitor.swift
@@ -21,7 +21,7 @@ final class ICloudBackupUpdateMonitor {
         self.filename = filename
         self.logger = logger
     }
-    
+
     @objc private func queryDidUpdate(_ notification: Notification) {
         logger.debug("Query did update \(filename): \(notification)")
 
@@ -44,17 +44,19 @@ final class ICloudBackupUpdateMonitor {
             return
         }
 
-        let status = item.value(forAttribute: NSMetadataUbiquitousItemDownloadingStatusKey)
+        let status = item.value(forAttribute: NSMetadataUbiquitousItemDownloadingStatusKey) as? String
 
         logger.debug("Cloud backup status: \(String(describing: status))")
-        
+
         switch status {
-        case nil, 
-            NSMetadataUbiquitousItemDownloadingStatusNotDownloaded,
-            NSMetadataUbiquitousItemDownloadingStatusDownloaded:
+        case nil,
+             NSMetadataUbiquitousItemDownloadingStatusNotDownloaded,
+             NSMetadataUbiquitousItemDownloadingStatusDownloaded:
             closure?(.success(.notDownloaded))
         case NSMetadataUbiquitousItemDownloadingStatusCurrent:
             closure?(.success(.downloaded))
+        default:
+            closure?(.success(.unknown))
         }
     }
 }

--- a/novawallet/Common/Services/CloudBackup/Operations/CloudBackupUpdateApplicationFactory.swift
+++ b/novawallet/Common/Services/CloudBackup/Operations/CloudBackupUpdateApplicationFactory.swift
@@ -1,0 +1,166 @@
+import Foundation
+import RobinHood
+import SoraKeystore
+
+protocol CloudBackupUpdateApplicationFactoryProtocol {
+    func createUpdateApplyOperation(for changes: CloudBackupSyncResult.Changes) -> CompoundOperationWrapper<Void>
+}
+
+enum CloudBackupUpdateApplicationFactoryError: Error {
+    case cloudUnavailable
+    case noRemoteFile
+    case missingPassword
+}
+
+final class CloudBackupUpdateApplicationFactory {
+    let serviceFactory: CloudBackupServiceFactoryProtocol
+    let walletRepositoryFactory: AccountRepositoryFactoryProtocol
+    let walletsUpdater: WalletUpdateMediating
+    let keystore: KeystoreProtocol
+    let syncMetadata: CloudBackupSyncMetadataManaging
+
+    init(
+        serviceFactory: CloudBackupServiceFactoryProtocol,
+        walletRepositoryFactory: AccountRepositoryFactoryProtocol,
+        walletsUpdater: WalletUpdateMediating,
+        keystore: KeystoreProtocol,
+        syncMetadata: CloudBackupSyncMetadataManaging
+    ) {
+        self.serviceFactory = serviceFactory
+        self.walletRepositoryFactory = walletRepositoryFactory
+        self.keystore = keystore
+        self.syncMetadata = syncMetadata
+    }
+    
+    private func createReadWrapper() -> CompoundOperationWrapper<CloudBackup.EncryptedFileModel> {
+        let fileManager = serviceFactory.createFileManager()
+        
+        guard let remoteFileUrl = fileManager.getFileUrl() else {
+            return CompoundOperationWrapper.createWithError(
+                CloudBackupUpdateApplicationFactoryError.cloudUnavailable
+            )
+        }
+        
+        let operationFactory = serviceFactory.createOperationFactory()
+        let readOperation = operationFactory.createReadingOperation(for: remoteFileUrl)
+        
+        let decoder = serviceFactory.createCodingManager()
+        
+        let decoderOperation = ClosureOperation<CloudBackup.EncryptedFileModel> {
+            guard let data = readOperation.extractNoCancellableResultData() else {
+                throw CloudBackupUpdateApplicationFactoryError.noRemoteFile
+            }
+            
+            return decoder.decode(data: data)
+        }
+        
+        decoderOperation.addDependency(readOperation)
+        
+        return CompoundOperationWrapper(targetOperation: decoderOperation, dependencies: [readOperation])
+    }
+    
+    private func createRemoteSecretsImportOperation(
+        for state: CloudBackupSyncResult.State,
+        syncMetadata: CloudBackupSyncMetadataManaging,
+        dependingOn readOperation: BaseOperation<CloudBackup.EncryptedFileModel>
+    ) -> BaseOperation<Void> {
+        let secretsImporter = serviceFactory.createSecretsImporter(to: keystore)
+        
+        return ClosureOperation<Void> {
+            let model = try readOperation.extractNoCancellableResultData()
+            
+            let walletIdsToUpdateSecrets = state.changes.compactMap { change in
+                switch change {
+                case let .new(remote):
+                    return remote.metaId
+                case .updatedChainAccounts(_, let remote, _):
+                    return remote.metaId
+                case .delete, .updatedMetadata:
+                    return nil
+                }
+            }
+            
+            guard !walletIdsToUpdateSecrets.isEmpty else {
+                return
+            }
+            
+            guard let password = syncMetadata.getPassword() else {
+                throw CloudBackupUpdateApplicationFactoryError.missingPassword
+            }
+            
+            try secretsImporter.importBackup(
+                from: model,
+                password: password,
+                onlyWallets: walletIdsToUpdateSecrets
+            )
+        }
+    }
+    
+    private func createUpdateLocalWrapper(
+        for state: CloudBackupSyncResult.State
+    ) -> CompoundOperationWrapper<Void> {
+        let readWrapper = createReadWrapper()
+        let secretsImportOperation = createRemoteSecretsImportOperation(
+            for: state,
+            syncMetadata: syncMetadata,
+            dependingOn: readWrapper.targetOperation
+        )
+        
+        secretsImportOperation.addDependency(readWrapper.targetOperation)
+        
+        let changesOperation = ClosureOperation {
+            _ = secretsImportOperation.extractNoCancellableResultData()
+            
+            let maxOrder = state.localWallets.max(by: { $0.order < $1.order })
+            let walletsById = Array(state.localWallets).reduceToDict()
+            
+            var newOrUpdatedWallets: [ManagedMetaAccountModel] = []
+            var removedWallets: [ManagedMetaAccountModel] = []
+            
+            var nextOrder = maxOrder.map { $0 + 1} ?? 0
+            
+            for change in state.changes {
+                switch change {
+                case let .new(remote):
+                    newOrUpdatedWallets.append(
+                        ManagedMetaAccountModel(
+                            info: remote,
+                            isSelected: false,
+                            order: nextOrder
+                        )
+                    )
+                    
+                    nextOrder += 1
+                case .updatedChainAccounts(_, let remote, _):
+                    if let local = walletsById[remote.metaId] {
+                        newOrUpdatedWallets.append(
+                            ManagedMetaAccountModel(
+                                info: remote,
+                                isSelected: local.isSelected,
+                                order: local.order
+                            )
+                        )
+                    }
+                case .updatedMetadata(_, let remote):
+                    if let local = walletsById[remote.metaId] {
+                        newOrUpdatedWallets.append(
+                            ManagedMetaAccountModel(
+                                info: remote,
+                                isSelected: local.isSelected,
+                                order: local.order
+                            )
+                        )
+                    }
+                case let .delete(local):
+                    if let managed = walletsById[local.metaId] {
+                        removedWallets.append(managed)
+                    }
+                }
+            }
+            
+            return SyncChanges(newOrUpdatedItems: newOrUpdatedWallets, removedItems: removedWallets)
+        }
+        
+        let updateOperation = walletsUpdater.saveChanges({ try changesOperation.extractNoCancellableResultData() })
+    }
+}

--- a/novawallet/Common/Services/CloudBackup/Operations/CloudBackupUpdateCalculationFactory.swift
+++ b/novawallet/Common/Services/CloudBackup/Operations/CloudBackupUpdateCalculationFactory.swift
@@ -10,13 +10,13 @@ enum CloudBackupSyncResult: Equatable {
         let changes: CloudBackupDiff
         let syncTime: UInt64
     }
-    
-    struct UpdateRemote {
+
+    struct UpdateRemote: Equatable {
         let localWallets: Set<ManagedMetaAccountModel>
         let syncTime: UInt64
     }
-    
-    struct UpdateByUnion {
+
+    struct UpdateByUnion: Equatable {
         let localWallets: Set<ManagedMetaAccountModel>
         let remoteModel: CloudBackup.EncryptedFileModel
         let addingWallets: Set<MetaAccountModel>
@@ -83,13 +83,13 @@ final class CloudBackupUpdateCalculationFactory {
                 let wallets = try walletsOperation.extractNoCancellableResultData()
 
                 let syncTime = UInt64(Date().timeIntervalSince1970)
-                
+
                 guard let remoteModel = try decodingOperation.extractNoCancellableResultData() else {
                     let state = CloudBackupSyncResult.UpdateRemote(
-                        localWallets: Set(wallets.map(\.info)),
+                        localWallets: Set(wallets),
                         syncTime: syncTime
                     )
-                    
+
                     return .changes(.updateRemote(state))
                 }
 
@@ -106,10 +106,10 @@ final class CloudBackupUpdateCalculationFactory {
                     let state = CloudBackupSyncResult.UpdateByUnion(
                         localWallets: Set(wallets),
                         remoteModel: remoteModel,
-                        addingWallets: diff.getNewWallets(),
+                        addingWallets: diff.deriveNewWallets(),
                         syncTime: syncTime
                     )
-                    
+
                     return .changes(.updateByUnion(state))
                 }
 
@@ -120,7 +120,7 @@ final class CloudBackupUpdateCalculationFactory {
                         changes: diff,
                         syncTime: syncTime
                     )
-                    
+
                     return .changes(.updateLocal(state))
                 } else {
                     let state = CloudBackupSyncResult.UpdateRemote(localWallets: Set(wallets), syncTime: syncTime)

--- a/novawallet/Common/Services/CloudBackup/Operations/CloudBackupUpdateCalculationFactory.swift
+++ b/novawallet/Common/Services/CloudBackup/Operations/CloudBackupUpdateCalculationFactory.swift
@@ -5,12 +5,12 @@ import IrohaCrypto
 
 enum CloudBackupSyncResult: Equatable {
     struct State: Equatable {
-        let localWallets: Set<MetaAccountModel>
+        let localWallets: Set<ManagedMetaAccountModel>
         let changes: CloudBackupDiff
 
-        static func createFromLocalWallets(_ wallets: Set<MetaAccountModel>) -> Self {
+        static func createFromLocalWallets(_ wallets: Set<ManagedMetaAccountModel>) -> Self {
             let changes = wallets.map { wallet in
-                CloudBackupChange.delete(local: wallet)
+                CloudBackupChange.delete(local: wallet.info)
             }
 
             return .init(localWallets: wallets, changes: Set(changes))
@@ -46,7 +46,7 @@ enum CloudBackupUpdateCalculationError: Error {
 
 final class CloudBackupUpdateCalculationFactory {
     let syncMetadataManager: CloudBackupSyncMetadataManaging
-    let walletsRepository: AnyDataProviderRepository<MetaAccountModel>
+    let walletsRepository: AnyDataProviderRepository<ManagedMetaAccountModel>
     let backupOperationFactory: CloudBackupOperationFactoryProtocol
     let decodingManager: CloudBackupCoding
     let cryptoManager: CloudBackupCryptoManagerProtocol
@@ -54,7 +54,7 @@ final class CloudBackupUpdateCalculationFactory {
 
     init(
         syncMetadataManager: CloudBackupSyncMetadataManaging,
-        walletsRepository: AnyDataProviderRepository<MetaAccountModel>,
+        walletsRepository: AnyDataProviderRepository<ManagedMetaAccountModel>,
         backupOperationFactory: CloudBackupOperationFactoryProtocol,
         decodingManager: CloudBackupCoding,
         cryptoManager: CloudBackupCryptoManagerProtocol,
@@ -69,7 +69,7 @@ final class CloudBackupUpdateCalculationFactory {
     }
 
     private func createDiffOperation(
-        dependingOn walletsOperation: BaseOperation<[MetaAccountModel]>,
+        dependingOn walletsOperation: BaseOperation<[ManagedMetaAccountModel]>,
         decodingOperation: BaseOperation<CloudBackup.PublicData?>
     ) -> ClosureOperation<CloudBackupSyncResult> {
         ClosureOperation<CloudBackupSyncResult> {
@@ -81,7 +81,7 @@ final class CloudBackupUpdateCalculationFactory {
                 }
 
                 let diff = try self.diffManager.calculateBetween(
-                    wallets: Set(wallets),
+                    wallets: Set(wallets.map(\.info)),
                     publicBackupInfo: publicData
                 )
 

--- a/novawallet/Common/Services/CloudBackup/Operations/CloudBackupUpdateCalculationFactory.swift
+++ b/novawallet/Common/Services/CloudBackup/Operations/CloudBackupUpdateCalculationFactory.swift
@@ -1,0 +1,121 @@
+import Foundation
+import RobinHood
+import SoraKeystore
+import IrohaCrypto
+
+enum CloudBackupSyncResult {
+    struct State {
+        let localWallets: Set<MetaAccountModel>
+        let changes: CloudBackupDiff
+        
+        static func createFromLocalWallets(_ wallets: Set<MetaAccountModel>) -> Self {
+            let changes = wallets.map { wallet in
+                CloudBackupChange.delete(local: wallet)
+            }
+            
+            return .init(localWallets: wallets, changes: changes)
+        }
+    }
+    
+    case noUpdates
+    case updateLocal(State)
+    case updateRemote(State)
+}
+
+protocol CloudBackupUpdateCalculationFactoryProtocol {
+    func createUpdateCalculation(for fileUrl: URL) -> CompoundOperationWrapper<CloudBackupSyncResult>
+}
+
+enum CloudBackupUpdateCalculationError {
+    case missingOrInvalidPassword
+}
+
+final class CloudBackupUpdateCalculationFactory {
+    let syncMetadataManager: CloudBackupSyncMetadataManaging
+    let walletsRepository: AnyDataProviderRepository<MetaAccountModel>
+    let backupOperationFactory: CloudBackupOperationFactoryProtocol
+    let decodingManager: CloudBackupCoding
+    let cryptoManager: CloudBackupCryptoManagerProtocol
+    let diffManager: CloudBackupDiffCalculating
+    
+    init(
+        syncMetadataManager: CloudBackupSyncMetadataManaging,
+        walletsRepository: AnyDataProviderRepository<MetaAccountModel>,
+        backupOperationFactory: CloudBackupOperationFactoryProtocol,
+        decodingManager: CloudBackupCoding,
+        cryptoManager: CloudBackupCryptoManagerProtocol,
+        diffManager: CloudBackupDiffCalculating
+    ) {
+        self.syncMetadataManager = syncMetadataManager
+        self.walletsRepository = walletsRepository
+        self.backupOperationFactory = backupOperationFactory
+        self.decodingManager = decodingManager
+        self.cryptoManager = cryptoManager
+        self.diffManager = diffManager
+    }
+}
+
+extension CloudBackupUpdateCalculationFactory: CloudBackupUpdateCalculationFactoryProtocol {
+    func createUpdateCalculation(for fileUrl: URL) -> CompoundOperationWrapper<CloudBackupSyncResult> {
+        let walletsOperation = walletsRepository.fetchAllOperation(with: RepositoryFetchOptions())
+        let remoteFileOperation = backupOperationFactory.createReadingOperation(for: fileUrl)
+        
+        let decodingOperation = ClosureOperation<CloudBackup.PublicData?> {
+            let data = try remoteFileOperation.extractNoCancellableResultData()
+            
+            let optEncryptedModel = try data.map { try self.decodingManager.decode(data: $0) }
+            
+            guard let encryptedModel = optEncryptedModel else {
+                return nil
+            }
+            
+            guard let password = try syncMetadataManager.getPassword() else {
+                throw CloudBackupUpdateCalculationError.missingOrInvalidPassword
+            }
+            
+            let privateData = try Data(hexString: encryptedModel.privateData)
+            _ = try cryptoManager.decrypt(data: privateData, password: password)
+            
+            return encryptedModel.publicData
+        }
+        
+        decodingOperation.addDependency(remoteFileOperation)
+        
+        let diffOperation = ClosureOperation<CloudBackupDiff> {
+            let wallets = try walletsOperation.extractNoCancellableResultData()
+            
+            guard let publicData = try decodingOperation.extractNoCancellableResultData() else {
+                let state = CloudBackupSyncResult.State.createFromLocalWallets(wallets)
+                return .updateRemote(state)
+            }
+            
+            let diff = diffManager.calculateBetween(
+                wallets: Set(wallets),
+                publicBackupInfo: publicData
+            )
+            
+            guard !diff.isEmpty else {
+                return .noUpdates
+            }
+            
+            let state = CloudBackupSyncResult.State(localWallets: wallets, changes: diff)
+            
+            guard let lastSyncTime = syncMetadataManager.getLastSyncDate() else {
+                return .updateRemote(state)
+            }
+            
+            if lastSyncTime < publicData.modificationDate {
+                return .updateLocal(state)
+            } else {
+                return .updateRemote(state)
+            }
+        }
+        
+        diffOperation.addDependency(decodingOperation)
+        
+        return CompoundOperationWrapper(
+            targetOperation: diffOperation,
+            dependencies: [walletsOperation, remoteFileOperation, decodingOperation]
+        )
+    }
+}

--- a/novawallet/Common/Services/CloudBackup/Operations/CloudBackupUpdateCalculationFactory.swift
+++ b/novawallet/Common/Services/CloudBackup/Operations/CloudBackupUpdateCalculationFactory.swift
@@ -3,20 +3,20 @@ import RobinHood
 import SoraKeystore
 import IrohaCrypto
 
-enum CloudBackupSyncResult {
-    struct State {
+enum CloudBackupSyncResult: Equatable {
+    struct State: Equatable {
         let localWallets: Set<MetaAccountModel>
         let changes: CloudBackupDiff
-        
+
         static func createFromLocalWallets(_ wallets: Set<MetaAccountModel>) -> Self {
             let changes = wallets.map { wallet in
                 CloudBackupChange.delete(local: wallet)
             }
-            
-            return .init(localWallets: wallets, changes: changes)
+
+            return .init(localWallets: wallets, changes: Set(changes))
         }
     }
-    
+
     case noUpdates
     case updateLocal(State)
     case updateRemote(State)
@@ -26,7 +26,7 @@ protocol CloudBackupUpdateCalculationFactoryProtocol {
     func createUpdateCalculation(for fileUrl: URL) -> CompoundOperationWrapper<CloudBackupSyncResult>
 }
 
-enum CloudBackupUpdateCalculationError {
+enum CloudBackupUpdateCalculationError: Error {
     case missingOrInvalidPassword
 }
 
@@ -37,7 +37,7 @@ final class CloudBackupUpdateCalculationFactory {
     let decodingManager: CloudBackupCoding
     let cryptoManager: CloudBackupCryptoManagerProtocol
     let diffManager: CloudBackupDiffCalculating
-    
+
     init(
         syncMetadataManager: CloudBackupSyncMetadataManaging,
         walletsRepository: AnyDataProviderRepository<MetaAccountModel>,
@@ -59,60 +59,60 @@ extension CloudBackupUpdateCalculationFactory: CloudBackupUpdateCalculationFacto
     func createUpdateCalculation(for fileUrl: URL) -> CompoundOperationWrapper<CloudBackupSyncResult> {
         let walletsOperation = walletsRepository.fetchAllOperation(with: RepositoryFetchOptions())
         let remoteFileOperation = backupOperationFactory.createReadingOperation(for: fileUrl)
-        
+
         let decodingOperation = ClosureOperation<CloudBackup.PublicData?> {
             let data = try remoteFileOperation.extractNoCancellableResultData()
-            
+
             let optEncryptedModel = try data.map { try self.decodingManager.decode(data: $0) }
-            
+
             guard let encryptedModel = optEncryptedModel else {
                 return nil
             }
-            
-            guard let password = try syncMetadataManager.getPassword() else {
+
+            guard let password = try self.syncMetadataManager.getPassword() else {
                 throw CloudBackupUpdateCalculationError.missingOrInvalidPassword
             }
-            
+
             let privateData = try Data(hexString: encryptedModel.privateData)
-            _ = try cryptoManager.decrypt(data: privateData, password: password)
-            
+            _ = try self.cryptoManager.decrypt(data: privateData, password: password)
+
             return encryptedModel.publicData
         }
-        
+
         decodingOperation.addDependency(remoteFileOperation)
-        
-        let diffOperation = ClosureOperation<CloudBackupDiff> {
+
+        let diffOperation = ClosureOperation<CloudBackupSyncResult> {
             let wallets = try walletsOperation.extractNoCancellableResultData()
-            
+
             guard let publicData = try decodingOperation.extractNoCancellableResultData() else {
-                let state = CloudBackupSyncResult.State.createFromLocalWallets(wallets)
+                let state = CloudBackupSyncResult.State.createFromLocalWallets(Set(wallets))
                 return .updateRemote(state)
             }
-            
-            let diff = diffManager.calculateBetween(
+
+            let diff = try self.diffManager.calculateBetween(
                 wallets: Set(wallets),
                 publicBackupInfo: publicData
             )
-            
+
             guard !diff.isEmpty else {
                 return .noUpdates
             }
-            
-            let state = CloudBackupSyncResult.State(localWallets: wallets, changes: diff)
-            
-            guard let lastSyncTime = syncMetadataManager.getLastSyncDate() else {
-                return .updateRemote(state)
+
+            let state = CloudBackupSyncResult.State(localWallets: Set(wallets), changes: diff)
+
+            guard let lastSyncTime = self.syncMetadataManager.getLastSyncDate() else {
+                return .updateLocal(state)
             }
-            
-            if lastSyncTime < publicData.modificationDate {
+
+            if lastSyncTime < publicData.modifiedAt {
                 return .updateLocal(state)
             } else {
                 return .updateRemote(state)
             }
         }
-        
+
         diffOperation.addDependency(decodingOperation)
-        
+
         return CompoundOperationWrapper(
             targetOperation: diffOperation,
             dependencies: [walletsOperation, remoteFileOperation, decodingOperation]

--- a/novawallet/Modules/CloudBackup/CloudBackupCreate/CloudBackupCreateInteractor.swift
+++ b/novawallet/Modules/CloudBackup/CloudBackupCreate/CloudBackupCreateInteractor.swift
@@ -33,7 +33,7 @@ final class CloudBackupCreateInteractor {
         password: String,
         proxyKeystore: KeychainProxyProtocol
     ) {
-        cloudBackupFacade.enableBackup(
+        cloudBackupFacade.createBackup(
             wallets: [wallet],
             keystore: proxyKeystore,
             password: password,

--- a/novawalletIntegrationTests/CloudBackup/CloudBackupFacadeTests.swift
+++ b/novawalletIntegrationTests/CloudBackup/CloudBackupFacadeTests.swift
@@ -4,7 +4,7 @@ import SoraKeystore
 import IrohaCrypto
 
 final class CloudBackupFacadeTests: XCTestCase {
-    func testEnableBackup() {
+    func testCreateBackup() {
         do {
             // given
             let keystore = InMemoryKeychain()
@@ -28,7 +28,7 @@ final class CloudBackupFacadeTests: XCTestCase {
             let expectation = XCTestExpectation()
             var operationResult: Result<Void, CloudBackupServiceFacadeError>?
             
-            facade.enableBackup(
+            facade.createBackup(
                 wallets: [wallet],
                 keystore: keystore,
                 password: password,


### PR DESCRIPTION
The aim of the PR is to define an architecture of how interactions will communicate with Cloud Backup syncing:

- ```CloudBackupSyncService``` maintains the state of the latest diff attempt between local wallets and remote wallets. It is automatically triggered when ```setup``` is called and ```syncUp``` can be called later on to trigger a new sync;
-  ```CloudBackupSyncServiceFacade``` offers an interface to enable/disable cloud backup and allows to subscribe to that state. Automatically, creates ```CloudBackupSyncService``` when backup is enabled and clears it when disabled. It creates a monitor to automatically detect new remote file and trigger sync up. And finally, one can use ```syncUp``` method to automatically trigger syncing, for example, when wallets changed locally.
- ```CloudBackupSyncService``` uses ```CloudBackupUpdateCalculationFactory``` to calculate diff between local list of wallets and remote one. ```CloudBackupUpdateCalculationFactory``` automatically detects issues and reflects them in the result ```CloudBackupSyncResult```.
- If ```CloudBackupSyncResult``` contains changes then those can be applied using ```CloudBackupUpdateApplicationFactory```. ```CloudBackupUpdateApplicationFactory``` handles 3 cases: 
1) when the local list of the wallets out of date and we need to apply changes from remote;
2) when remote wallets out of date and we need to push local wallets
3) when backup is enabled on the device with existing wallets and we need to union local wallets with remote ones. Here there is a decision that if there is a wallet with the same id in both sets the we are prefer local one.

- in result we either update local wallets or remote file that will trigger sync service again and in the happy path scenario it will emit ```CloudBackupSyncResult.noUpdates```. In the worst case we will ask a user to resolve ```CloudBackupSyncResult.issue```.

