### PR TITLE
Show fee in a custom asset for OperationDetails module

### DIFF
--- a/novawallet/Common/Services/PersistExtrinsicService/PersistExtrinsicFactory.swift
+++ b/novawallet/Common/Services/PersistExtrinsicService/PersistExtrinsicFactory.swift
@@ -52,7 +52,7 @@ final class PersistExtrinsicFactory: PersistExtrinsicFactoryProtocol {
             txHash: txHash,
             timestamp: timestamp,
             fee: feeString,
-            feeAssetId: nil,
+            feeAssetId: details.feeAssetId,
             blockNumber: nil,
             txIndex: nil,
             callPath: details.callPath,

--- a/novawallet/Common/Services/PersistExtrinsicService/PersistTransferDetails.swift
+++ b/novawallet/Common/Services/PersistExtrinsicService/PersistTransferDetails.swift
@@ -8,6 +8,7 @@ struct PersistTransferDetails {
     let txHash: Data
     let callPath: CallCodingPath
     let fee: BigUInt?
+    let feeAssetId: AssetModel.Id?
 }
 
 struct PersistExtrinsicDetails {

--- a/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+AssetHubSwapMatching.swift
+++ b/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+AssetHubSwapMatching.swift
@@ -83,7 +83,7 @@ extension ExtrinsicProcessor {
                     return nil
                 }
 
-                fee = nativeFee
+                fee = nativeFee.amount
                 feeAssetId = chain.utilityAsset()?.assetId
             }
 

--- a/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+Fee.swift
+++ b/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+Fee.swift
@@ -3,14 +3,26 @@ import BigInt
 import SubstrateSdk
 
 extension ExtrinsicProcessor {
+    struct Fee {
+        let amount: BigUInt
+        let assetId: JSON?
+    }
+
     func findFee(
         for index: UInt32,
         sender: AccountId,
         eventRecords: [EventRecord],
         metadata: RuntimeMetadataProtocol,
         runtimeJsonContext: RuntimeJsonContext
-    ) -> BigUInt? {
-        if let fee = findTransactionFeePaid(
+    ) -> Fee? {
+        if let fee = findTransactionFeePaidInCustomAsset(
+            for: index,
+            eventRecords: eventRecords,
+            metadata: metadata,
+            runtimeJsonContext: runtimeJsonContext
+        ) {
+            return fee
+        } else if let fee = findTransactionFeePaid(
             for: index,
             eventRecords: eventRecords,
             metadata: metadata,
@@ -35,25 +47,54 @@ extension ExtrinsicProcessor {
         }
     }
 
+    private func findTransactionFeePaidInCustomAsset(
+        for index: UInt32,
+        eventRecords: [EventRecord],
+        metadata: RuntimeMetadataProtocol,
+        runtimeJsonContext: RuntimeJsonContext
+    ) -> Fee? {
+        let extrinsicEvents = eventRecords.filter { $0.extrinsicIndex == index }
+
+        let path = AssetTxPaymentPallet.assetTxFeePaidEvent
+        guard
+            let record = extrinsicEvents.last(where: { metadata.eventMatches($0.event, path: path) }),
+            let feePaidEvent: AssetTxPaymentPallet.AssetTxFeePaid = try? ExtrinsicExtraction.getEventParams(
+                from: record.event,
+                context: runtimeJsonContext
+            )
+        else {
+            return nil
+        }
+
+        return Fee(
+            amount: feePaidEvent.actualFee,
+            assetId: feePaidEvent.assetId
+        )
+    }
+
     private func findTransactionFeePaid(
         for index: UInt32,
         eventRecords: [EventRecord],
         metadata: RuntimeMetadataProtocol,
         runtimeJsonContext: RuntimeJsonContext
-    ) -> BigUInt? {
+    ) -> Fee? {
         let extrinsicEvents = eventRecords.filter { $0.extrinsicIndex == index }
 
         let path = TransactionPaymentPallet.feePaidPath
-        guard let record = extrinsicEvents.last(where: { metadata.eventMatches($0.event, path: path) }) else {
+        guard
+            let record = extrinsicEvents.last(where: { metadata.eventMatches($0.event, path: path) }),
+            let feePaidEvent: TransactionPaymentPallet.TransactionFeePaid = try? ExtrinsicExtraction.getEventParams(
+                from: record.event,
+                context: runtimeJsonContext
+            )
+        else {
             return nil
         }
 
-        let feePaidEvent: TransactionPaymentPallet.TransactionFeePaid? = try? ExtrinsicExtraction.getEventParams(
-            from: record.event,
-            context: runtimeJsonContext
+        return Fee(
+            amount: feePaidEvent.amount,
+            assetId: nil
         )
-
-        return feePaidEvent?.amount
     }
 
     private func findFeeOfBalancesWithdraw(
@@ -62,7 +103,7 @@ extension ExtrinsicProcessor {
         eventRecords: [EventRecord],
         metadata: RuntimeMetadataProtocol,
         runtimeJsonContext: RuntimeJsonContext
-    ) -> BigUInt? {
+    ) -> Fee? {
         let withdraw = EventCodingPath.balancesWithdraw
         let closure: (EventRecord) -> Bool = { record in
             guard record.extrinsicIndex == index,
@@ -94,7 +135,10 @@ extension ExtrinsicProcessor {
             return nil
         }
 
-        return event.amount
+        return Fee(
+            amount: event.amount,
+            assetId: nil
+        )
     }
 
     private func findFeeOfBalancesTreasuryDeposit(
@@ -102,7 +146,7 @@ extension ExtrinsicProcessor {
         eventRecords: [EventRecord],
         metadata: RuntimeMetadataProtocol,
         runtimeJsonContext: RuntimeJsonContext
-    ) -> BigUInt? {
+    ) -> Fee? {
         let balances = EventCodingPath.balancesDeposit
 
         let maybeBalancesDeposit: BigUInt? = eventRecords.last { record in
@@ -149,6 +193,15 @@ extension ExtrinsicProcessor {
             deposits.append(treasury)
         }
 
-        return !deposits.isEmpty ? deposits.reduce(0, +) : nil
+        let amount: BigUInt? = !deposits.isEmpty ? deposits.reduce(0, +) : nil
+
+        guard let amount else {
+            return nil
+        }
+
+        return Fee(
+            amount: amount,
+            assetId: nil
+        )
     }
 }

--- a/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+Fee.swift
+++ b/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+Fee.swift
@@ -66,34 +66,18 @@ extension ExtrinsicProcessor {
         eventRecords: [EventRecord],
         codingFactory: RuntimeCoderFactoryProtocol
     ) throws -> Fee? {
-        if
-            let customFee = try findHydraCustomFee(
-                in: eventRecords,
-                swapEvents: params.events,
-                codingFactory: codingFactory
-            ) {
-            return customFee
-        } else {
-            let optNativeFee = findFee(
+        try findHydraCustomFee(
+            in: eventRecords,
+            swapEvents: params.events,
+            codingFactory: codingFactory
+        )
+            ?? findFee(
                 for: extrinsicIndex,
                 sender: params.sender,
                 eventRecords: eventRecords,
                 metadata: codingFactory.metadata,
                 runtimeJsonContext: codingFactory.createRuntimeJsonContext()
             )
-
-            guard
-                let feeAssetId = chain.utilityChainAssetId()?.assetId,
-                let nativeFee = optNativeFee?.amount
-            else {
-                return nil
-            }
-
-            return Fee(
-                amount: nativeFee,
-                assetId: feeAssetId
-            )
-        }
     }
 
     private func findTransactionFeePaid(

--- a/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+HydraSwapMatching.swift
+++ b/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+HydraSwapMatching.swift
@@ -366,7 +366,7 @@ extension ExtrinsicProcessor {
 
             guard
                 let feeAssetId = chain.utilityChainAssetId()?.assetId,
-                let nativeFee = optNativeFee else {
+                let nativeFee = optNativeFee?.amount else {
                 return nil
             }
 

--- a/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+HydraSwapMatching.swift
+++ b/novawallet/Common/Services/TransactionSubscription/ExtrinsicProcessor+HydraSwapMatching.swift
@@ -2,19 +2,14 @@ import Foundation
 import BigInt
 import SubstrateSdk
 
-private struct HydraSwapExtrinsicCallArgs {
+struct HydraSwapExtrinsicCallArgs {
     let assetIn: HydraDx.AssetId
     let assetOut: HydraDx.AssetId
     let amountIn: BigUInt
     let amountOut: BigUInt
 }
 
-private struct HydraFee {
-    let assetId: AssetModel.Id
-    let amount: BigUInt
-}
-
-private struct HydraSwapExtrinsicParsingParams {
+struct HydraSwapExtrinsicParsingParams {
     let sender: AccountId
     let events: Set<EventCodingPath>
     let eventParser: (Event, EventCodingPath) throws -> HydraSwapExtrinsicCallArgs
@@ -47,7 +42,7 @@ extension ExtrinsicProcessor {
                 return nil
             }
 
-            let params = prepareParsingParams(for: sender, codingFactory: codingFactory)
+            let params = prepareHydraParsingParams(for: sender, codingFactory: codingFactory)
 
             guard let swapResult = try parseHydraSwapExtrinsic(
                 extrinsic,
@@ -59,7 +54,7 @@ extension ExtrinsicProcessor {
                 return nil
             }
 
-            guard let fee = try findHydraFee(
+            guard let fee = try findOrmlFee(
                 for: params,
                 extrinsicIndex: extrinsicIndex,
                 eventRecords: extrinsicEvents,
@@ -93,7 +88,7 @@ extension ExtrinsicProcessor {
     }
 
     // swiftlint:disable:next function_body_length
-    private func prepareParsingParams(
+    func prepareHydraParsingParams(
         for sender: AccountId,
         codingFactory: RuntimeCoderFactoryProtocol
     ) -> HydraSwapExtrinsicParsingParams {
@@ -340,80 +335,5 @@ extension ExtrinsicProcessor {
             call: call.args,
             isSuccess: false
         )
-    }
-
-    private func findHydraFee(
-        for params: HydraSwapExtrinsicParsingParams,
-        extrinsicIndex: UInt32,
-        eventRecords: [EventRecord],
-        codingFactory: RuntimeCoderFactoryProtocol
-    ) throws -> HydraFee? {
-        if
-            let customFee = try findHydraCustomFee(
-                in: eventRecords,
-                swapEvents: params.events,
-                codingFactory: codingFactory
-            ) {
-            return customFee
-        } else {
-            let optNativeFee = findFee(
-                for: extrinsicIndex,
-                sender: params.sender,
-                eventRecords: eventRecords,
-                metadata: codingFactory.metadata,
-                runtimeJsonContext: codingFactory.createRuntimeJsonContext()
-            )
-
-            guard
-                let feeAssetId = chain.utilityChainAssetId()?.assetId,
-                let nativeFee = optNativeFee?.amount else {
-                return nil
-            }
-
-            return HydraFee(assetId: feeAssetId, amount: nativeFee)
-        }
-    }
-
-    private func findHydraCustomFee(
-        in events: [EventRecord],
-        swapEvents: Set<EventCodingPath>,
-        codingFactory: RuntimeCoderFactoryProtocol
-    ) throws -> HydraFee? {
-        let metadata = codingFactory.metadata
-
-        let swapIndex = events.lastIndex { metadata.eventMatches($0.event, oneOf: swapEvents) } ?? 0
-
-        let feePaidPath = TransactionPaymentPallet.feePaidPath
-        let optFeePaidIndex = events.lastIndex { metadata.eventMatches($0.event, path: feePaidPath) }
-
-        guard let feePaidIndex = optFeePaidIndex,
-              swapIndex < feePaidIndex else {
-            return nil
-        }
-
-        let depositedPath = TokensPallet.depositedEventPath
-        let optDepositEvent = events[swapIndex ..< feePaidIndex].first {
-            metadata.eventMatches($0.event, path: depositedPath)
-        }
-
-        let context = codingFactory.createRuntimeJsonContext()
-
-        guard
-            let depositedEvent = optDepositEvent,
-            let depositedModel: TokensPallet.DepositedEvent<StringScaleMapper<BigUInt>> =
-            try? ExtrinsicExtraction.getEventParams(
-                from: depositedEvent.event,
-                context: context
-            ) else {
-            return nil
-        }
-
-        let assetId = try HydraDxTokenConverter.converToLocal(
-            for: depositedModel.currencyId.value,
-            chain: chain,
-            codingFactory: codingFactory
-        ).assetId
-
-        return HydraFee(assetId: assetId, amount: depositedModel.amount)
     }
 }

--- a/novawallet/Modules/AssetConversion/Service/AssetHub/AssetHubTokensConverter.swift
+++ b/novawallet/Modules/AssetConversion/Service/AssetHub/AssetHubTokensConverter.swift
@@ -161,4 +161,26 @@ enum AssetHubTokensConverter {
             }
         }
     }
+
+    static func convertToLocalAsset(
+        for assetId: JSON?,
+        on chain: ChainModel,
+        using codingFactory: RuntimeCoderFactoryProtocol
+    ) -> ChainAsset? {
+        guard let remoteAssetId = try? assetId?.map(
+            to: AssetConversionPallet.AssetId.self,
+            with: codingFactory.createRuntimeJsonContext().toRawContext()
+        ) else {
+            return nil
+        }
+
+        return convertFromMultilocationToLocal(
+            remoteAssetId,
+            chain: chain,
+            conversionClosure: createPoolAssetToLocalClosure(
+                for: chain,
+                codingFactory: codingFactory
+            )
+        )
+    }
 }

--- a/novawallet/Modules/OperationDetails/Model/OperationTransferModel.swift
+++ b/novawallet/Modules/OperationDetails/Model/OperationTransferModel.swift
@@ -6,6 +6,7 @@ struct OperationTransferModel {
     let amount: BigUInt
     let amountPriceData: PriceData?
     let fee: BigUInt
+    let feeAssetId: AssetModel.Id?
     let feePriceData: PriceData?
     let sender: DisplayAddress
     let receiver: DisplayAddress

--- a/novawallet/Modules/OperationDetails/OperationDataProviders/OperationDetailsTransferProvider.swift
+++ b/novawallet/Modules/OperationDetails/OperationDataProviders/OperationDetailsTransferProvider.swift
@@ -34,8 +34,15 @@ extension OperationDetailsTransferProvider: OperationDetailsDataProviderProtocol
             progressClosure(nil)
             return
         }
+
+        let feeAsset = if let feeAssetId = transaction.feeAssetId {
+            chainAsset.chain.asset(for: feeAssetId)
+        } else {
+            chainAsset.chain.utilityAsset()
+        }
+
         let priceCalculator = calculatorFactory.createPriceCalculator(for: chainAsset.asset.priceId)
-        let feePriceCalculator = calculatorFactory.createPriceCalculator(for: chainAsset.chain.utilityAsset()?.priceId)
+        let feePriceCalculator = calculatorFactory.createPriceCalculator(for: feeAsset?.priceId)
         let peerAddress = (transaction.sender == accountAddress ? transaction.receiver : transaction.sender)
             ?? transaction.sender
         let accountId = try? peerAddress.toAccountId(using: chain.chainFormat)
@@ -82,6 +89,7 @@ extension OperationDetailsTransferProvider: OperationDetailsDataProviderProtocol
                         amount: amount,
                         amountPriceData: priceData,
                         fee: fee,
+                        feeAssetId: feeAsset?.assetId,
                         feePriceData: feePriceData,
                         sender: isOutgoing ? currentDisplayAddress : otherDisplayAddress,
                         receiver: isOutgoing ? otherDisplayAddress : currentDisplayAddress,

--- a/novawallet/Modules/OperationDetails/ViewModel/OperationDetailsViewModelFactory.swift
+++ b/novawallet/Modules/OperationDetails/ViewModel/OperationDetailsViewModelFactory.swift
@@ -328,11 +328,14 @@ final class OperationDetailsViewModelFactory {
     private func createContentViewModel(
         from data: OperationDetailsModel.OperationData,
         chainAsset: ChainAsset,
-        feeAssetInfo: AssetBalanceDisplayInfo,
         locale: Locale
     ) -> OperationDetailsViewModel.ContentViewModel {
         switch data {
         case let .transfer(model):
+            let feeAssetInfo: AssetBalanceDisplayInfo = model.feeAssetId == chainAsset.asset.assetId
+                ? chainAsset.assetDisplayInfo
+                : chainAsset.chain.utilityAssetDisplayInfo() ?? chainAsset.assetDisplayInfo
+
             let viewModel = createTransferViewModel(
                 from: model,
                 feeAssetInfo: feeAssetInfo,
@@ -391,12 +394,10 @@ extension OperationDetailsViewModelFactory: OperationDetailsViewModelFactoryProt
         let networkViewModel = networkViewModelFactory.createViewModel(from: chainAsset.chain)
 
         let assetInfo = chainAsset.assetDisplayInfo
-        let feeAssetInfo = chainAsset.chain.utilityAsset()?.displayInfo(with: chainAsset.chain.icon) ?? assetInfo
 
         let contentViewModel = createContentViewModel(
             from: model.operation,
             chainAsset: chainAsset,
-            feeAssetInfo: feeAssetInfo,
             locale: locale
         )
 

--- a/novawallet/Modules/Transfer/TransferConfirm/OnChain/TransferEvmOnChainConfirmInteractor.swift
+++ b/novawallet/Modules/Transfer/TransferConfirm/OnChain/TransferEvmOnChainConfirmInteractor.swift
@@ -115,7 +115,8 @@ extension TransferEvmOnChainConfirmInteractor: TransferConfirmOnChainInteractorI
                             amount: amount.value,
                             txHash: txHashData,
                             callPath: callCodingPath,
-                            fee: lastFee
+                            fee: lastFee,
+                            feeAssetId: nil
                         )
 
                         self?.persistExtrinsicAndComplete(details: details, type: transferType)

--- a/novawallet/Modules/Transfer/TransferConfirm/OnChain/TransferOnChainConfirmInteractor.swift
+++ b/novawallet/Modules/Transfer/TransferConfirm/OnChain/TransferOnChainConfirmInteractor.swift
@@ -114,7 +114,8 @@ extension TransferOnChainConfirmInteractor: TransferConfirmOnChainInteractorInpu
                                 amount: amount.value,
                                 txHash: txHashData,
                                 callPath: callCodingPath,
-                                fee: lastFee
+                                fee: lastFee,
+                                feeAssetId: self?.feeAsset?.asset.assetId
                             )
 
                             self?.persistExtrinsicAndComplete(details: details)


### PR DESCRIPTION
- Parse the transfer extrinsic to find the 'AssetTxPaymentPallet.assetTxFeePaidEvent' event
- Use the 'assetId' from the event as the fee asset
- Adapt the 'OperationDetails' module to show the fee in a custom asset

<img src="https://github.com/user-attachments/assets/6025462e-40fd-4597-95b2-d57accb5b02b" width=50% height=50%>
