### PR TITLE
Use migration ledger app for onboarding

### DIFF
--- a/novawallet/Common/Ledger/LedgerApplication.swift
+++ b/novawallet/Common/Ledger/LedgerApplication.swift
@@ -1,23 +1,18 @@
 import Foundation
 import Operation_iOS
 
-protocol LedgerApplicationProtocol {
+protocol LedgerAccountRetrievable {
+    var connectionManager: LedgerConnectionManagerProtocol { get }
+
     func getAccountWrapper(
         for deviceId: UUID,
         chainId: ChainModel.Id,
         index: UInt32,
         displayVerificationDialog: Bool
     ) -> CompoundOperationWrapper<LedgerAccountResponse>
-
-    func getSignWrapper(
-        for payload: Data,
-        deviceId: UUID,
-        chainId: ChainModel.Id,
-        derivationPathClosure: @escaping LedgerPayloadClosure
-    ) -> CompoundOperationWrapper<Data>
 }
 
-extension LedgerApplicationProtocol {
+extension LedgerAccountRetrievable {
     func getAccountWrapper(
         for deviceId: UUID,
         chainId: ChainModel.Id,
@@ -25,6 +20,15 @@ extension LedgerApplicationProtocol {
     ) -> CompoundOperationWrapper<LedgerAccountResponse> {
         getAccountWrapper(for: deviceId, chainId: chainId, index: index, displayVerificationDialog: false)
     }
+}
+
+protocol LedgerApplicationProtocol: LedgerAccountRetrievable {
+    func getSignWrapper(
+        for payload: Data,
+        deviceId: UUID,
+        chainId: ChainModel.Id,
+        derivationPathClosure: @escaping LedgerPayloadClosure
+    ) -> CompoundOperationWrapper<Data>
 }
 
 enum LedgerApplicationError: Error {

--- a/novawallet/Common/Ledger/MigrationLedgerSubstrateApplication.swift
+++ b/novawallet/Common/Ledger/MigrationLedgerSubstrateApplication.swift
@@ -1,5 +1,43 @@
 import Foundation
+import Operation_iOS
 
-final class MigrationLedgerSubstrateApplication: NewSubstrateLedgerApplication {}
+final class MigrationLedgerSubstrateApplication: NewSubstrateLedgerApplication {
+    let chainRegistry: ChainRegistryProtocol
+    let supportedApps: [SupportedLedgerApp]
+
+    init(
+        connectionManager: LedgerConnectionManagerProtocol,
+        chainRegistry: ChainRegistryProtocol,
+        supportedApps: [SupportedLedgerApp]
+    ) {
+        self.chainRegistry = chainRegistry
+        self.supportedApps = supportedApps
+
+        super.init(connectionManager: connectionManager)
+    }
+}
 
 extension MigrationLedgerSubstrateApplication: NewSubstrateLedgerSigningProtocol {}
+
+extension MigrationLedgerSubstrateApplication: LedgerAccountRetrievable {
+    func getAccountWrapper(
+        for deviceId: UUID,
+        chainId: ChainModel.Id,
+        index: UInt32,
+        displayVerificationDialog: Bool
+    ) -> CompoundOperationWrapper<LedgerAccountResponse> {
+        guard
+            let chain = chainRegistry.getChain(for: chainId),
+            let application = supportedApps.first(where: { $0.chainId == chainId }) else {
+            return CompoundOperationWrapper.createWithError(LedgerApplicationError.unsupportedApp(chainId: chainId))
+        }
+
+        return getAccountWrapper(
+            for: deviceId,
+            coin: application.coin,
+            index: index,
+            addressPrefix: chain.addressPrefix,
+            displayVerificationDialog: displayVerificationDialog
+        )
+    }
+}

--- a/novawallet/Common/Ledger/SupportedLedgerApps.swift
+++ b/novawallet/Common/Ledger/SupportedLedgerApps.swift
@@ -26,7 +26,8 @@ extension SupportedLedgerApp {
             SupportedLedgerApp(chainId: KnowChainId.polymesh, coin: 595, cla: 0x91, type: .substrate),
             SupportedLedgerApp(chainId: KnowChainId.xxNetwork, coin: 1955, cla: 0xA3, type: .substrate),
             SupportedLedgerApp(chainId: KnowChainId.astar, coin: 810, cla: 0xA9, type: .substrate),
-            SupportedLedgerApp(chainId: KnowChainId.alephZero, coin: 643, cla: 0xA4, type: .substrate)
+            SupportedLedgerApp(chainId: KnowChainId.alephZero, coin: 643, cla: 0xA4, type: .substrate),
+            SupportedLedgerApp(chainId: KnowChainId.polkadex, coin: 799, cla: 0xA0, type: .substrate)
         ]
     }
 

--- a/novawallet/Modules/Ledger/AccountConfirmation/AccountAddFlow/LedgerAddAccountConfirmationInteractor.swift
+++ b/novawallet/Modules/Ledger/AccountConfirmation/AccountAddFlow/LedgerAddAccountConfirmationInteractor.swift
@@ -15,7 +15,7 @@ final class LedgerAddAccountConfirmationInteractor: LedgerBaseAccountConfirmatio
         wallet: MetaAccountModel,
         chain: ChainModel,
         deviceId: UUID,
-        application: LedgerApplication,
+        application: LedgerAccountRetrievable,
         requestFactory: StorageRequestFactoryProtocol,
         connection: JSONRPCEngine,
         runtimeService: RuntimeCodingServiceProtocol,

--- a/novawallet/Modules/Ledger/AccountConfirmation/Base/LedgerBaseAccountConfirmationInteractor.swift
+++ b/novawallet/Modules/Ledger/AccountConfirmation/Base/LedgerBaseAccountConfirmationInteractor.swift
@@ -11,7 +11,7 @@ class LedgerBaseAccountConfirmationInteractor {
 
     let chain: ChainModel
     let deviceId: UUID
-    let application: LedgerApplication
+    let application: LedgerAccountRetrievable
     let requestFactory: StorageRequestFactoryProtocol
     let connection: JSONRPCEngine
     let runtimeService: RuntimeCodingServiceProtocol
@@ -20,7 +20,7 @@ class LedgerBaseAccountConfirmationInteractor {
     init(
         chain: ChainModel,
         deviceId: UUID,
-        application: LedgerApplication,
+        application: LedgerAccountRetrievable,
         requestFactory: StorageRequestFactoryProtocol,
         connection: JSONRPCEngine,
         runtimeService: RuntimeCodingServiceProtocol,

--- a/novawallet/Modules/Ledger/AccountConfirmation/LedgerAccountConfirmationViewFactory.swift
+++ b/novawallet/Modules/Ledger/AccountConfirmation/LedgerAccountConfirmationViewFactory.swift
@@ -9,7 +9,7 @@ struct LedgerAccountConfirmationViewFactory {
         wallet: MetaAccountModel,
         chain: ChainModel,
         device: LedgerDeviceProtocol,
-        application: LedgerApplication
+        application: LedgerAccountRetrievable
     ) -> LedgerAccountConfirmationViewProtocol? {
         let chainRegistry = ChainRegistryFacade.sharedRegistry
 
@@ -56,7 +56,7 @@ struct LedgerAccountConfirmationViewFactory {
     static func createNewWalletView(
         chain: ChainModel,
         device: LedgerDeviceProtocol,
-        application: LedgerApplication,
+        application: LedgerAccountRetrievable,
         accountsStore: LedgerAccountsStore
     ) -> LedgerAccountConfirmationViewProtocol? {
         let chainRegistry = ChainRegistryFacade.sharedRegistry

--- a/novawallet/Modules/Ledger/AccountConfirmation/WalletCreateFlow/LedgerWalletAccountConfirmationInteractor.swift
+++ b/novawallet/Modules/Ledger/AccountConfirmation/WalletCreateFlow/LedgerWalletAccountConfirmationInteractor.swift
@@ -9,7 +9,7 @@ final class LedgerWalletAccountConfirmationInteractor: LedgerBaseAccountConfirma
     init(
         chain: ChainModel,
         deviceId: UUID,
-        application: LedgerApplication,
+        application: LedgerAccountRetrievable,
         accountsStore: LedgerAccountsStore,
         requestFactory: StorageRequestFactoryProtocol,
         connection: JSONRPCEngine,

--- a/novawallet/Modules/Ledger/Discovery/LedgerDiscoverViewFactory.swift
+++ b/novawallet/Modules/Ledger/Discovery/LedgerDiscoverViewFactory.swift
@@ -34,7 +34,7 @@ struct LedgerDiscoverViewFactory {
             application: ledgerApplication,
             chain: chain
         )
-        
+
         let appName = chain.supportsGenericLedgerApp ?
             LedgerSubstrateApp.migration.displayName(for: nil) :
             chain.name

--- a/novawallet/Modules/Ledger/Discovery/Legacy/LedgerDiscoverInteractor.swift
+++ b/novawallet/Modules/Ledger/Discovery/Legacy/LedgerDiscoverInteractor.swift
@@ -12,13 +12,13 @@ final class LedgerDiscoverInteractor: LedgerPerformOperationInteractor {
     }
 
     let chain: ChainModel
-    let ledgerApplication: LedgerApplicationProtocol
+    let ledgerApplication: LedgerAccountRetrievable
     let operationQueue: OperationQueue
     let logger: LoggerProtocol
 
     init(
         chain: ChainModel,
-        ledgerApplication: LedgerApplicationProtocol,
+        ledgerApplication: LedgerAccountRetrievable,
         ledgerConnection: LedgerConnectionManagerProtocol,
         operationQueue: OperationQueue,
         logger: LoggerProtocol

--- a/novawallet/Modules/Ledger/Discovery/Legacy/LedgerDiscoverWalletCreateWireframe.swift
+++ b/novawallet/Modules/Ledger/Discovery/Legacy/LedgerDiscoverWalletCreateWireframe.swift
@@ -3,9 +3,9 @@ import Foundation
 final class LedgerDiscoverWalletCreateWireframe: LedgerDiscoverWireframeProtocol {
     let accountsStore: LedgerAccountsStore
     let chain: ChainModel
-    let application: LedgerApplication
+    let application: LedgerAccountRetrievable
 
-    init(accountsStore: LedgerAccountsStore, application: LedgerApplication, chain: ChainModel) {
+    init(accountsStore: LedgerAccountsStore, application: LedgerAccountRetrievable, chain: ChainModel) {
         self.accountsStore = accountsStore
         self.application = application
         self.chain = chain
@@ -27,10 +27,10 @@ final class LedgerDiscoverWalletCreateWireframe: LedgerDiscoverWireframeProtocol
 
 final class LedgerDiscoverAccountAddWireframe: LedgerDiscoverWireframeProtocol {
     let wallet: MetaAccountModel
-    let application: LedgerApplication
+    let application: LedgerAccountRetrievable
     let chain: ChainModel
 
-    init(wallet: MetaAccountModel, application: LedgerApplication, chain: ChainModel) {
+    init(wallet: MetaAccountModel, application: LedgerAccountRetrievable, chain: ChainModel) {
         self.wallet = wallet
         self.application = application
         self.chain = chain

--- a/novawallet/Modules/Ledger/TxConfirmation/LedgerTxConfirmViewFactory.swift
+++ b/novawallet/Modules/Ledger/TxConfirmation/LedgerTxConfirmViewFactory.swift
@@ -101,7 +101,11 @@ struct LedgerTxConfirmViewFactory {
         let ledgerConnection = LedgerConnectionManager(logger: Logger.shared)
 
         let ledgerApplication: NewSubstrateLedgerSigningProtocol = if isForMigration {
-            MigrationLedgerSubstrateApplication(connectionManager: ledgerConnection)
+            MigrationLedgerSubstrateApplication(
+                connectionManager: ledgerConnection,
+                chainRegistry: ChainRegistryFacade.sharedRegistry,
+                supportedApps: SupportedLedgerApp.substrate()
+            )
         } else {
             GenericLedgerSubstrateApplication(connectionManager: ledgerConnection)
         }


### PR DESCRIPTION
- if the network supports generic ledger then we need to use migration ledger app