### PR TITLE
Fix Ledger call vector limits

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -514,6 +514,8 @@
 		0CE632A12B9035B2002E4D20 /* Web3Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE632A02B9035B2002E4D20 /* Web3Alert.swift */; };
 		0CE632A32B904449002E4D20 /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE632A22B904449002E4D20 /* PushNotification.swift */; };
 		0CE92A672B2ADBBA009A21E9 /* RuntimeProviderChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE92A662B2ADBBA009A21E9 /* RuntimeProviderChain.swift */; };
+		0CE9338E2C019998000F3EFE /* MetaAccountModelType+ExtrinsicLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE9338D2C019998000F3EFE /* MetaAccountModelType+ExtrinsicLimit.swift */; };
+		0CE933902C01A009000F3EFE /* ExtrinsicServiceTypes+Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE9338F2C01A009000F3EFE /* ExtrinsicServiceTypes+Conversion.swift */; };
 		0CEB4ED12AF14B8B0048FD84 /* SubmoduleNavigationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB4ED02AF14B8B0048FD84 /* SubmoduleNavigationStrategy.swift */; };
 		0CEB4ED32AF1689D0048FD84 /* AssetConversionAggregationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB4ED22AF1689D0048FD84 /* AssetConversionAggregationFactory.swift */; };
 		0CEB4ED52AF20EB90048FD84 /* CancellableCallHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB4ED42AF20EB90048FD84 /* CancellableCallHelper.swift */; };
@@ -5121,6 +5123,8 @@
 		0CE632A02B9035B2002E4D20 /* Web3Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Web3Alert.swift; sourceTree = "<group>"; };
 		0CE632A22B904449002E4D20 /* PushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotification.swift; sourceTree = "<group>"; };
 		0CE92A662B2ADBBA009A21E9 /* RuntimeProviderChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeProviderChain.swift; sourceTree = "<group>"; };
+		0CE9338D2C019998000F3EFE /* MetaAccountModelType+ExtrinsicLimit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MetaAccountModelType+ExtrinsicLimit.swift"; sourceTree = "<group>"; };
+		0CE9338F2C01A009000F3EFE /* ExtrinsicServiceTypes+Conversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExtrinsicServiceTypes+Conversion.swift"; sourceTree = "<group>"; };
 		0CEB4ECF2AF148500048FD84 /* SubstrateDataModel20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SubstrateDataModel20.xcdatamodel; sourceTree = "<group>"; };
 		0CEB4ED02AF14B8B0048FD84 /* SubmoduleNavigationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmoduleNavigationStrategy.swift; sourceTree = "<group>"; };
 		0CEB4ED22AF1689D0048FD84 /* AssetConversionAggregationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetConversionAggregationFactory.swift; sourceTree = "<group>"; };
@@ -16456,6 +16460,7 @@
 				0C8AF7A92B33455A00005AC9 /* ExtrinsicFee.swift */,
 				0C0E0A942B3E89D200865F10 /* ExtrinsicWrapperResult.swift */,
 				0C0E0A9A2B3E8C8A00865F10 /* ExtrinsicSigningContext.swift */,
+				0CE9338F2C01A009000F3EFE /* ExtrinsicServiceTypes+Conversion.swift */,
 			);
 			path = Substrate;
 			sourceTree = "<group>";
@@ -17223,6 +17228,7 @@
 				845B821E26EF8E8900D25C72 /* ManagedMetaAccountModel.swift */,
 				77D2ED6A2B1DD78100A0E58C /* ProxyAccountModel.swift */,
 				0C37AFC72B59815500009ECA /* ProxiedSettings.swift */,
+				0CE9338D2C019998000F3EFE /* MetaAccountModelType+ExtrinsicLimit.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -21974,6 +21980,7 @@
 				8428766724ADF22000D91AD8 /* TransformAnimator+Common.swift in Sources */,
 				8419F054295ED55000A14E05 /* LocalChainExternalApi.swift in Sources */,
 				8476D39F27F4582A004D9A7A /* DAppMetamaskPhishingDetectedState.swift in Sources */,
+				0CE9338E2C019998000F3EFE /* MetaAccountModelType+ExtrinsicLimit.swift in Sources */,
 				77F9FB0D2A9D9C5600820625 /* NominationPoolBondMoreBaseProtocols.swift in Sources */,
 				AEFC6D6F2600D7CD000BD310 /* NetworkInfoViewModelFactory.swift in Sources */,
 				84AA004526C6A04A00BCB4DC /* CommonTypesSyncService.swift in Sources */,
@@ -24522,6 +24529,7 @@
 				F4FDA0FD26A57860003D753B /* EraCountdown.swift in Sources */,
 				844CB56C26F9C5C900396E13 /* WalletLocalSubscriptionHandler.swift in Sources */,
 				AEA0C8B6267BABCC00F9666F /* SelectedValidatorListViewModel.swift in Sources */,
+				0CE933902C01A009000F3EFE /* ExtrinsicServiceTypes+Conversion.swift in Sources */,
 				84AEEE6C27A92AEF005EBA77 /* AssetListFlowLayout.swift in Sources */,
 				8410D6972815DE3300B83CF7 /* IconDetails+Hint.swift in Sources */,
 				4FBD73DD27CAA339727616B5 /* StakingUnbondSetupPresenter.swift in Sources */,

--- a/novawallet/Common/Model/ChainRegistry/Account/MetaAccountModelType+ExtrinsicLimit.swift
+++ b/novawallet/Common/Model/ChainRegistry/Account/MetaAccountModelType+ExtrinsicLimit.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension MetaAccountModelType {
+    var maxCallsPerExtrinsic: Int? {
+        switch self {
+        case .ledger:
+            // took min value from this https://github.com/Zondax/ledger-polkadot/blob/main/app/src/parser_txdef.h#L31
+            return 5
+        case .secrets, .watchOnly, .paritySigner, .polkadotVault, .proxied:
+            return nil
+        }
+    }
+}

--- a/novawallet/Common/Model/ChainRegistry/Account/MetaAccountModelType+ExtrinsicLimit.swift
+++ b/novawallet/Common/Model/ChainRegistry/Account/MetaAccountModelType+ExtrinsicLimit.swift
@@ -4,8 +4,8 @@ extension MetaAccountModelType {
     var maxCallsPerExtrinsic: Int? {
         switch self {
         case .ledger:
-            // took min value from this https://github.com/Zondax/ledger-polkadot/blob/main/app/src/parser_txdef.h#L31
-            return 5
+            // https://github.com/Zondax/ledger-polkadot/blob/main/app/src/parser_txdef.h#L28
+            return 6
         case .secrets, .watchOnly, .paritySigner, .polkadotVault, .proxied:
             return nil
         }

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicServiceTypes+Conversion.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicServiceTypes+Conversion.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension FeeIndexedExtrinsicResult {
+    func convertToTotalFee() -> FeeExtrinsicResult {
+        do {
+            let totalFee = try results.map(\.result).reduce(ExtrinsicFee.zero()) { accum, result in
+                let newFeeInfo = try result.get()
+                return ExtrinsicFee(
+                    amount: newFeeInfo.amount + accum.amount,
+                    payer: newFeeInfo.payer,
+                    weight: newFeeInfo.weight + accum.weight
+                )
+            }
+
+            return .success(totalFee)
+        } catch {
+            return .failure(error)
+        }
+    }
+}

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicSplitter.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicSplitter.swift
@@ -153,7 +153,7 @@ final class ExtrinsicSplitter {
                 }
 
                 let maxCallsExceeded = if let maxCallsPerExtrinsic {
-                    targetCalls.count < maxCallsPerExtrinsic
+                    targetCalls.count >= maxCallsPerExtrinsic
                 } else {
                     false
                 }

--- a/novawallet/Modules/Ledger/TxConfirmation/LedgerTxConfirmPresenter.swift
+++ b/novawallet/Modules/Ledger/TxConfirmation/LedgerTxConfirmPresenter.swift
@@ -42,9 +42,9 @@ final class LedgerTxConfirmPresenter: LedgerPerformOperationPresenter {
     }
 
     private func performCancellation() {
-        wireframe?.complete(on: view)
-
-        completion(.failure(HardwareSigningError.signingCancelled))
+        wireframe?.complete(on: view) {
+            self.completion(.failure(HardwareSigningError.signingCancelled))
+        }
     }
 
     override func handleAppConnection(error: Error, deviceId: UUID) {
@@ -128,8 +128,9 @@ extension LedgerTxConfirmPresenter: LedgerTxConfirmInteractorOutputProtocol {
             }
 
             wireframe?.closeMessageSheet(on: view)
-            wireframe?.complete(on: view)
-            completion(.success(signature))
+            wireframe?.complete(on: view) {
+                self.completion(.success(signature))
+            }
         case let .failure(error):
             stopConnecting()
 

--- a/novawallet/Modules/Ledger/TxConfirmation/LedgerTxConfirmProtocols.swift
+++ b/novawallet/Modules/Ledger/TxConfirmation/LedgerTxConfirmProtocols.swift
@@ -15,7 +15,7 @@ protocol LedgerTxConfirmInteractorOutputProtocol: LedgerPerformOperationOutputPr
 }
 
 protocol LedgerTxConfirmWireframeProtocol: LedgerPerformOperationWireframeProtocol {
-    func complete(on view: ControllerBackedProtocol?)
+    func complete(on view: ControllerBackedProtocol?, completionClosure: @escaping () -> Void)
 
     func transitToTransactionReview(
         on view: ControllerBackedProtocol?,

--- a/novawallet/Modules/Ledger/TxConfirmation/LedgerTxConfirmWireframe.swift
+++ b/novawallet/Modules/Ledger/TxConfirmation/LedgerTxConfirmWireframe.swift
@@ -3,8 +3,8 @@ import SoraUI
 import SoraFoundation
 
 final class LedgerTxConfirmWireframe: LedgerTxConfirmWireframeProtocol {
-    func complete(on view: ControllerBackedProtocol?) {
-        view?.controller.dismiss(animated: true)
+    func complete(on view: ControllerBackedProtocol?, completionClosure: @escaping () -> Void) {
+        view?.controller.dismiss(animated: true, completion: completionClosure)
     }
 
     func transitToTransactionReview(

--- a/novawallet/Modules/Staking/StakingPayoutConfirmation/StakingPayoutConfirmationInteractor.swift
+++ b/novawallet/Modules/Staking/StakingPayoutConfirmation/StakingPayoutConfirmationInteractor.swift
@@ -63,7 +63,11 @@ final class StakingPayoutConfirmationInteractor {
             throw CommonError.dataCorruption
         }
 
-        var splitter: ExtrinsicSplitting = ExtrinsicSplitter(chain: chainAsset.chain, chainRegistry: chainRegistry)
+        var splitter: ExtrinsicSplitting = ExtrinsicSplitter(
+            chain: chainAsset.chain,
+            maxCallsPerExtrinsic: selectedAccount.chainAccount.type.maxCallsPerExtrinsic,
+            chainRegistry: chainRegistry
+        )
 
         splitter = try payouts.reduce(splitter) { accum, payout in
             try Staking.PayoutCall.appendingCall(

--- a/novawallet/Modules/Vote/Governance/Delegations/Delegate/GovernanceDelegateInteractor.swift
+++ b/novawallet/Modules/Vote/Governance/Delegations/Delegate/GovernanceDelegateInteractor.swift
@@ -171,7 +171,12 @@ class GovernanceDelegateInteractor: AnyCancellableCleaning {
     }
 
     func createExtrinsicSplitter(for actions: [GovernanceDelegatorAction]) throws -> ExtrinsicSplitting {
-        let splitter = ExtrinsicSplitter(chain: chain, chainRegistry: chainRegistry)
+        let splitter = ExtrinsicSplitter(
+            chain: chain,
+            maxCallsPerExtrinsic: selectedAccount.chainAccount.type.maxCallsPerExtrinsic,
+            chainRegistry: chainRegistry
+        )
+
         return try extrinsicFactory.delegationUpdate(with: actions, splitter: splitter)
     }
 

--- a/novawallet/Modules/Vote/Governance/GovernanceRemoveVotesConfirm/GovernanceRemoveVotesConfirmInteractor.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceRemoveVotesConfirm/GovernanceRemoveVotesConfirmInteractor.swift
@@ -7,6 +7,7 @@ final class GovernanceRemoveVotesConfirmInteractor: AnyProviderAutoCleaning {
 
     let selectedAccount: ChainAccountResponse
     let chain: ChainModel
+    let chainRegistry: ChainRegistryProtocol
     let subscriptionFactory: GovernanceSubscriptionFactoryProtocol
     let walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol
     let priceLocalSubscriptionFactory: PriceProviderFactoryProtocol
@@ -20,6 +21,7 @@ final class GovernanceRemoveVotesConfirmInteractor: AnyProviderAutoCleaning {
     init(
         selectedAccount: ChainAccountResponse,
         chain: ChainModel,
+        chainRegistry: ChainRegistryProtocol,
         subscriptionFactory: GovernanceSubscriptionFactoryProtocol,
         walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol,
         priceLocalSubscriptionFactory: PriceProviderFactoryProtocol,
@@ -30,6 +32,7 @@ final class GovernanceRemoveVotesConfirmInteractor: AnyProviderAutoCleaning {
     ) {
         self.selectedAccount = selectedAccount
         self.chain = chain
+        self.chainRegistry = chainRegistry
         self.subscriptionFactory = subscriptionFactory
         self.walletLocalSubscriptionFactory = walletLocalSubscriptionFactory
         self.priceLocalSubscriptionFactory = priceLocalSubscriptionFactory
@@ -90,9 +93,9 @@ final class GovernanceRemoveVotesConfirmInteractor: AnyProviderAutoCleaning {
         }
     }
 
-    private func createExtrinsicBuilderClosure(
+    private func createExtrinsicSplitter(
         for requests: [GovernanceRemoveVoteRequest]
-    ) -> ExtrinsicBuilderClosure {
+    ) throws -> ExtrinsicSplitting {
         let actions = requests.map { request in
             GovernanceUnlockSchedule.Action.unvote(
                 track: request.trackId,
@@ -100,17 +103,21 @@ final class GovernanceRemoveVotesConfirmInteractor: AnyProviderAutoCleaning {
             )
         }
 
-        return { [weak self] builder in
-            guard let strongSelf = self else {
-                return builder
-            }
+        let splitter = ExtrinsicSplitter(
+            chain: chain,
+            maxCallsPerExtrinsic: selectedAccount.type.maxCallsPerExtrinsic,
+            chainRegistry: chainRegistry
+        )
 
-            return try strongSelf.extrinsicFactory.unlock(
-                with: Set(actions),
-                accountId: strongSelf.selectedAccount.accountId,
-                builder: builder
-            )
-        }
+        return try extrinsicFactory.unlock(
+            with: Set(actions),
+            accountId: selectedAccount.accountId,
+            splitter: splitter
+        )
+    }
+
+    func handleMultiExtrinsicSubmission(result: SubmitIndexedExtrinsicResult) {
+        presenter?.didReceiveSubmissionResult(result)
     }
 }
 
@@ -122,28 +129,38 @@ extension GovernanceRemoveVotesConfirmInteractor: GovernanceRemoveVotesConfirmIn
     }
 
     func estimateFee(for requests: [GovernanceRemoveVoteRequest]) {
-        let closure = createExtrinsicBuilderClosure(for: requests)
+        do {
+            let splitter = try createExtrinsicSplitter(for: requests)
 
-        extrinsicService.estimateFee(closure, runningIn: .main) { [weak self] feeResult in
-            switch feeResult {
-            case let .success(info):
-                self?.presenter?.didReceiveFee(info)
-            case let .failure(error):
-                self?.presenter?.didReceiveError(.feeFetchFailed(error))
+            extrinsicService.estimateFeeWithSplitter(
+                splitter,
+                runningIn: .main
+            ) { [weak self] result in
+                switch result.convertToTotalFee() {
+                case let .success(fee):
+                    self?.presenter?.didReceiveFee(fee)
+                case let .failure(error):
+                    self?.presenter?.didReceiveError(.feeFetchFailed(error))
+                }
             }
+        } catch {
+            presenter?.didReceiveError(.feeFetchFailed(error))
         }
     }
 
     func submit(requests: [GovernanceRemoveVoteRequest]) {
-        let closure = createExtrinsicBuilderClosure(for: requests)
+        do {
+            let splitter = try createExtrinsicSplitter(for: requests)
 
-        extrinsicService.submit(closure, signer: signer, runningIn: .main) { [weak self] result in
-            switch result {
-            case let .success(hash):
-                self?.presenter?.didReceiveRemoveVotesHash(hash)
-            case let .failure(error):
-                self?.presenter?.didReceiveError(.removeVotesFailed(error))
+            extrinsicService.submitWithTxSplitter(
+                splitter,
+                signer: signer,
+                runningIn: .main
+            ) { [weak self] result in
+                self?.handleMultiExtrinsicSubmission(result: result)
             }
+        } catch {
+            presenter?.didReceiveError(.removeVotesFailed(error))
         }
     }
 

--- a/novawallet/Modules/Vote/Governance/GovernanceRemoveVotesConfirm/GovernanceRemoveVotesConfirmProtocols.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceRemoveVotesConfirm/GovernanceRemoveVotesConfirmProtocols.swift
@@ -15,7 +15,7 @@ protocol GovernanceRemoveVotesConfirmPresenterProtocol: AnyObject {
     func confirm()
 }
 
-protocol GovernanceRemoveVotesConfirmInteractorInputProtocol: AnyObject {
+protocol GovernanceRemoveVotesConfirmInteractorInputProtocol: MultiExtrinsicSubmitRetryInputProtocol {
     func setup()
     func estimateFee(for requests: [GovernanceRemoveVoteRequest])
     func submit(requests: [GovernanceRemoveVoteRequest])
@@ -26,16 +26,19 @@ protocol GovernanceRemoveVotesConfirmInteractorOutputProtocol: AnyObject {
     func didReceiveVotingResult(_ result: CallbackStorageSubscriptionResult<ReferendumTracksVotingDistribution>)
     func didReceiveBalance(_ assetBalance: AssetBalance?)
     func didReceivePrice(_ price: PriceData?)
-    func didReceiveRemoveVotesHash(_ hash: String)
+    func didReceiveSubmissionResult(_ result: SubmitIndexedExtrinsicResult)
     func didReceiveFee(_ fee: ExtrinsicFeeProtocol)
     func didReceiveError(_ error: GovernanceRemoveVotesInteractorError)
 }
 
 protocol GovernanceRemoveVotesConfirmWireframeProtocol: AlertPresentable, ErrorPresentable,
     CommonRetryable, FeeRetryable, MessageSheetPresentable, AddressOptionsPresentable,
-    ExtrinsicSubmissionPresenting, GovernanceErrorPresentable, ExtrinsicSigningErrorHandling {
+    ExtrinsicSubmissionPresenting, GovernanceErrorPresentable, ExtrinsicSigningErrorHandling, MultiExtrinsicRetryable {
     func showTracks(
         from view: GovernanceRemoveVotesConfirmViewProtocol?,
         tracks: [GovernanceTrackInfoLocal]
     )
+
+    func complete(on view: GovernanceRemoveVotesConfirmViewProtocol?, locale: Locale)
+    func skip(on view: GovernanceRemoveVotesConfirmViewProtocol?)
 }

--- a/novawallet/Modules/Vote/Governance/GovernanceRemoveVotesConfirm/GovernanceRemoveVotesConfirmViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceRemoveVotesConfirm/GovernanceRemoveVotesConfirmViewFactory.swift
@@ -104,6 +104,7 @@ struct GovernanceRemoveVotesConfirmViewFactory {
         return GovernanceRemoveVotesConfirmInteractor(
             selectedAccount: selectedAccount.chainAccount,
             chain: chain,
+            chainRegistry: state.chainRegistry,
             subscriptionFactory: subscriptionFactory,
             walletLocalSubscriptionFactory: WalletLocalSubscriptionFactory.shared,
             priceLocalSubscriptionFactory: PriceProviderFactory.shared,

--- a/novawallet/Modules/Vote/Governance/GovernanceRemoveVotesConfirm/GovernanceRemoveVotesConfirmWireframe.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceRemoveVotesConfirm/GovernanceRemoveVotesConfirmWireframe.swift
@@ -27,4 +27,12 @@ final class GovRemoveVotesConfirmWireframe: GovernanceRemoveVotesConfirmWirefram
 
         view?.controller.present(tracksView.controller, animated: true)
     }
+
+    func complete(on view: GovernanceRemoveVotesConfirmViewProtocol?, locale: Locale) {
+        presentExtrinsicSubmission(from: view, completionAction: .popBack, locale: locale)
+    }
+
+    func skip(on view: GovernanceRemoveVotesConfirmViewProtocol?) {
+        view?.controller.navigationController?.popViewController(animated: true)
+    }
 }

--- a/novawallet/Modules/Vote/Governance/GovernanceUnlockConfirm/GovernanceUnlockConfirmInteractor.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceUnlockConfirm/GovernanceUnlockConfirmInteractor.swift
@@ -17,6 +17,7 @@ final class GovernanceUnlockConfirmInteractor: GovernanceUnlockInteractor, AnyPr
     let walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol
     let extrinsicFactory: GovernanceExtrinsicFactoryProtocol
     let extrinsicService: ExtrinsicServiceProtocol
+    let chainRegistry: ChainRegistryProtocol
     let signer: SigningWrapperProtocol
 
     private var locksSubscription: StreamableProvider<AssetLock>?
@@ -24,6 +25,7 @@ final class GovernanceUnlockConfirmInteractor: GovernanceUnlockInteractor, AnyPr
 
     init(
         chain: ChainModel,
+        chainRegistry: ChainRegistryProtocol,
         selectedAccount: MetaChainAccountResponse,
         subscriptionFactory: GovernanceSubscriptionFactoryProtocol,
         lockStateFactory: GovernanceLockStateFactoryProtocol,
@@ -40,6 +42,7 @@ final class GovernanceUnlockConfirmInteractor: GovernanceUnlockInteractor, AnyPr
         operationQueue: OperationQueue,
         currencyManager: CurrencyManagerProtocol
     ) {
+        self.chainRegistry = chainRegistry
         self.walletLocalSubscriptionFactory = walletLocalSubscriptionFactory
         self.extrinsicFactory = extrinsicFactory
         self.extrinsicService = extrinsicService
@@ -89,20 +92,18 @@ final class GovernanceUnlockConfirmInteractor: GovernanceUnlockInteractor, AnyPr
         )
     }
 
-    private func createExtrinsicBuilderClosure(
-        for actions: Set<GovernanceUnlockSchedule.Action>
-    ) -> ExtrinsicBuilderClosure {
-        { [weak self] builder in
-            guard let strongSelf = self else {
-                return builder
-            }
+    func createExtrinsicSplitter(for actions: Set<GovernanceUnlockSchedule.Action>) throws -> ExtrinsicSplitting {
+        let splitter = ExtrinsicSplitter(
+            chain: chain,
+            maxCallsPerExtrinsic: selectedAccount.chainAccount.type.maxCallsPerExtrinsic,
+            chainRegistry: chainRegistry
+        )
 
-            return try strongSelf.extrinsicFactory.unlock(
-                with: actions,
-                accountId: strongSelf.selectedAccount.chainAccount.accountId,
-                builder: builder
-            )
-        }
+        return try extrinsicFactory.unlock(
+            with: actions,
+            accountId: selectedAccount.chainAccount.accountId,
+            splitter: splitter
+        )
     }
 
     private func makeSubscription() {
@@ -121,32 +122,46 @@ final class GovernanceUnlockConfirmInteractor: GovernanceUnlockInteractor, AnyPr
 
         makeSubscription()
     }
+
+    func handleMultiExtrinsicSubmission(result: SubmitIndexedExtrinsicResult) {
+        presenter?.didReceiveSubmissionResult(result)
+    }
 }
 
 extension GovernanceUnlockConfirmInteractor: GovernanceUnlockConfirmInteractorInputProtocol {
     func estimateFee(for actions: Set<GovernanceUnlockSchedule.Action>) {
-        let closure = createExtrinsicBuilderClosure(for: actions)
+        do {
+            let extrinsicSplitter = try createExtrinsicSplitter(for: actions)
 
-        extrinsicService.estimateFee(closure, runningIn: .main) { [weak self] result in
-            switch result {
-            case let .success(feeInfo):
-                self?.presenter?.didReceiveFee(feeInfo)
-            case let .failure(error):
-                self?.presenter?.didReceiveError(.feeFetchFailed(error))
+            extrinsicService.estimateFeeWithSplitter(
+                extrinsicSplitter,
+                runningIn: .main
+            ) { [weak self] result in
+                switch result.convertToTotalFee() {
+                case let .success(feeInfo):
+                    self?.presenter?.didReceiveFee(feeInfo)
+                case let .failure(error):
+                    self?.presenter?.didReceiveError(.feeFetchFailed(error))
+                }
             }
+        } catch {
+            presenter?.didReceiveError(.feeFetchFailed(error))
         }
     }
 
     func unlock(using actions: Set<GovernanceUnlockSchedule.Action>) {
-        let closure = createExtrinsicBuilderClosure(for: actions)
+        do {
+            let extrinsicSplitter = try createExtrinsicSplitter(for: actions)
 
-        extrinsicService.submit(closure, signer: signer, runningIn: .main) { [weak self] result in
-            switch result {
-            case let .success(hashString):
-                self?.presenter?.didReceiveUnlockHash(hashString)
-            case let .failure(error):
-                self?.presenter?.didReceiveError(.unlockFailed(error))
+            extrinsicService.submitWithTxSplitter(
+                extrinsicSplitter,
+                signer: signer,
+                runningIn: .main
+            ) { [weak self] result in
+                self?.handleMultiExtrinsicSubmission(result: result)
             }
+        } catch {
+            presenter?.didReceiveError(.unlockFailed(error))
         }
     }
 }

--- a/novawallet/Modules/Vote/Governance/GovernanceUnlockConfirm/GovernanceUnlockConfirmPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceUnlockConfirm/GovernanceUnlockConfirmPresenter.swift
@@ -253,10 +253,34 @@ extension GovernanceUnlockConfirmPresenter: GovernanceUnlockConfirmInteractorOut
         provideChangesViewModels()
     }
 
-    func didReceiveUnlockHash(_: String) {
+    func didReceiveSubmissionResult(_ result: SubmitIndexedExtrinsicResult) {
         view?.didStopLoading()
 
-        wireframe.presentExtrinsicSubmission(from: view, completionAction: .dismiss, locale: selectedLocale)
+        let handlers = MultiExtrinsicResultActions(
+            onSuccess: { [weak self] in
+                guard let strongSelf = self else {
+                    return
+                }
+
+                strongSelf.wireframe.complete(on: strongSelf.view, locale: strongSelf.selectedLocale)
+            }, onErrorRetry: { [weak self] closure, indexes in
+                self?.view?.didStartLoading()
+
+                self?.interactor.retryMultiExtrinsic(
+                    for: closure,
+                    indexes: indexes
+                )
+            }, onErrorSkip: { [weak self] in
+                self?.wireframe.skip(on: self?.view)
+            }
+        )
+
+        wireframe.presentMultiExtrinsicStatusFromResult(
+            on: view,
+            result: result,
+            locale: selectedLocale,
+            handlers: handlers
+        )
     }
 
     func didReceiveFee(_ fee: ExtrinsicFeeProtocol) {

--- a/novawallet/Modules/Vote/Governance/GovernanceUnlockConfirm/GovernanceUnlockConfirmProtocols.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceUnlockConfirm/GovernanceUnlockConfirmProtocols.swift
@@ -16,7 +16,8 @@ protocol GovernanceUnlockConfirmPresenterProtocol: AnyObject {
     func presentSenderDetails()
 }
 
-protocol GovernanceUnlockConfirmInteractorInputProtocol: GovernanceUnlockInteractorInputProtocol {
+protocol GovernanceUnlockConfirmInteractorInputProtocol: GovernanceUnlockInteractorInputProtocol,
+    MultiExtrinsicSubmitRetryInputProtocol {
     func estimateFee(for actions: Set<GovernanceUnlockSchedule.Action>)
     func unlock(using actions: Set<GovernanceUnlockSchedule.Action>)
 }
@@ -24,11 +25,14 @@ protocol GovernanceUnlockConfirmInteractorInputProtocol: GovernanceUnlockInterac
 protocol GovernanceUnlockConfirmInteractorOutputProtocol: GovernanceUnlockInteractorOutputProtocol {
     func didReceiveBalance(_ assetBalance: AssetBalance?)
     func didReceiveLocks(_ locks: AssetLocks)
-    func didReceiveUnlockHash(_ hash: String)
+    func didReceiveSubmissionResult(_ result: SubmitIndexedExtrinsicResult)
     func didReceiveFee(_ fee: ExtrinsicFeeProtocol)
     func didReceiveError(_ error: GovernanceUnlockConfirmInteractorError)
 }
 
 protocol GovernanceUnlockConfirmWireframeProtocol: AlertPresentable, ErrorPresentable, CommonRetryable,
     FeeRetryable, MessageSheetPresentable, AddressOptionsPresentable,
-    ExtrinsicSubmissionPresenting, GovernanceErrorPresentable, ExtrinsicSigningErrorHandling {}
+    GovernanceErrorPresentable, ExtrinsicSigningErrorHandling, ExtrinsicSubmissionPresenting, MultiExtrinsicRetryable {
+    func complete(on view: GovernanceUnlockConfirmViewProtocol?, locale: Locale)
+    func skip(on view: GovernanceUnlockConfirmViewProtocol?)
+}

--- a/novawallet/Modules/Vote/Governance/GovernanceUnlockConfirm/GovernanceUnlockConfirmViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceUnlockConfirm/GovernanceUnlockConfirmViewFactory.swift
@@ -110,6 +110,7 @@ struct GovernanceUnlockConfirmViewFactory {
 
         return .init(
             chain: chain,
+            chainRegistry: ChainRegistryFacade.sharedRegistry,
             selectedAccount: selectedAccount,
             subscriptionFactory: subscriptionFactory,
             lockStateFactory: lockStateFactory,

--- a/novawallet/Modules/Vote/Governance/GovernanceUnlockConfirm/GovernanceUnlockConfirmWireframe.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceUnlockConfirm/GovernanceUnlockConfirmWireframe.swift
@@ -1,3 +1,15 @@
 import Foundation
 
-final class GovernanceUnlockConfirmWireframe: GovernanceUnlockConfirmWireframeProtocol, ModalAlertPresenting {}
+final class GovernanceUnlockConfirmWireframe: GovernanceUnlockConfirmWireframeProtocol, ModalAlertPresenting {
+    func complete(on view: GovernanceUnlockConfirmViewProtocol?, locale: Locale) {
+        presentExtrinsicSubmission(
+            from: view,
+            completionAction: .dismiss,
+            locale: locale
+        )
+    }
+
+    func skip(on view: GovernanceUnlockConfirmViewProtocol?) {
+        view?.controller.dismiss(animated: true)
+    }
+}

--- a/novawallet/Modules/Vote/Governance/Operation/Extrinsics/Gov1ExtrinsicFactory.swift
+++ b/novawallet/Modules/Vote/Governance/Operation/Extrinsics/Gov1ExtrinsicFactory.swift
@@ -25,8 +25,8 @@ final class Gov1ExtrinsicFactory: GovernanceExtrinsicFactory, GovernanceExtrinsi
     func unlock(
         with actions: Set<GovernanceUnlockSchedule.Action>,
         accountId: AccountId,
-        builder: ExtrinsicBuilderProtocol
-    ) throws -> ExtrinsicBuilderProtocol {
+        splitter: ExtrinsicSplitting
+    ) throws -> ExtrinsicSplitting {
         let removeVoteCalls: [RuntimeCall<Democracy.RemoveVoteCall>] = actions.compactMap { action in
             switch action {
             case let .unvote(_, index):
@@ -45,9 +45,8 @@ final class Gov1ExtrinsicFactory: GovernanceExtrinsicFactory, GovernanceExtrinsi
             }
         }
 
-        let newBuilder = try appendCalls(removeVoteCalls, builder: builder)
-
-        return try appendCalls(unlockCalls, builder: newBuilder)
+        let newSplitter = removeVoteCalls.reduce(splitter) { $0.adding(call: $1) }
+        return unlockCalls.reduce(newSplitter) { $0.adding(call: $1) }
     }
 
     func delegationUpdate(

--- a/novawallet/Modules/Vote/Governance/Operation/Extrinsics/Gov2ExtrinsicFactory.swift
+++ b/novawallet/Modules/Vote/Governance/Operation/Extrinsics/Gov2ExtrinsicFactory.swift
@@ -25,8 +25,8 @@ final class Gov2ExtrinsicFactory: GovernanceExtrinsicFactory, GovernanceExtrinsi
     func unlock(
         with actions: Set<GovernanceUnlockSchedule.Action>,
         accountId: AccountId,
-        builder: ExtrinsicBuilderProtocol
-    ) throws -> ExtrinsicBuilderProtocol {
+        splitter: ExtrinsicSplitting
+    ) throws -> ExtrinsicSplitting {
         let removeVoteCalls: [RuntimeCall<ConvictionVoting.RemoveVoteCall>] = actions.compactMap { action in
             switch action {
             case let .unvote(track, index):
@@ -51,9 +51,8 @@ final class Gov2ExtrinsicFactory: GovernanceExtrinsicFactory, GovernanceExtrinsi
             }
         }
 
-        let newBuilder = try appendCalls(removeVoteCalls, builder: builder)
-
-        return try appendCalls(unlockCalls, builder: newBuilder)
+        let newSplitter = removeVoteCalls.reduce(splitter) { $0.adding(call: $1) }
+        return unlockCalls.reduce(newSplitter) { $0.adding(call: $1) }
     }
 
     func delegationUpdate(

--- a/novawallet/Modules/Vote/Governance/Operation/GovernanceExtrinsicFactoryProtocol.swift
+++ b/novawallet/Modules/Vote/Governance/Operation/GovernanceExtrinsicFactoryProtocol.swift
@@ -11,8 +11,8 @@ protocol GovernanceExtrinsicFactoryProtocol {
     func unlock(
         with actions: Set<GovernanceUnlockSchedule.Action>,
         accountId: AccountId,
-        builder: ExtrinsicBuilderProtocol
-    ) throws -> ExtrinsicBuilderProtocol
+        splitter: ExtrinsicSplitting
+    ) throws -> ExtrinsicSplitting
 
     func delegationUpdate(
         with actions: [GovernanceDelegatorAction],

--- a/novawalletTests/Common/Services/ChainRegistry/ChainRegistryTests.swift
+++ b/novawalletTests/Common/Services/ChainRegistry/ChainRegistryTests.swift
@@ -166,7 +166,6 @@ class ChainRegistryTests: XCTestCase {
         wait(for: [expectation], timeout: 10)
 
         XCTAssertEqual(expectedChainIds, setupChainIds)
-        XCTAssertEqual(expectedChainIds, registry.availableChainIds)
 
         for chain in expectedChains {
             XCTAssertNotNil(registry.getConnection(for: chain.chainId))

--- a/novawalletTests/Modules/AccountConfirm/AccountConfirmTests.swift
+++ b/novawalletTests/Modules/AccountConfirm/AccountConfirmTests.swift
@@ -81,7 +81,7 @@ class AccountConfirmTests: XCTestCase {
 
         presenter.setup()
 
-        wait(for: [setupExpectation], timeout: Constants.defaultExpectationDuration)
+        wait(for: [setupExpectation], timeout: 10)
 
         presenter.confirm(words: mnemonic.allWords())
 


### PR DESCRIPTION
- move unlock confirm and remove votes flow to extrinsic splitter
- support limiting extrinsic batches by manual number of calls per extrinsic in ```ExtrinsicSplitter```
- add limits for number of calls per batch for Ledger wallets