### PR TITLE
refactor swap params and flow state logic

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -937,6 +937,7 @@
 		2D95DF5B2C6F7D83009BB063 /* HydraExtrinsicAssetsCustomFeeEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D95DF5A2C6F7D83009BB063 /* HydraExtrinsicAssetsCustomFeeEstimator.swift */; };
 		2D95DF5D2C6F9129009BB063 /* HydraExtrinsicFeeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D95DF5C2C6F9129009BB063 /* HydraExtrinsicFeeInstaller.swift */; };
 		2D95DF5F2C6FAFF6009BB063 /* ExtrinsicFeeEstimatingWrapperFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D95DF5E2C6FAFF6009BB063 /* ExtrinsicFeeEstimatingWrapperFactory.swift */; };
+		2D95DF612C74B79A009BB063 /* HydraFlowStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D95DF602C74B79A009BB063 /* HydraFlowStateStore.swift */; };
 		2DA9CC932C2C261100DC74A8 /* BlockHashOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA9CC922C2C261100DC74A8 /* BlockHashOperationFactory.swift */; };
 		2DAF53952C16E3D40076B4B6 /* NetworkDetailsViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAF53942C16E3D40076B4B6 /* NetworkDetailsViewModelFactory.swift */; };
 		2DAF539B2C1842D00076B4B6 /* NetworkDetailsNodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAF539A2C1842D00076B4B6 /* NetworkDetailsNodeView.swift */; };
@@ -5937,6 +5938,7 @@
 		2D95DF5A2C6F7D83009BB063 /* HydraExtrinsicAssetsCustomFeeEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraExtrinsicAssetsCustomFeeEstimator.swift; sourceTree = "<group>"; };
 		2D95DF5C2C6F9129009BB063 /* HydraExtrinsicFeeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraExtrinsicFeeInstaller.swift; sourceTree = "<group>"; };
 		2D95DF5E2C6FAFF6009BB063 /* ExtrinsicFeeEstimatingWrapperFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrinsicFeeEstimatingWrapperFactory.swift; sourceTree = "<group>"; };
+		2D95DF602C74B79A009BB063 /* HydraFlowStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraFlowStateStore.swift; sourceTree = "<group>"; };
 		2DA9CC922C2C261100DC74A8 /* BlockHashOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockHashOperationFactory.swift; sourceTree = "<group>"; };
 		2DAF53942C16E3D40076B4B6 /* NetworkDetailsViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDetailsViewModelFactory.swift; sourceTree = "<group>"; };
 		2DAF539A2C1842D00076B4B6 /* NetworkDetailsNodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDetailsNodeView.swift; sourceTree = "<group>"; };
@@ -10327,6 +10329,7 @@
 				0CA7197C2B7737D5000B086E /* HydraQuoteFactory.swift */,
 				0CA7197E2B773E99000B086E /* HydraSwapRoute.swift */,
 				0CA719822B787FCA000B086E /* HydraFlowState.swift */,
+				2D95DF602C74B79A009BB063 /* HydraFlowStateStore.swift */,
 				0CA7198D2B791811000B086E /* HydraReQuoteService.swift */,
 				0CA7198F2B79C92E000B086E /* HydraRoutesOperationFactory.swift */,
 				0CA719972B79D033000B086E /* HydraRoutesResolver.swift */,
@@ -24654,6 +24657,7 @@
 				8470D6D0253E321C009E9A5D /* StorageSubscriptionProtocols.swift in Sources */,
 				8499FE6C27BD319300712589 /* RMRKV2OperationFactory.swift in Sources */,
 				84D184F42A04F5210060C1BD /* StackInfoTableCell+WallectConnect.swift in Sources */,
+				2D95DF612C74B79A009BB063 /* HydraFlowStateStore.swift in Sources */,
 				88A5317D28B9170100AF18F5 /* NSCollectionLayoutSection+create.swift in Sources */,
 				8444D1BE2671465A00AF6D8C /* CrowdloanBonusServiceError.swift in Sources */,
 				8448F7A22882ABF50080CEA9 /* CustomSearchView.swift in Sources */,

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicOperationFactory.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicOperationFactory.swift
@@ -360,8 +360,7 @@ final class ExtrinsicOperationFactory: BaseExtrinsicOperationFactory {
 
         let feeInstallerWrapper = feeEstimationRegistry.createFeeInstallerWrapper(
             payingIn: chainAssetId,
-            connection: connection,
-            runtimeService: runtimeRegistry
+            senderResolutionOperation: senderResolutionOperation
         )
 
         let extrinsicsOperation = createExtrinsicsOperation(

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicOperationFactory.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicOperationFactory.swift
@@ -358,10 +358,11 @@ final class ExtrinsicOperationFactory: BaseExtrinsicOperationFactory {
 
         nonceOperation.addDependency(senderResolutionOperation)
 
-        let feeInstallerWrapper = feeEstimationRegistry.createFeeInstallerWrapper(
-            payingIn: chainAssetId,
-            senderResolutionOperation: senderResolutionOperation
-        )
+        let feeInstallerWrapper = feeEstimationRegistry.createFeeInstallerWrapper(payingIn: chainAssetId) {
+            try senderResolutionOperation.extractNoCancellableResultData().sender.account
+        }
+
+        feeInstallerWrapper.addDependency(operations: [senderResolutionOperation])
 
         let extrinsicsOperation = createExtrinsicsOperation(
             dependingOn: nonceOperation,

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicServiceFactory.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicServiceFactory.swift
@@ -117,7 +117,10 @@ extension ExtrinsicServiceFactory: ExtrinsicServiceFactoryProtocol {
 
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
-            estimatingWrapperFactory: feeEstimatingWrapperFactory
+            estimatingWrapperFactory: feeEstimatingWrapperFactory,
+            chainRegistry: ChainRegistryFacade.sharedRegistry,
+            userStorageFacade: userStorageFacade,
+            substrateStorageFacade: SubstrateDataStorageFacade.shared
         )
 
         return ExtrinsicService(
@@ -151,7 +154,10 @@ extension ExtrinsicServiceFactory: ExtrinsicServiceFactoryProtocol {
         )
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
-            estimatingWrapperFactory: feeEstimatingWrapperFactory
+            estimatingWrapperFactory: feeEstimatingWrapperFactory,
+            chainRegistry: ChainRegistryFacade.sharedRegistry,
+            userStorageFacade: userStorageFacade,
+            substrateStorageFacade: SubstrateDataStorageFacade.shared
         )
 
         return ExtrinsicOperationFactory(

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicServiceFactory.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicServiceFactory.swift
@@ -73,6 +73,7 @@ final class ExtrinsicServiceFactory {
     private let engine: JSONRPCEngine
     private let operationQueue: OperationQueue
     private let userStorageFacade: StorageFacadeProtocol
+    private let substrateStorageFacade: StorageFacadeProtocol
     private let metadataHashOperationFactory: MetadataHashOperationFactoryProtocol
 
     init(
@@ -92,6 +93,7 @@ final class ExtrinsicServiceFactory {
 
         self.operationQueue = operationQueue
         self.userStorageFacade = userStorageFacade
+        self.substrateStorageFacade = substrateStorageFacade
     }
 }
 
@@ -118,9 +120,11 @@ extension ExtrinsicServiceFactory: ExtrinsicServiceFactoryProtocol {
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
             estimatingWrapperFactory: feeEstimatingWrapperFactory,
-            chainRegistry: ChainRegistryFacade.sharedRegistry,
+            connection: engine,
+            runtimeProvider: runtimeRegistry,
             userStorageFacade: userStorageFacade,
-            substrateStorageFacade: SubstrateDataStorageFacade.shared
+            substrateStorageFacade: substrateStorageFacade,
+            operationQueue: operationQueue
         )
 
         return ExtrinsicService(
@@ -155,9 +159,11 @@ extension ExtrinsicServiceFactory: ExtrinsicServiceFactoryProtocol {
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
             estimatingWrapperFactory: feeEstimatingWrapperFactory,
-            chainRegistry: ChainRegistryFacade.sharedRegistry,
+            connection: engine,
+            runtimeProvider: runtimeRegistry,
             userStorageFacade: userStorageFacade,
-            substrateStorageFacade: SubstrateDataStorageFacade.shared
+            substrateStorageFacade: substrateStorageFacade,
+            operationQueue: operationQueue
         )
 
         return ExtrinsicOperationFactory(

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/FeeManaging/ExtrinsicFeeEstimationProtocol.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/FeeManaging/ExtrinsicFeeEstimationProtocol.swift
@@ -27,6 +27,6 @@ protocol ExtrinsicFeeEstimationRegistring {
 
     func createFeeInstallerWrapper(
         payingIn chainAssetId: ChainAssetId?,
-        senderResolutionOperation: ClosureOperation<ExtrinsicSenderBuilderResolution>
+        accountClosure: @escaping () throws -> ChainAccountResponse
     ) -> CompoundOperationWrapper<ExtrinsicFeeInstalling>
 }

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/FeeManaging/ExtrinsicFeeEstimationProtocol.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/FeeManaging/ExtrinsicFeeEstimationProtocol.swift
@@ -27,7 +27,6 @@ protocol ExtrinsicFeeEstimationRegistring {
 
     func createFeeInstallerWrapper(
         payingIn chainAssetId: ChainAssetId?,
-        connection: JSONRPCEngine,
-        runtimeService: RuntimeCodingServiceProtocol
+        senderResolutionOperation: ClosureOperation<ExtrinsicSenderBuilderResolution>
     ) -> CompoundOperationWrapper<ExtrinsicFeeInstalling>
 }

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/FeeManaging/Hydra/HydraExtrinsicFeeInstaller.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/FeeManaging/Hydra/HydraExtrinsicFeeInstaller.swift
@@ -47,19 +47,27 @@ extension HydraExtrinsicFeeInstaller: ExtrinsicFeeInstalling {
     }
 
     private func createTransferFeeCalls(using assetId: HydraDx.LocalRemoteAssetId) -> TransferFeeInstallingCalls {
-        guard
-            let currentFeeAssetId = swapState.feeCurrency,
-            currentFeeAssetId != assetId.remoteAssetId
-        else {
-            return TransferFeeInstallingCalls(
-                setCurrencyCall: nil,
-                revertCurrencyCall: nil
-            )
-        }
+        let setCurrencyCall: HydraDx.SetCurrencyCall? = {
+            let currentFeeAssetId = swapState.feeCurrency ?? HydraDx.nativeAssetId
+
+            guard currentFeeAssetId != assetId.remoteAssetId else {
+                return nil
+            }
+
+            return .init(currency: assetId.remoteAssetId)
+        }()
+
+        let revertCurrencyCall: HydraDx.SetCurrencyCall? = {
+            guard assetId.remoteAssetId != HydraDx.nativeAssetId else {
+                return nil
+            }
+
+            return .init(currency: HydraDx.nativeAssetId)
+        }()
 
         return TransferFeeInstallingCalls(
-            setCurrencyCall: .init(currency: assetId.remoteAssetId),
-            revertCurrencyCall: .init(currency: HydraDx.nativeAssetId)
+            setCurrencyCall: setCurrencyCall,
+            revertCurrencyCall: revertCurrencyCall
         )
     }
 }

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransferService.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransferService.swift
@@ -78,7 +78,10 @@ final class XcmTransferService {
 
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
-            estimatingWrapperFactory: feeEstimatingWrapperFactory
+            estimatingWrapperFactory: feeEstimatingWrapperFactory,
+            chainRegistry: chainRegistry,
+            userStorageFacade: UserDataStorageFacade.shared,
+            substrateStorageFacade: SubstrateDataStorageFacade.shared
         )
 
         let signedExtensionFactory = ExtrinsicSignedExtensionFacade().createFactory(for: chain.chainId)

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransferService.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransferService.swift
@@ -79,9 +79,11 @@ final class XcmTransferService {
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
             estimatingWrapperFactory: feeEstimatingWrapperFactory,
-            chainRegistry: chainRegistry,
+            connection: connection,
+            runtimeProvider: runtimeProvider,
             userStorageFacade: UserDataStorageFacade.shared,
-            substrateStorageFacade: SubstrateDataStorageFacade.shared
+            substrateStorageFacade: SubstrateDataStorageFacade.shared,
+            operationQueue: operationQueue
         )
 
         let signedExtensionFactory = ExtrinsicSignedExtensionFacade().createFactory(for: chain.chainId)

--- a/novawallet/Modules/AssetConversion/Service/AssetConversionFlowState.swift
+++ b/novawallet/Modules/AssetConversion/Service/AssetConversionFlowState.swift
@@ -101,17 +101,19 @@ final class AssetConversionFlowFacade {
             throw ChainAccountFetchingError.accountNotExists
         }
 
-        let hydra = HydraFlowState(
-            account: account,
-            chain: chain,
-            connection: connection,
-            runtimeProvider: runtimeProvider,
+        let flowStateStore = HydraFlowStateStore.getShared(
+            for: chainRegistry,
             userStorageFacade: userStorageFacade,
-            substrateStorageFacade: substrateStorageFacade,
-            operationQueue: operationQueue
+            substrateStorageFacade: substrateStorageFacade
         )
 
-        let newState = AssetConversionFlowState.hydra(hydra)
+        let hydraFlowState = try flowStateStore.setupFlowState(
+            account: account,
+            chain: chain,
+            queue: operationQueue
+        )
+
+        let newState = AssetConversionFlowState.hydra(hydraFlowState)
         state = newState
 
         return newState

--- a/novawallet/Modules/AssetConversion/Service/AssetConversionFlowState.swift
+++ b/novawallet/Modules/AssetConversion/Service/AssetConversionFlowState.swift
@@ -102,7 +102,8 @@ final class AssetConversionFlowFacade {
         }
 
         let flowStateStore = HydraFlowStateStore.getShared(
-            for: chainRegistry,
+            for: connection,
+            runtimeProvider: runtimeProvider,
             userStorageFacade: userStorageFacade,
             substrateStorageFacade: substrateStorageFacade
         )

--- a/novawallet/Modules/AssetConversion/Service/HydraDx/HydraFlowStateStore.swift
+++ b/novawallet/Modules/AssetConversion/Service/HydraDx/HydraFlowStateStore.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+private struct StateKey: Hashable {
+    let chainId: ChainModel.Id
+    let accountId: AccountId
+}
+
+protocol HydraFlowStateStoreSubscriber: AnyObject {
+    func flowStateStoreDidUpdate(_ newStates: [HydraFlowState])
+}
+
+class HydraFlowStateStore {
+    private static var shared: HydraFlowStateStore?
+
+    private var states: [StateKey: WeakWrapper] = [:]
+    private var statesUpdatesSubscriptions: [WeakWrapper] = []
+    private let mutex = NSLock()
+    private let chainRegistry: ChainRegistryProtocol
+    private let userStorageFacade: StorageFacadeProtocol
+    private let substrateStorageFacade: StorageFacadeProtocol
+
+    init(
+        chainRegistry: ChainRegistryProtocol,
+        userStorageFacade: StorageFacadeProtocol,
+        substrateStorageFacade: StorageFacadeProtocol
+    ) {
+        self.chainRegistry = chainRegistry
+        self.userStorageFacade = userStorageFacade
+        self.substrateStorageFacade = substrateStorageFacade
+    }
+}
+
+private extension HydraFlowStateStore {
+    func setupNewFlowState(
+        account: ChainAccountResponse,
+        chain: ChainModel,
+        stateKey: StateKey,
+        queue: OperationQueue
+    ) throws -> HydraFlowState {
+        guard let connection = chainRegistry.getConnection(for: chain.chainId) else {
+            throw ChainRegistryError.connectionUnavailable
+        }
+
+        guard let runtimeProvider = chainRegistry.getRuntimeProvider(for: chain.chainId) else {
+            throw ChainRegistryError.runtimeMetadaUnavailable
+        }
+
+        let flowState = HydraFlowState(
+            account: account,
+            chain: chain,
+            connection: connection,
+            runtimeProvider: runtimeProvider,
+            userStorageFacade: userStorageFacade,
+            substrateStorageFacade: substrateStorageFacade,
+            operationQueue: queue
+        )
+
+        states[stateKey] = WeakWrapper(target: flowState)
+
+        statesUpdatesSubscriptions.forEach { sub in
+            let mappedStates = states
+                .values
+                .compactMap { $0.target as? HydraFlowState }
+
+            (sub.target as? HydraFlowStateStoreSubscriber)?.flowStateStoreDidUpdate(mappedStates)
+        }
+
+        return flowState
+    }
+}
+
+extension HydraFlowStateStore {
+    func setupFlowState(
+        account: ChainAccountResponse,
+        chain: ChainModel,
+        queue: OperationQueue
+    ) throws -> HydraFlowState {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        let stateKey = StateKey(
+            chainId: chain.chainId,
+            accountId: account.accountId
+        )
+
+        let existingState = states[stateKey]?.target as? HydraFlowState
+
+        return if let existingState {
+            existingState
+        } else {
+            try setupNewFlowState(
+                account: account,
+                chain: chain,
+                stateKey: stateKey,
+                queue: queue
+            )
+        }
+    }
+
+    func subscribeForChangesUpdates(_ subscriber: HydraFlowStateStoreSubscriber) {
+        mutex.lock()
+
+        let weak = WeakWrapper(target: subscriber)
+        statesUpdatesSubscriptions.append(weak)
+
+        mutex.unlock()
+    }
+
+    static func getShared(
+        for chainRegistry: ChainRegistryProtocol,
+        userStorageFacade: StorageFacadeProtocol,
+        substrateStorageFacade: StorageFacadeProtocol
+    ) -> HydraFlowStateStore {
+        if let shared {
+            return shared
+        }
+
+        let store = HydraFlowStateStore(
+            chainRegistry: chainRegistry,
+            userStorageFacade: userStorageFacade,
+            substrateStorageFacade: substrateStorageFacade
+        )
+
+        shared = store
+
+        return store
+    }
+}

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmViewFactory.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmViewFactory.swift
@@ -162,9 +162,11 @@ struct DAppOperationConfirmViewFactory {
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
             estimatingWrapperFactory: feeEstimatingWrapperFactory,
-            chainRegistry: chainRegistry,
+            connection: connection,
+            runtimeProvider: runtimeProvider,
             userStorageFacade: UserDataStorageFacade.shared,
-            substrateStorageFacade: SubstrateDataStorageFacade.shared
+            substrateStorageFacade: SubstrateDataStorageFacade.shared,
+            operationQueue: operationQueue
         )
 
         return DAppOperationConfirmInteractor(

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmViewFactory.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmViewFactory.swift
@@ -161,7 +161,10 @@ struct DAppOperationConfirmViewFactory {
         )
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
-            estimatingWrapperFactory: feeEstimatingWrapperFactory
+            estimatingWrapperFactory: feeEstimatingWrapperFactory,
+            chainRegistry: chainRegistry,
+            userStorageFacade: UserDataStorageFacade.shared,
+            substrateStorageFacade: SubstrateDataStorageFacade.shared
         )
 
         return DAppOperationConfirmInteractor(

--- a/novawalletIntegrationTests/AutocompounDelegateStakeTests.swift
+++ b/novawalletIntegrationTests/AutocompounDelegateStakeTests.swift
@@ -204,7 +204,10 @@ class AutocompounDelegateStakeTests: XCTestCase {
 
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
-            estimatingWrapperFactory: feeEstimatingWrapperFactory
+            estimatingWrapperFactory: feeEstimatingWrapperFactory,
+            chainRegistry: chainRegistry,
+            userStorageFacade: UserDataStorageTestFacade(),
+            substrateStorageFacade: storageFacade
         )
         
         extrinsicService = ExtrinsicService(
@@ -297,7 +300,10 @@ class AutocompounDelegateStakeTests: XCTestCase {
 
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
-            estimatingWrapperFactory: feeEstimatingWrapperFactory
+            estimatingWrapperFactory: feeEstimatingWrapperFactory,
+            chainRegistry: chainRegistry,
+            userStorageFacade: UserDataStorageTestFacade(),
+            substrateStorageFacade: storageFacade
         )
         
         extrinsicService = ExtrinsicService(

--- a/novawalletIntegrationTests/AutocompounDelegateStakeTests.swift
+++ b/novawalletIntegrationTests/AutocompounDelegateStakeTests.swift
@@ -205,9 +205,11 @@ class AutocompounDelegateStakeTests: XCTestCase {
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
             estimatingWrapperFactory: feeEstimatingWrapperFactory,
-            chainRegistry: chainRegistry,
+            connection: connection,
+            runtimeProvider: runtimeProvider,
             userStorageFacade: UserDataStorageTestFacade(),
-            substrateStorageFacade: storageFacade
+            substrateStorageFacade: storageFacade,
+            operationQueue: operationQueue
         )
         
         extrinsicService = ExtrinsicService(
@@ -301,9 +303,11 @@ class AutocompounDelegateStakeTests: XCTestCase {
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
             estimatingWrapperFactory: feeEstimatingWrapperFactory,
-            chainRegistry: chainRegistry,
+            connection: connection,
+            runtimeProvider: runtimeService,
             userStorageFacade: UserDataStorageTestFacade(),
-            substrateStorageFacade: storageFacade
+            substrateStorageFacade: storageFacade,
+            operationQueue: operationQueue
         )
         
         extrinsicService = ExtrinsicService(

--- a/novawalletIntegrationTests/ExtrinsicServiceTests.swift
+++ b/novawalletIntegrationTests/ExtrinsicServiceTests.swift
@@ -77,9 +77,11 @@ class ExtrinsicServiceTests: XCTestCase {
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
             estimatingWrapperFactory: feeEstimatingWrapperFactory,
-            chainRegistry: chainRegistry,
+            connection: connection,
+            runtimeProvider: runtimeService,
             userStorageFacade: UserDataStorageTestFacade(),
-            substrateStorageFacade: storageFacade
+            substrateStorageFacade: storageFacade,
+            operationQueue: operationQueue
         )
         
         let extrinsicService = ExtrinsicService(
@@ -155,9 +157,11 @@ class ExtrinsicServiceTests: XCTestCase {
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
             estimatingWrapperFactory: feeEstimatingWrapperFactory,
-            chainRegistry: chainRegistry,
+            connection: connection,
+            runtimeProvider: runtimeService,
             userStorageFacade: UserDataStorageTestFacade(),
-            substrateStorageFacade: storageFacade
+            substrateStorageFacade: storageFacade,
+            operationQueue: operationQueue
         )
         
         let extrinsicService = ExtrinsicService(

--- a/novawalletIntegrationTests/ExtrinsicServiceTests.swift
+++ b/novawalletIntegrationTests/ExtrinsicServiceTests.swift
@@ -76,7 +76,10 @@ class ExtrinsicServiceTests: XCTestCase {
 
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
-            estimatingWrapperFactory: feeEstimatingWrapperFactory
+            estimatingWrapperFactory: feeEstimatingWrapperFactory,
+            chainRegistry: chainRegistry,
+            userStorageFacade: UserDataStorageTestFacade(),
+            substrateStorageFacade: storageFacade
         )
         
         let extrinsicService = ExtrinsicService(
@@ -151,7 +154,10 @@ class ExtrinsicServiceTests: XCTestCase {
 
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
-            estimatingWrapperFactory: feeEstimatingWrapperFactory
+            estimatingWrapperFactory: feeEstimatingWrapperFactory,
+            chainRegistry: chainRegistry,
+            userStorageFacade: UserDataStorageTestFacade(),
+            substrateStorageFacade: storageFacade
         )
         
         let extrinsicService = ExtrinsicService(

--- a/novawalletTests/Modules/DApps/DAppOperationConfirm/DAppOperationConfirmTests.swift
+++ b/novawalletTests/Modules/DApps/DAppOperationConfirm/DAppOperationConfirmTests.swift
@@ -121,7 +121,10 @@ class DAppOperationConfirmTests: XCTestCase {
 
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
-            estimatingWrapperFactory: feeEstimatingWrapperFactory
+            estimatingWrapperFactory: feeEstimatingWrapperFactory,
+            chainRegistry: ChainRegistryFacade.sharedRegistry,
+            userStorageFacade: UserDataStorageTestFacade(),
+            substrateStorageFacade: SubstrateStorageTestFacade()
         )
 
         let interactor = DAppOperationConfirmInteractor(

--- a/novawalletTests/Modules/DApps/DAppOperationConfirm/DAppOperationConfirmTests.swift
+++ b/novawalletTests/Modules/DApps/DAppOperationConfirm/DAppOperationConfirmTests.swift
@@ -122,9 +122,11 @@ class DAppOperationConfirmTests: XCTestCase {
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
             estimatingWrapperFactory: feeEstimatingWrapperFactory,
-            chainRegistry: ChainRegistryFacade.sharedRegistry,
+            connection: connection,
+            runtimeProvider: runtimeProvider,
             userStorageFacade: UserDataStorageTestFacade(),
-            substrateStorageFacade: SubstrateStorageTestFacade()
+            substrateStorageFacade: SubstrateStorageTestFacade(),
+            operationQueue: operationQueue
         )
 
         let interactor = DAppOperationConfirmInteractor(


### PR DESCRIPTION
- Store weak 'HydraFlowStates' inside of shared 'HydraFlowStateStore'
- Keep flows alive until the end of flow by storing strong refs in ExtrinsicFeeEstimationRegistry
- Use hydra swap state to get current fee currency
- Determine if we need a setCurrency call depending on current fee currency and new one