### PR TITLE
Fix unlock for abstain voting

### DIFF
--- a/novawallet/Modules/Vote/Governance/Model/ReferendumAccountVoteLocal.swift
+++ b/novawallet/Modules/Vote/Governance/Model/ReferendumAccountVoteLocal.swift
@@ -122,7 +122,7 @@ enum ReferendumAccountVoteLocal: Equatable {
     }
 
     var totalBalance: BigUInt {
-        ayeBalance + nayBalance
+        ayeBalance + nayBalance + abstainBalance
     }
 
     var conviction: Decimal? {

--- a/novawalletTests/Modules/Governance/Gov2UnlockScheduleTests.swift
+++ b/novawalletTests/Modules/Governance/Gov2UnlockScheduleTests.swift
@@ -15,7 +15,7 @@ class Gov2UnlockScheduleTests: XCTestCase {
             GovernanceUnlocksTestBuilding.given {
                 TrackTestBuilding.track(0) {
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 0, amount: 1, unlockAt: 1000)
+                        TrackTestBuilding.Vote.standard(referendum: 0, amount: 1, unlockAt: 1000)
                     }
                 }
             }
@@ -61,7 +61,7 @@ class Gov2UnlockScheduleTests: XCTestCase {
                 TrackTestBuilding.track(0) {
                     TrackTestBuilding.VotingParams.prior(amount: 1, unlockAt: 1100)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 1, amount: 2, unlockAt: 1000)
+                        TrackTestBuilding.Vote.standard(referendum: 1, amount: 2, unlockAt: 1000)
                     }
                 }
             }
@@ -82,8 +82,8 @@ class Gov2UnlockScheduleTests: XCTestCase {
             GovernanceUnlocksTestBuilding.given {
                 TrackTestBuilding.track(0) {
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 0, amount: 8, unlockAt: 1000)
-                        TrackTestBuilding.Vote(referendum: 1, amount: 2, unlockAt: 1000)
+                        TrackTestBuilding.Vote.standard(referendum: 0, amount: 8, unlockAt: 1000)
+                        TrackTestBuilding.Vote.standard(referendum: 1, amount: 2, unlockAt: 1000)
                     }
                 }
             }
@@ -104,7 +104,7 @@ class Gov2UnlockScheduleTests: XCTestCase {
                 TrackTestBuilding.track(0) {
                     TrackTestBuilding.VotingParams.prior(amount: 1, unlockAt: 1100)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 1, amount: 2, unlockAt: 1000)
+                        TrackTestBuilding.Vote.standard(referendum: 1, amount: 2, unlockAt: 1000)
                     }
                 }
             }
@@ -124,13 +124,13 @@ class Gov2UnlockScheduleTests: XCTestCase {
                 TrackTestBuilding.track(0) {
                     TrackTestBuilding.VotingParams.locked(0)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 0, amount: 1, unlockAt: 1100)
+                        TrackTestBuilding.Vote.standard(referendum: 0, amount: 1, unlockAt: 1100)
                     }
                 }
                 TrackTestBuilding.track(1) {
                     TrackTestBuilding.VotingParams.locked(0)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 1, amount: 2, unlockAt: 1000)
+                        TrackTestBuilding.Vote.standard(referendum: 1, amount: 2, unlockAt: 1000)
                     }
                 }
             }
@@ -152,19 +152,19 @@ class Gov2UnlockScheduleTests: XCTestCase {
                 TrackTestBuilding.track(1) {
                     TrackTestBuilding.VotingParams.locked(0)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 1, amount: 1, unlockAt: 1000)
+                        TrackTestBuilding.Vote.standard(referendum: 1, amount: 1, unlockAt: 1000)
                     }
                 }
                 TrackTestBuilding.track(2) {
                     TrackTestBuilding.VotingParams.locked(0)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 2, amount: 2, unlockAt: 1100)
+                        TrackTestBuilding.Vote.standard(referendum: 2, amount: 2, unlockAt: 1100)
                     }
                 }
                 TrackTestBuilding.track(3) {
                     TrackTestBuilding.VotingParams.locked(0)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 3, amount: 1, unlockAt: 1200)
+                        TrackTestBuilding.Vote.standard(referendum: 3, amount: 1, unlockAt: 1200)
                     }
                 }
             }
@@ -188,7 +188,7 @@ class Gov2UnlockScheduleTests: XCTestCase {
                 TrackTestBuilding.track(0) {
                     TrackTestBuilding.VotingParams.locked(10)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 0, amount: 2, unlockAt: 1000)
+                        TrackTestBuilding.Vote.standard(referendum: 0, amount: 2, unlockAt: 1000)
                     }
                 }
             }
@@ -208,7 +208,7 @@ class Gov2UnlockScheduleTests: XCTestCase {
                 TrackTestBuilding.track(0) {
                     TrackTestBuilding.VotingParams.locked(10)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 0, amount: 1, unlockAt: 1000)
+                        TrackTestBuilding.Vote.standard(referendum: 0, amount: 1, unlockAt: 1000)
                     }
                 }
 
@@ -282,9 +282,9 @@ class Gov2UnlockScheduleTests: XCTestCase {
             GovernanceUnlocksTestBuilding.given {
                 TrackTestBuilding.track(0) {
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 0, amount: 3, unlockAt: 1100)
-                        TrackTestBuilding.Vote(referendum: 2, amount: 2, unlockAt: 1200)
-                        TrackTestBuilding.Vote(referendum: 1, amount: 1, unlockAt: 1300)
+                        TrackTestBuilding.Vote.standard(referendum: 0, amount: 3, unlockAt: 1100)
+                        TrackTestBuilding.Vote.standard(referendum: 2, amount: 2, unlockAt: 1200)
+                        TrackTestBuilding.Vote.standard(referendum: 1, amount: 1, unlockAt: 1300)
                     }
                 }
             }
@@ -316,14 +316,14 @@ class Gov2UnlockScheduleTests: XCTestCase {
                 TrackTestBuilding.track(20) {
                     TrackTestBuilding.VotingParams.locked(1)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 13, amount: 1, unlockAt: 2000)
+                        TrackTestBuilding.Vote.standard(referendum: 13, amount: 1, unlockAt: 2000)
                     }
                 }
 
                 TrackTestBuilding.track(21) {
                     TrackTestBuilding.VotingParams.locked(101)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 5, amount: 10, unlockAt: 1500)
+                        TrackTestBuilding.Vote.standard(referendum: 5, amount: 10, unlockAt: 1500)
                     }
                 }
             }
@@ -416,7 +416,7 @@ class Gov2UnlockScheduleTests: XCTestCase {
                 TrackTestBuilding.track(1) {
                     TrackTestBuilding.VotingParams.prior(amount: 10, unlockAt: 1000)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 0, amount: 5, unlockAt: 1100)
+                        TrackTestBuilding.Vote.standard(referendum: 0, amount: 5, unlockAt: 1100)
                     }
                 }
             }
@@ -451,7 +451,7 @@ class Gov2UnlockScheduleTests: XCTestCase {
                 TrackTestBuilding.track(1) {
                     TrackTestBuilding.VotingParams.prior(amount: 10, unlockAt: 1000)
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote(referendum: 0, amount: 5, unlockAt: 1100)
+                        TrackTestBuilding.Vote.standard(referendum: 0, amount: 5, unlockAt: 1100)
                     }
                 }
 


### PR DESCRIPTION
## Purpose

- take abstain balance into account when calculating unlock schedule and add test for it #8695883wd
- add test to ensure that no duplication actions are generated in unlock schedule when vote for same track #86955bu54

##

![RefList](https://github.com/user-attachments/assets/93a3aed6-d9a0-4fb2-8a3b-b8dbc1a71f20)

![unlockDetails](https://github.com/user-attachments/assets/63a1dfda-15f6-4de9-b6d5-afa1a141c7a5)
