### PR TITLE
fix connection cast that always produces nil

### DIFF
--- a/novawallet/Common/Services/ChainRegistry/ConnectionPool/ConnectionPool.swift
+++ b/novawallet/Common/Services/ChainRegistry/ConnectionPool/ConnectionPool.swift
@@ -99,7 +99,7 @@ extension ConnectionPool: ConnectionPoolProtocol {
             mutex.unlock()
         }
 
-        let optConnection = connections[chainId]
+        let optConnection = connections[chainId]?.target
         connections[chainId] = nil
         oneShotConnections[chainId] = nil
         stateSubscriptions[chainId] = nil

--- a/novawallet/Common/Services/ChainRegistry/ConnectionPool/ConnectionPool.swift
+++ b/novawallet/Common/Services/ChainRegistry/ConnectionPool/ConnectionPool.swift
@@ -54,7 +54,7 @@ extension ConnectionPool: ConnectionPoolProtocol {
         subscribers.append(WeakWrapper(target: subscriber))
         stateSubscriptions[chainId] = subscribers
 
-        let connection = connections[chainId] as? ChainConnection
+        let connection = connections[chainId]?.target as? ChainConnection
 
         DispatchQueue.main.async {
             subscriber.didReceive(state: connection?.state ?? .notConnected, for: chainId)


### PR DESCRIPTION
Fixed the type casting of connection stored with `WeakWrapper` in the `connections` dictionary so we can receive the true connection state with subscription.
