### PR TITLE
Fix/swipegov fixes

### DIFF
--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Helpers/SwipeGovModelBuilder.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Helpers/SwipeGovModelBuilder.swift
@@ -114,10 +114,8 @@ private extension SwipeGovModelBuilder {
         var updates: [ReferendumLocal] = []
         var deletes: [ReferendumIdLocal] = []
 
-        let lastDeletes = Set(currentModel.referendumsChanges.deletes)
-
         newReferendums.forEach { key, value in
-            if self.referendums[key] == nil || lastDeletes.contains(key) {
+            if self.referendums[key] == nil {
                 inserts.append(value)
             } else {
                 updates.append(value)

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Helpers/SwipeGovModelBuilder.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Helpers/SwipeGovModelBuilder.swift
@@ -41,10 +41,9 @@ extension SwipeGovModelBuilder: SwipeGovModelBuilderProtocol {
         workingQueue.addOperation { [weak self] in
             guard let self else { return }
 
-            let filteredReferendums = filteredReferendums(from: referendumsState)
-            let changes = createReferendumsChange(from: filteredReferendums)
+            referendums = filteredReferendums(from: referendumsState)
 
-            referendums = filteredReferendums
+            let changes = createReferendumsChange(from: referendums)
 
             rebuild(
                 with: changes,
@@ -115,8 +114,10 @@ private extension SwipeGovModelBuilder {
         var updates: [ReferendumLocal] = []
         var deletes: [ReferendumIdLocal] = []
 
+        let lastDeletes = Set(currentModel.referendumsChanges.deletes)
+
         newReferendums.forEach { key, value in
-            if self.referendums[key] == nil {
+            if self.referendums[key] == nil || lastDeletes.contains(key) {
                 inserts.append(value)
             } else {
                 updates.append(value)

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Helpers/SwipeGovViewModelFactory.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Helpers/SwipeGovViewModelFactory.swift
@@ -74,13 +74,16 @@ struct SwipeGovViewModelFactory: SwipeGovViewModelFactoryProtocol {
         votingList: [VotingBasketItemLocal],
         locale: Locale
     ) -> String? {
-        guard !referendums.isEmpty else {
+        guard
+            !referendums.isEmpty,
+            referendums.count - votingList.count > 0
+        else {
             return R.string.localizable.swipeGovReferendaCounterEmpty(
                 preferredLanguages: locale.rLanguages
             )
         }
 
-        let currentNumber = referendums.count - votingList.count
+        let currentNumber = votingList.count + 1
 
         let counterString = R.string.localizable.commonCounter(
             currentNumber,

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovPresenter.swift
@@ -36,6 +36,10 @@ extension SwipeGovPresenter: SwipeGovPresenterProtocol {
         interactor.setup()
     }
 
+    func cardsStackBecameEmpty() {
+        showVotingList()
+    }
+
     func actionBack() {
         wireframe.back(from: view)
     }

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovProtocols.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovProtocols.swift
@@ -9,6 +9,7 @@ protocol SwipeGovViewProtocol: ControllerBackedProtocol {
 
 protocol SwipeGovPresenterProtocol: AnyObject {
     func setup()
+    func cardsStackBecameEmpty()
     func actionBack()
     func actionSettings()
     func actionVotingList()

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovViewController.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovViewController.swift
@@ -7,6 +7,8 @@ final class SwipeGovViewController: UIViewController, ViewHolder {
 
     let presenter: SwipeGovPresenterProtocol
 
+    var cardsStackViewModel: CardsZStackViewModel?
+
     private lazy var titleLabel: UILabel = .create { view in
         view.apply(style: .semiboldBodyPrimary)
         view.textAlignment = .center
@@ -91,6 +93,16 @@ extension SwipeGovViewController: SwipeGovViewProtocol {
         rootView.cardsStack.setupValidationAction(viewModel.validationAction)
         rootView.emptyStateView.bind(with: viewModel.emptyViewModel)
         rootView.finishedAddingCards()
+
+        if viewModel.stackIsEmpty {
+            rootView.hideVoteButtons()
+        } else {
+            rootView.showVoteButtons()
+        }
+
+        notifyPresenterOnEmptyIfNeeded(using: viewModel)
+
+        cardsStackViewModel = viewModel
     }
 
     func skipCard() {
@@ -109,6 +121,18 @@ extension SwipeGovViewController: SwipeGovViewProtocol {
 // MARK: Private
 
 private extension SwipeGovViewController {
+    func notifyPresenterOnEmptyIfNeeded(using viewModel: CardsZStackViewModel) {
+        guard
+            let oldViewModel = cardsStackViewModel,
+            viewModel.stackIsEmpty,
+            !oldViewModel.stackIsEmpty
+        else {
+            return
+        }
+
+        presenter.cardsStackBecameEmpty()
+    }
+
     func setupNavigationBar() {
         let titleStackView = UIStackView.vStack(
             spacing: 2,

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovViewLayout.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovViewLayout.swift
@@ -23,6 +23,7 @@ final class SwipeGovViewLayout: UIView {
         button.roundedBackgroundView?.highlightedFillColor = R.color.colorButtonBackgroundApprove()!
         button.roundedBackgroundView?.cornerRadius = Constants.bigButtonSize / 2
         button.imageWithTitleView?.iconImage = R.image.iconThumbsUpFilled()
+        button.alpha = 0
         return button
     }()
 
@@ -33,6 +34,7 @@ final class SwipeGovViewLayout: UIView {
         button.roundedBackgroundView?.highlightedFillColor = R.color.colorButtonBackgroundSecondary()!
         button.roundedBackgroundView?.cornerRadius = Constants.smallButtonSize / 2
         button.imageWithTitleView?.iconImage = R.image.iconAbstain()
+        button.alpha = 0
         return button
     }()
 
@@ -43,10 +45,29 @@ final class SwipeGovViewLayout: UIView {
         button.roundedBackgroundView?.highlightedFillColor = R.color.colorButtonBackgroundReject()!
         button.roundedBackgroundView?.cornerRadius = Constants.bigButtonSize / 2
         button.imageWithTitleView?.iconImage = R.image.iconThumbsDownFilled()
+        button.alpha = 0
         return button
     }()
 
     let emptyStateView = SwipeGovEmptyStateView()
+
+    let buttonsHideAnimator: ViewAnimatorProtocol = FadeAnimator(
+        from: 1.0,
+        to: 0.0,
+        duration: 0.3,
+        delay: 0.0,
+        options: .curveEaseInOut
+    )
+
+    let buttonsShowAnimator: ViewAnimatorProtocol = FadeAnimator(
+        from: 0.0,
+        to: 1.0,
+        duration: 0.3,
+        delay: 0.0,
+        options: .curveEaseInOut
+    )
+
+    var voteButtonsAreHidden: Bool = true
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -57,6 +78,36 @@ final class SwipeGovViewLayout: UIView {
     @available(*, unavailable)
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func hideVoteButtons() {
+        guard !voteButtonsAreHidden else {
+            return
+        }
+
+        [nayButton, abstainButton, ayeButton].forEach {
+            buttonsHideAnimator.animate(
+                view: $0,
+                completionBlock: { [weak self] _ in
+                    self?.voteButtonsAreHidden = true
+                }
+            )
+        }
+    }
+
+    func showVoteButtons() {
+        guard voteButtonsAreHidden else {
+            return
+        }
+
+        [nayButton, abstainButton, ayeButton].forEach {
+            buttonsShowAnimator.animate(
+                view: $0,
+                completionBlock: { [weak self] _ in
+                    self?.voteButtonsAreHidden = false
+                }
+            )
+        }
     }
 }
 

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Views/CardsZStack/CardsZStack.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Views/CardsZStack/CardsZStack.swift
@@ -511,9 +511,10 @@ private extension CardsZStack {
         static let cardCornerRadius: CGFloat = 16
         static let stackZScaling: CGFloat = 0.9
         static let lowerCardsOffset: CGFloat = 10.0
-        static let screenSizeDivider: CGFloat = 2.3
-        static let topMostY = -(UIScreen.main.bounds.height / Constants.screenSizeDivider)
-        static let leftMostX = -(UIScreen.main.bounds.width / Constants.screenSizeDivider)
-        static let rightMostX = UIScreen.main.bounds.width / Constants.screenSizeDivider
+        static let horizontalScreenSizeDivider: CGFloat = 3.15
+        static let verticalScreenSizeDivider: CGFloat = 3.8
+        static let topMostY = -(UIScreen.main.bounds.height / Constants.verticalScreenSizeDivider)
+        static let leftMostX = -(UIScreen.main.bounds.width / Constants.horizontalScreenSizeDivider)
+        static let rightMostX = UIScreen.main.bounds.width / Constants.horizontalScreenSizeDivider
     }
 }

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Views/CardsZStack/CardsZStack.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Views/CardsZStack/CardsZStack.swift
@@ -12,6 +12,8 @@ struct CardsZStackViewModel {
     let changeModel: CardsZStackChangeModel
     let emptyViewModel: SwipeGovEmptyStateViewModel
     let validationAction: ((VoteCardViewModel?) -> Bool)?
+
+    let stackIsEmpty: Bool
 }
 
 struct CardsZStackChangeModel {

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Views/CardsZStack/VoteCardViewModelFactory.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Views/CardsZStack/VoteCardViewModelFactory.swift
@@ -77,10 +77,15 @@ extension VoteCardViewModelFactory: VoteCardViewModelFactoryProtocol {
             emptyViewAction: emptyViewAction
         )
 
+        // we use <= instead of == to cover the case where there might be no
+        // loaded referendums yet, but we have voting items persisted
+        let stackIsEmpty = (model.referendums.count - model.votingList.count) <= 0
+
         let viewModel = CardsZStackViewModel(
             changeModel: stackChangeModel,
             emptyViewModel: emptyViewModel,
-            validationAction: validationClosure
+            validationAction: validationClosure,
+            stackIsEmpty: stackIsEmpty
         )
 
         return viewModel

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Views/VotingListWidget.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/Views/VotingListWidget.swift
@@ -51,6 +51,8 @@ class VotingListWidget: UIView {
 
             counterView.titleLabel.text = value
             titleLabel.text = title
+
+            isUserInteractionEnabled = true
         case let .empty(value, title):
             counterView.backgroundView.fillColor = R.color.colorIconInactive()!
             counterView.titleLabel.apply(style: .semiboldCaps2Inactive)
@@ -58,6 +60,8 @@ class VotingListWidget: UIView {
 
             counterView.titleLabel.text = value
             titleLabel.text = title
+
+            isUserInteractionEnabled = false
         }
     }
 }

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListPresenter.swift
@@ -103,7 +103,7 @@ extension SwipeGovVotingListPresenter: SwipeGovVotingListInteractorOutputProtoco
             } else {
                 validateBalanceSufficient()
 
-                updateView(with: deletes)
+                updateView()
             }
         }
 
@@ -169,7 +169,7 @@ extension SwipeGovVotingListPresenter: SwipeGovVotingListInteractorOutputProtoco
 // MARK: Private
 
 private extension SwipeGovVotingListPresenter {
-    func updateView(with deletes: [ReferendumIdLocal]? = nil) {
+    func updateView() {
         guard
             !referendumsMetadata.isEmpty,
             !votingListItems.isEmpty
@@ -184,13 +184,7 @@ private extension SwipeGovVotingListPresenter {
             locale: localizationManager.selectedLocale
         )
 
-        if let deletes, !deletes.isEmpty {
-            deletes.forEach { referendumId in
-                view?.didChangeViewModel(viewModel, byRemovingItemWith: referendumId)
-            }
-        } else {
-            view?.didReceive(viewModel)
-        }
+        view?.didReceive(viewModel)
     }
 
     func validateBalanceSufficient(_ closure: (() -> Void)? = nil) {
@@ -263,13 +257,16 @@ private extension SwipeGovVotingListPresenter {
             return
         }
 
+        let action: () -> Void = { [weak self] in
+            self?.votingListItems.removeAll(where: { $0.referendumId == referendumId })
+            self?.interactor.removeItem(with: removeItem.identifier)
+        }
+
         wireframe.presentRemoveListItem(
             from: view,
             for: removeItem,
             locale: localizationManager.selectedLocale,
-            action: { [weak self] in
-                self?.interactor.removeItem(with: removeItem.identifier)
-            }
+            action: action
         )
     }
 

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListProtocols.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListProtocols.swift
@@ -2,10 +2,6 @@ import Operation_iOS
 
 protocol SwipeGovVotingListViewProtocol: ControllerBackedProtocol {
     func didReceive(_ viewModel: SwipeGovVotingListViewModel)
-    func didChangeViewModel(
-        _ viewModel: SwipeGovVotingListViewModel,
-        byRemovingItemWith referendumId: ReferendumIdLocal
-    )
 }
 
 protocol SwipeGovVotingListPresenterProtocol: AnyObject {

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListViewController.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListViewController.swift
@@ -48,24 +48,6 @@ extension SwipeGovVotingListViewController: SwipeGovVotingListViewProtocol {
         self.viewModel = viewModel
         rootView.tableView.reloadData()
     }
-
-    func didChangeViewModel(
-        _ viewModel: SwipeGovVotingListViewModel,
-        byRemovingItemWith referendumId: ReferendumIdLocal
-    ) {
-        guard let rowIndex = self.viewModel?.cellViewModels.firstIndex(where: {
-            $0.referendumIndex == referendumId
-        }) else {
-            return
-        }
-
-        self.viewModel = viewModel
-
-        let indexPath = IndexPath(row: rowIndex, section: 0)
-        rootView.tableView.deleteRows(at: [indexPath], with: .left)
-
-        updateVoteButton()
-    }
 }
 
 // MARK: UITableViewDataSource


### PR DESCRIPTION
- Referendums removed from the list are now enqueued back to the stack of cards.
- Fixed issue with fast sequential card dismissal.
- The excluded referenda alert is no longer triggered by the user's removal actions on the voting list.
- Cards are now more sensitive to swipes.
- Vote controls are hidden in the empty state, and the user is redirected to the basket if the stack becomes empty.
- The card counter now shows the position of the cards.