### PR TITLE
Take confirm period into account when estimating unlock time

### DIFF
--- a/novawallet/Modules/Vote/Governance/Operation/Locks/Gov1LockStateFactory.swift
+++ b/novawallet/Modules/Vote/Governance/Operation/Locks/Gov1LockStateFactory.swift
@@ -70,6 +70,7 @@ final class Gov1LockStateFactory: GovernanceLockStateFactory {
 
             return GovUnlockCalculationInfo(
                 decisionPeriods: [Gov1OperationFactory.trackId: votingPeriod],
+                confirmPeriods: [:],
                 undecidingTimeout: 0,
                 voteLockingPeriod: lockingPeriod
             )

--- a/novawallet/Modules/Vote/Governance/Operation/Locks/Gov2LockStateFactory.swift
+++ b/novawallet/Modules/Vote/Governance/Operation/Locks/Gov2LockStateFactory.swift
@@ -74,12 +74,17 @@ final class Gov2LockStateFactory: GovernanceLockStateFactory {
                 into: [Referenda.TrackId: Moment]()
             ) { $0[$1.trackId] = $1.info.decisionPeriod }
 
+            let confirmPeriods = try tracksOperation.extractNoCancellableResultData().reduce(
+                into: [Referenda.TrackId: Moment]()
+            ) { $0[$1.trackId] = $1.info.confirmPeriod }
+
             let undecidingTimeout = try undecidingTimeoutOperation.extractNoCancellableResultData()
 
             let lockingPeriod = try lockingPeriodOperation.extractNoCancellableResultData()
 
             return GovUnlockCalculationInfo(
                 decisionPeriods: decisionPeriods,
+                confirmPeriods: confirmPeriods,
                 undecidingTimeout: undecidingTimeout,
                 voteLockingPeriod: lockingPeriod
             )

--- a/novawallet/Modules/Vote/Governance/Operation/Locks/Gov2UnlockReferendum.swift
+++ b/novawallet/Modules/Vote/Governance/Operation/Locks/Gov2UnlockReferendum.swift
@@ -21,15 +21,17 @@ extension Gov2UnlockReferendum: GovUnlockReferendumProtocol {
 
         switch referendumInfo {
         case let .ongoing(ongoingStatus):
-            guard let decisionPeriod = additionalInfo.decisionPeriods[ongoingStatus.track] else {
+            guard
+                let decisionPeriod = additionalInfo.decisionPeriods[ongoingStatus.track],
+                let confirmPeriod = additionalInfo.confirmPeriods[ongoingStatus.track] else {
                 return nil
             }
 
             if let decidingSince = ongoingStatus.deciding?.since {
-                return decidingSince + decisionPeriod + convictionPeriod
+                return decidingSince + decisionPeriod + confirmPeriod + convictionPeriod
             } else {
                 return ongoingStatus.submitted + additionalInfo.undecidingTimeout +
-                    decisionPeriod + convictionPeriod
+                    decisionPeriod + confirmPeriod + convictionPeriod
             }
         case let .approved(completedStatus):
             if accountVote.hasAyeVotes {

--- a/novawallet/Modules/Vote/Governance/Operation/Locks/GovernanceUnlocksCalculator.swift
+++ b/novawallet/Modules/Vote/Governance/Operation/Locks/GovernanceUnlocksCalculator.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct GovUnlockCalculationInfo {
     let decisionPeriods: [Referenda.TrackId: Moment]
+    let confirmPeriods: [Referenda.TrackId: Moment]
     let undecidingTimeout: Moment
     let voteLockingPeriod: Moment
 }

--- a/novawalletTests/Modules/Governance/Gov2UnlockScheduleTests.swift
+++ b/novawalletTests/Modules/Governance/Gov2UnlockScheduleTests.swift
@@ -506,7 +506,7 @@ class Gov2UnlockScheduleTests: XCTestCase {
         GovernanceUnlocksTestBuilding.run(atBlock: 1100) {
             GovernanceUnlocksTestBuilding.given(
                 tracksDef: [
-                    .init(trackId: 1, decisionPeriod: 200)
+                    .init(trackId: 1, decisionPeriod: 200, confirmPeriod: 10)
                 ],
                 referendumsDef: [
                     .init(index: 1, trackId: 1, type: .ongoing(since: 1000))
@@ -514,14 +514,14 @@ class Gov2UnlockScheduleTests: XCTestCase {
             ) {
                 TrackTestBuilding.track(1) {
                     TrackTestBuilding.VotingParams.votes {
-                        TrackTestBuilding.Vote.abstain(referendum: 1, amount: 2, unlockAt: 1200)
+                        TrackTestBuilding.Vote.abstain(referendum: 1, amount: 2, unlockAt: 1210)
                     }
                 }
             }
             
             GovernanceUnlocksTestBuilding.expect {
                 UnlockScheduleTestBuilding.ScheduleResult.remainingItems {
-                    UnlockScheduleTestBuilding.unlock(amount: 2, atBlock: 1200) {
+                    UnlockScheduleTestBuilding.unlock(amount: 2, atBlock: 1210) {
                         GovernanceUnlockSchedule.Action.unvote(track: 1, index: 1)
                         GovernanceUnlockSchedule.Action.unlock(track: 1)
                     }

--- a/novawalletTests/Modules/Governance/GovernanceUnlocksTestBuilding.swift
+++ b/novawalletTests/Modules/Governance/GovernanceUnlocksTestBuilding.swift
@@ -21,6 +21,7 @@ enum GovernanceUnlocksTestBuilding {
     struct TrackDef {
         let trackId: Referenda.TrackId
         let decisionPeriod: Moment
+        let confirmPeriod: Moment
     }
 
     @resultBuilder
@@ -86,6 +87,7 @@ enum GovernanceUnlocksTestBuilding {
 
         let additions = GovUnlockCalculationInfo(
             decisionPeriods: prepareDecisionPeriods(from: tracksDef),
+            confirmPeriods: prepareConfirmPeriods(from: tracksDef),
             undecidingTimeout: 0,
             voteLockingPeriod: 0
         )
@@ -144,6 +146,10 @@ enum GovernanceUnlocksTestBuilding {
     
     private static func prepareDecisionPeriods(from tracksDef: [TrackDef]) -> [Referenda.TrackId: Moment] {
         tracksDef.reduce(into: [Referenda.TrackId: Moment]()) { $0[$1.trackId] = $1.decisionPeriod }
+    }
+    
+    private static func prepareConfirmPeriods(from tracksDef: [TrackDef]) -> [Referenda.TrackId: Moment] {
+        tracksDef.reduce(into: [Referenda.TrackId: Moment]()) { $0[$1.trackId] = $1.confirmPeriod }
     }
 }
 


### PR DESCRIPTION
## Purpose

Previous logic didn't take into account confirm period when estimated unlock time. Now it does as we can go to the confirmation period on the border of the decision period.