### PR TITLE
ConnectionPool test fix

### DIFF
--- a/novawalletTests/Common/Services/ChainRegistry/ConnectionPoolTests.swift
+++ b/novawalletTests/Common/Services/ChainRegistry/ConnectionPoolTests.swift
@@ -60,6 +60,10 @@ class ConnectionPoolTests: XCTestCase {
 
                     stub.urls.get.thenReturn(urls)
                 }
+                
+                stub(mockConnection.stateReporting) { stub in
+                    stub.state.get.thenReturn(.notConnected(url: nil))
+                }
 
                 return mockConnection
             }


### PR DESCRIPTION
add stub for state getter as we now checking state in `setupConnection` method.