### PR TITLE
Support Generic Ledger in DApp Browser

### DIFF
--- a/novawallet/Common/ViewModel/RemoteImageViewModel.swift
+++ b/novawallet/Common/ViewModel/RemoteImageViewModel.swift
@@ -76,7 +76,7 @@ final class RemoteImageSerializer: CacheSerializer {
             return uiImage
         } else {
             let imsvg = SVGKImage(data: data)
-            return imsvg?.uiImage ?? UIImage()
+            return imsvg?.uiImage
         }
     }
 }

--- a/novawallet/Modules/DApp/DAppBrowser/StateMachine/PolkadotExtensionStates/DAppBrowserSigningState.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/StateMachine/PolkadotExtensionStates/DAppBrowserSigningState.swift
@@ -9,7 +9,11 @@ final class DAppBrowserSigningState: DAppBrowserBaseState {
         super.init(stateMachine: stateMachine)
     }
 
-    private func provideOperationResponse(with signature: Data, nextState: DAppBrowserStateProtocol) throws {
+    private func provideOperationResponse(
+        with signature: Data,
+        modifiedTransaction: Data?,
+        nextState: DAppBrowserStateProtocol
+    ) throws {
         guard let msgType = signingType.msgType else {
             return
         }
@@ -17,7 +21,8 @@ final class DAppBrowserSigningState: DAppBrowserBaseState {
         let identifier = (0 ... UInt32.max).randomElement() ?? 0
         let result = PolkadotExtensionSignerResult(
             identifier: UInt(identifier),
-            signature: signature.toHex(includePrefix: true)
+            signature: signature.toHex(includePrefix: true),
+            signedTransaction: modifiedTransaction?.toHex(includePrefix: true)
         )
 
         try provideResponse(for: msgType, result: result, nextState: nextState)
@@ -54,7 +59,11 @@ extension DAppBrowserSigningState: DAppBrowserStateProtocol {
 
         if let signature = response.signature {
             do {
-                try provideOperationResponse(with: signature, nextState: nextState)
+                try provideOperationResponse(
+                    with: signature,
+                    modifiedTransaction: response.modifiedTransaction,
+                    nextState: nextState
+                )
             } catch {
                 stateMachine?.emit(error: error, nextState: nextState)
             }

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppEthereumConfirmInteractor.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppEthereumConfirmInteractor.swift
@@ -202,7 +202,7 @@ final class DAppEthereumConfirmInteractor: DAppOperationBaseInteractor {
                 switch result {
                 case let .success(txHash):
                     let txHashData = try Data(hexString: txHash)
-                    let response = DAppOperationResponse(signature: txHashData)
+                    let response = DAppOperationResponse(signature: txHashData, modifiedTransaction: nil)
                     let result: Result<DAppOperationResponse, Error> = .success(response)
                     self.presenter?.didReceive(responseResult: result, for: self.request)
                 case let .failure(error):
@@ -234,7 +234,7 @@ final class DAppEthereumConfirmInteractor: DAppOperationBaseInteractor {
             do {
                 switch result {
                 case let .success(signedTransaction):
-                    let response = DAppOperationResponse(signature: signedTransaction)
+                    let response = DAppOperationResponse(signature: signedTransaction, modifiedTransaction: nil)
                     let result: Result<DAppOperationResponse, Error> = .success(response)
                     self.presenter?.didReceive(responseResult: result, for: self.request)
                 case let .failure(error):
@@ -304,7 +304,7 @@ extension DAppEthereumConfirmInteractor: DAppOperationConfirmInteractorInputProt
     }
 
     func reject() {
-        let response = DAppOperationResponse(signature: nil)
+        let response = DAppOperationResponse(signature: nil, modifiedTransaction: nil)
         presenter?.didReceive(responseResult: .success(response), for: request)
     }
 

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppEthereumSignBytesInteractor.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppEthereumSignBytesInteractor.swift
@@ -103,7 +103,7 @@ extension DAppEthereumSignBytesInteractor: DAppOperationConfirmInteractorInputPr
 
                     do {
                         let signature = try signingOperation.extractNoCancellableResultData()
-                        let response = DAppOperationResponse(signature: signature)
+                        let response = DAppOperationResponse(signature: signature, modifiedTransaction: nil)
 
                         self.presenter?.didReceive(responseResult: .success(response), for: self.request)
                     } catch {
@@ -119,7 +119,7 @@ extension DAppEthereumSignBytesInteractor: DAppOperationConfirmInteractorInputPr
     }
 
     func reject() {
-        let response = DAppOperationResponse(signature: nil)
+        let response = DAppOperationResponse(signature: nil, modifiedTransaction: nil)
         presenter?.didReceive(responseResult: .success(response), for: request)
     }
 

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Proccessing.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Proccessing.swift
@@ -79,19 +79,13 @@ extension DAppOperationConfirmInteractor {
                 )
             }
 
-            // TODO: Find out whether to return this validation
-
             guard
-                let specVersion = BigUInt.fromHexString(extrinsic.specVersion) /* ,
-                 codingFactory.specVersion == specVersion */ else {
+                let specVersion = BigUInt.fromHexString(extrinsic.specVersion) else {
                 throw DAppOperationConfirmInteractorError.extrinsicBadField(name: "specVersion")
             }
 
-            // TODO: Find out whether to return this validation
-
             guard
-                let transactionVersion = BigUInt.fromHexString(extrinsic.transactionVersion) /* ,
-                 codingFactory.txVersion == transactionVersion */ else {
+                let transactionVersion = BigUInt.fromHexString(extrinsic.transactionVersion) else {
                 throw DAppOperationConfirmInteractorError.extrinsicBadField(name: "transactionVersion")
             }
 
@@ -135,6 +129,8 @@ extension DAppOperationConfirmInteractor {
                 specVersion: UInt32(specVersion),
                 tip: tip,
                 transactionVersion: UInt32(transactionVersion),
+                metadataHash: extrinsic.metadataHash,
+                withSignedTransaction: extrinsic.withSignedTransaction ?? false,
                 signedExtensions: expectedSignedExtensions,
                 version: extrinsic.version
             )

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Protocol.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Protocol.swift
@@ -13,7 +13,7 @@ extension DAppOperationConfirmInteractor: DAppOperationConfirmInteractorInputPro
     }
 
     func confirm() {
-        guard signWrapper == nil, let extrinsicFactory = extrinsicFactory else {
+        guard !signCancellable.hasCall, let extrinsicFactory = extrinsicFactory else {
             return
         }
 
@@ -24,46 +24,43 @@ extension DAppOperationConfirmInteractor: DAppOperationConfirmInteractorInputPro
 
         let signWrapper = createSignatureOperation(for: extrinsicFactory, signer: signer)
 
-        self.signWrapper = signWrapper
+        executeCancellable(
+            wrapper: signWrapper,
+            inOperationQueue: operationQueue,
+            backingCallIn: signCancellable,
+            runningCallbackIn: .main
+        ) { [weak self] result in
+            guard let request = self?.request else {
+                return
+            }
 
-        signWrapper.targetOperation.completionBlock = { [weak self] in
-            DispatchQueue.main.async {
-                guard self?.signWrapper != nil else {
-                    return
+            switch result {
+            case let .success(signatureResult):
+                let response = DAppOperationResponse(
+                    signature: signatureResult.signature,
+                    modifiedTransaction: signatureResult.modifiedExtrinsic
+                )
+
+                self?.presenter?.didReceive(responseResult: .success(response), for: request)
+            case let .failure(error):
+                let interactorError: Error
+                if let noKeysError = error as? NoKeysSigningWrapperError {
+                    interactorError = noKeysError
+                } else if let hardwareSigningError = error as? HardwareSigningError {
+                    interactorError = hardwareSigningError
+                } else if let operationError = error as? DAppOperationConfirmInteractorError {
+                    interactorError = operationError
+                } else {
+                    interactorError = DAppOperationConfirmInteractorError.signingFailed
                 }
 
-                self?.signWrapper = nil
-
-                guard let request = self?.request else {
-                    return
-                }
-
-                do {
-                    let signature = try signWrapper.targetOperation.extractNoCancellableResultData()
-                    let response = DAppOperationResponse(signature: signature)
-                    self?.presenter?.didReceive(responseResult: .success(response), for: request)
-                } catch {
-                    let interactorError: Error
-                    if let noKeysError = error as? NoKeysSigningWrapperError {
-                        interactorError = noKeysError
-                    } else if let hardwareSigningError = error as? HardwareSigningError {
-                        interactorError = hardwareSigningError
-                    } else if let operationError = error as? DAppOperationConfirmInteractorError {
-                        interactorError = operationError
-                    } else {
-                        interactorError = DAppOperationConfirmInteractorError.signingFailed
-                    }
-
-                    self?.presenter?.didReceive(responseResult: .failure(interactorError), for: request)
-                }
+                self?.presenter?.didReceive(responseResult: .failure(interactorError), for: request)
             }
         }
-
-        operationQueue.addOperations(signWrapper.allOperations, waitUntilFinished: false)
     }
 
     func reject() {
-        guard signWrapper == nil else {
+        guard !signCancellable.hasCall else {
             return
         }
 
@@ -72,7 +69,7 @@ extension DAppOperationConfirmInteractor: DAppOperationConfirmInteractorInputPro
     }
 
     func estimateFee() {
-        guard feeWrapper == nil, let extrinsicFactory = extrinsicFactory else {
+        guard !feeCancellable.hasCall, let extrinsicFactory = extrinsicFactory else {
             return
         }
 
@@ -89,29 +86,21 @@ extension DAppOperationConfirmInteractor: DAppOperationConfirmInteractorInputPro
             builder
         }
 
-        feeWrapper.targetOperation.completionBlock = { [weak self] in
-            DispatchQueue.main.async {
-                guard self?.feeWrapper != nil else {
-                    return
-                }
-
-                self?.feeWrapper = nil
-
-                do {
-                    let info = try feeWrapper.targetOperation.extractNoCancellableResultData()
-
-                    // TODO: Consider fee payer here
-                    let feeModel = FeeOutputModel(value: info, validationProvider: nil)
-                    self?.presenter?.didReceive(feeResult: .success(feeModel))
-                } catch {
-                    self?.presenter?.didReceive(feeResult: .failure(error))
-                }
+        executeCancellable(
+            wrapper: feeWrapper,
+            inOperationQueue: operationQueue,
+            backingCallIn: feeCancellable,
+            runningCallbackIn: .main
+        ) { [weak self] result in
+            switch result {
+            case let .success(info):
+                // TODO: Consider fee payer here
+                let feeModel = FeeOutputModel(value: info, validationProvider: nil)
+                self?.presenter?.didReceive(feeResult: .success(feeModel))
+            case let .failure(error):
+                self?.presenter?.didReceive(feeResult: .failure(error))
             }
         }
-
-        self.feeWrapper = feeWrapper
-
-        operationQueue.addOperations(feeWrapper.allOperations, waitUntilFinished: false)
     }
 
     func prepareTxDetails() {

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Protocol.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Protocol.swift
@@ -67,7 +67,7 @@ extension DAppOperationConfirmInteractor: DAppOperationConfirmInteractorInputPro
             return
         }
 
-        let response = DAppOperationResponse(signature: nil)
+        let response = DAppOperationResponse(signature: nil, modifiedTransaction: nil)
         presenter?.didReceive(responseResult: .success(response), for: request)
     }
 

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor.swift
@@ -9,7 +9,7 @@ final class DAppOperationConfirmInteractor: DAppOperationBaseInteractor {
         let signature: Data
         let modifiedExtrinsic: Data?
     }
-    
+
     let request: DAppOperationRequest
     let chain: ChainModel
 
@@ -24,8 +24,8 @@ final class DAppOperationConfirmInteractor: DAppOperationBaseInteractor {
     var extrinsicFactory: DAppExtrinsicBuilderOperationFactory?
 
     var priceProvider: StreamableProvider<PriceData>?
-    var feeWrapper: CompoundOperationWrapper<ExtrinsicFeeProtocol>?
-    var signWrapper: CompoundOperationWrapper<Data>?
+    let feeCancellable = CancellableCallStore()
+    var signCancellable = CancellableCallStore()
 
     init(
         request: DAppOperationRequest,
@@ -125,7 +125,7 @@ final class DAppOperationConfirmInteractor: DAppOperationBaseInteractor {
 
             let scaleEncoder = codingFactory.createEncoder()
 
-            let rawSignature = signatureResult.signedExtrinsic
+            let rawSignature = signatureResult.signature
 
             switch extrinsicFactory.processedResult.account.cryptoType {
             case .sr25519:
@@ -159,8 +159,8 @@ final class DAppOperationConfirmInteractor: DAppOperationBaseInteractor {
             }
 
             let signature = try scaleEncoder.encode()
-            
-            return SignatureResult(signature: signature, modifiedExtrinsic: signatureResult.signedExtrinsic)
+
+            return SignatureResult(signature: signature, modifiedExtrinsic: signatureResult.modifiedExtrinsic)
         }
 
         signatureOperation.addDependency(codingFactoryOperation)

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmViewFactory.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmViewFactory.swift
@@ -151,6 +151,7 @@ struct DAppOperationConfirmViewFactory {
         }
 
         let operationQueue = OperationManagerFacade.sharedDefaultQueue
+        let substrateStorageFacade = SubstrateDataStorageFacade.shared
 
         let feeEstimatingWrapperFactory = ExtrinsicFeeEstimatingWrapperFactory(
             account: account,
@@ -159,13 +160,19 @@ struct DAppOperationConfirmViewFactory {
             connection: connection,
             operationQueue: operationQueue
         )
+
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
             estimatingWrapperFactory: feeEstimatingWrapperFactory,
             connection: connection,
             runtimeProvider: runtimeProvider,
             userStorageFacade: UserDataStorageFacade.shared,
-            substrateStorageFacade: SubstrateDataStorageFacade.shared,
+            substrateStorageFacade: substrateStorageFacade,
+            operationQueue: operationQueue
+        )
+
+        let metadataHashFactory = MetadataHashOperationFactory(
+            metadataRepositoryFactory: RuntimeMetadataRepositoryFactory(storageFacade: substrateStorageFacade),
             operationQueue: operationQueue
         )
 
@@ -176,6 +183,7 @@ struct DAppOperationConfirmViewFactory {
             feeEstimationRegistry: feeEstimationRegistry,
             connection: connection,
             signingWrapperFactory: SigningWrapperFactory(keystore: Keychain()),
+            metadataHashFactory: metadataHashFactory,
             priceProviderFactory: PriceProviderFactory.shared,
             currencyManager: currencyManager,
             operationQueue: operationQueue

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppSignBytesConfirmInteractor.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppSignBytesConfirmInteractor.swift
@@ -113,7 +113,7 @@ extension DAppSignBytesConfirmInteractor: DAppOperationConfirmInteractorInputPro
                     do {
                         let signature = try signingOperation.extractNoCancellableResultData()
 
-                        let response = DAppOperationResponse(signature: signature)
+                        let response = DAppOperationResponse(signature: signature, modifiedTransaction: nil)
 
                         self.presenter?.didReceive(responseResult: .success(response), for: self.request)
                     } catch {
@@ -129,7 +129,7 @@ extension DAppSignBytesConfirmInteractor: DAppOperationConfirmInteractorInputPro
     }
 
     func reject() {
-        let response = DAppOperationResponse(signature: nil)
+        let response = DAppOperationResponse(signature: nil, modifiedTransaction: nil)
         presenter?.didReceive(responseResult: .success(response), for: request)
     }
 

--- a/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppExtrinsicBuilderOperationFactory.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppExtrinsicBuilderOperationFactory.swift
@@ -4,6 +4,12 @@ import Operation_iOS
 
 struct DAppExtrinsicRawSignatureResult {
     let sender: ExtrinsicSenderResolution
+    let signature: Data
+    let modifiedExtrinsic: Data?
+}
+
+struct DAppExtrinsicRawExtrinsicResult {
+    let sender: ExtrinsicSenderResolution
     let signedExtrinsic: Data
 }
 
@@ -11,25 +17,99 @@ final class DAppExtrinsicBuilderOperationFactory {
     struct ExtrinsicSenderBuilderResult {
         let sender: ExtrinsicSenderResolution
         let builder: ExtrinsicBuilderProtocol
+        let modifiedOriginalExtrinsic: Bool
+    }
+
+    struct MetadataHashResult {
+        let modifiedOriginal: Bool
+        let metadataHash: Data?
     }
 
     let processedResult: DAppOperationProcessedResult
+    let chain: ChainModel
     let runtimeProvider: RuntimeCodingServiceProtocol
+    let connection: JSONRPCEngine
+    let metadataHashOperationFactory: MetadataHashOperationFactoryProtocol
 
     init(
         processedResult: DAppOperationProcessedResult,
-        runtimeProvider: RuntimeCodingServiceProtocol
+        chain: ChainModel,
+        runtimeProvider: RuntimeCodingServiceProtocol,
+        connection: JSONRPCEngine,
+        metadataHashOperationFactory: MetadataHashOperationFactoryProtocol
     ) {
+        self.chain = chain
         self.processedResult = processedResult
         self.runtimeProvider = runtimeProvider
+        self.connection = connection
+        self.metadataHashOperationFactory = metadataHashOperationFactory
+    }
+
+    private func createActualMetadataHashWrapper(
+        for result: DAppOperationProcessedResult,
+        chain: ChainModel,
+        connection: JSONRPCEngine,
+        runtimeProvider: RuntimeCodingServiceProtocol
+    ) -> CompoundOperationWrapper<MetadataHashResult> {
+        do {
+            let optMetadataHash = try result.extrinsic.metadataHash.map { try Data(hexString: $0) }
+
+            /**
+             *  If a dapp haven't declared a permission to modify extrinsic - return whatever metadataHash present in payload
+             */
+            if !result.extrinsic.withSignedTransaction {
+                return .createWithResult(
+                    .init(
+                        modifiedOriginal: false,
+                        metadataHash: optMetadataHash
+                    )
+                )
+            }
+
+            // If a dapp have specified metadata hash explicitly - use it
+            if let metadataHash = optMetadataHash {
+                return .createWithResult(
+                    .init(
+                        modifiedOriginal: false,
+                        metadataHash: metadataHash
+                    )
+                )
+            }
+
+            let metadataHashWrapper = metadataHashOperationFactory.createCheckMetadataHashWrapper(
+                for: chain,
+                connection: connection,
+                runtimeProvider: runtimeProvider
+            )
+
+            let mappingOperation = ClosureOperation<MetadataHashResult> {
+                let metadataHash = try metadataHashWrapper.targetOperation.extractNoCancellableResultData()
+
+                return MetadataHashResult(modifiedOriginal: true, metadataHash: metadataHash)
+            }
+
+            mappingOperation.addDependency(metadataHashWrapper.targetOperation)
+
+            return metadataHashWrapper.insertingTail(operation: mappingOperation)
+        } catch {
+            return .createWithError(error)
+        }
     }
 
     private func createBaseBuilderWrapper(
         for result: DAppOperationProcessedResult,
         codingFactoryOperation: BaseOperation<RuntimeCoderFactoryProtocol>
     ) -> CompoundOperationWrapper<ExtrinsicSenderBuilderResult> {
+        let metadataHashWrapper = createActualMetadataHashWrapper(
+            for: processedResult,
+            chain: chain,
+            connection: connection,
+            runtimeProvider: runtimeProvider
+        )
+
         let builderOperation = ClosureOperation<ExtrinsicSenderBuilderResult> {
             let runtimeContext = try codingFactoryOperation.extractNoCancellableResultData().createRuntimeJsonContext()
+            let metadataHashResult = try metadataHashWrapper.targetOperation.extractNoCancellableResultData()
 
             let extrinsic = result.extrinsic
 
@@ -53,6 +133,10 @@ final class DAppExtrinsicBuilderOperationFactory {
             .with(nonce: UInt32(extrinsic.nonce))
             .with(era: extrinsic.era, blockHash: extrinsic.blockHash)
 
+            if let metadataHash = metadataHashResult.metadataHash {
+                builder = builder.with(metadataHash: metadataHash)
+            }
+
             for signedExtension in signedExtensionFactory.createExtensions() {
                 builder = builder.adding(extrinsicSignedExtension: signedExtension)
             }
@@ -63,16 +147,22 @@ final class DAppExtrinsicBuilderOperationFactory {
                 builder = builder.with(tip: extrinsic.tip)
             }
 
-            return ExtrinsicSenderBuilderResult(sender: sender, builder: builder)
+            return ExtrinsicSenderBuilderResult(
+                sender: sender,
+                builder: builder,
+                modifiedOriginalExtrinsic: metadataHashResult.modifiedOriginal
+            )
         }
 
-        return CompoundOperationWrapper(targetOperation: builderOperation)
+        builderOperation.addDependency(metadataHashWrapper.targetOperation)
+
+        return metadataHashWrapper.insertingTail(operation: builderOperation)
     }
 
     private func createRawSignatureOperation(
         for result: DAppOperationProcessedResult,
         signingClosure: @escaping (Data, ExtrinsicSigningContext) throws -> Data
-    ) -> CompoundOperationWrapper<DAppExtrinsicRawSignatureResult> {
+    ) -> CompoundOperationWrapper<DAppExtrinsicRawExtrinsicResult> {
         let codingFactoryOperation = runtimeProvider.fetchCoderFactoryOperation()
 
         let builderWrapper = createBaseBuilderWrapper(
@@ -100,7 +190,7 @@ final class DAppExtrinsicBuilderOperationFactory {
             )
             .build(encodingBy: codingFactory.createEncoder(), metadata: codingFactory.metadata)
 
-            return DAppExtrinsicRawSignatureResult(sender: builderResult.sender, signedExtrinsic: signedExtrinsic)
+            return DAppExtrinsicRawExtrinsicResult(sender: builderResult.sender, signedExtrinsic: signedExtrinsic)
         }
 
         payloadOperation.addDependency(codingFactoryOperation)
@@ -176,8 +266,22 @@ extension DAppExtrinsicBuilderOperationFactory: ExtrinsicBuilderOperationFactory
                 encoder: codingFactory.createEncoder(),
                 metadata: codingFactory.metadata
             )
+            
+            let modifiedExtrinsic = if builderResult.modifiedOriginalExtrinsic {
+                try builder.signing(
+                    with: { _, _ in rawSignature },
+                    context: context,
+                    codingFactory: codingFactory
+                ).build(encodingBy: codingFactory.createEncoder(), metadata: codingFactory.metadata)
+            } else {
+                nil
+            }
 
-            return DAppExtrinsicRawSignatureResult(sender: builderResult.sender, signedExtrinsic: rawSignature)
+            return DAppExtrinsicRawSignatureResult(
+                sender: builderResult.sender,
+                signature: rawSignature,
+                modifiedExtrinsic: modifiedExtrinsic
+            )
         }
 
         signOperation.addDependency(builderWrapper.targetOperation)

--- a/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppOperationRequest.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppOperationRequest.swift
@@ -13,4 +13,5 @@ struct DAppOperationRequest {
 
 struct DAppOperationResponse {
     let signature: Data?
+    let modifiedTransaction: Data?
 }

--- a/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppParsedExtrinsic.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppParsedExtrinsic.swift
@@ -13,6 +13,8 @@ struct DAppParsedExtrinsic: Encodable {
     let specVersion: UInt32
     let tip: BigUInt
     let transactionVersion: UInt32
+    let metadataHash: String?
+    let withSignedTransaction: Bool
     let signedExtensions: [String]
     let version: UInt
 }

--- a/novawallet/Modules/DApp/Model/PolkadotExtensionProtocol/PolkadotExtensionExtrinsic.swift
+++ b/novawallet/Modules/DApp/Model/PolkadotExtensionProtocol/PolkadotExtensionExtrinsic.swift
@@ -52,6 +52,17 @@ struct PolkadotExtensionExtrinsic: Codable {
     let transactionVersion: String
 
     /**
+     *   Metadata hash to use for signing
+     */
+
+    let metadataHash: String?
+
+    /**
+     *   Whether transaction modification is allowed
+     */
+    let withSignedTransaction: Bool?
+
+    /**
      *   The applicable signed extensions for this runtime
      */
     let signedExtensions: [String]

--- a/novawallet/Modules/DApp/Model/PolkadotExtensionProtocol/PolkadotExtensionSignerResult.swift
+++ b/novawallet/Modules/DApp/Model/PolkadotExtensionProtocol/PolkadotExtensionSignerResult.swift
@@ -4,8 +4,10 @@ struct PolkadotExtensionSignerResult: Codable {
     enum CodingKeys: String, CodingKey {
         case identifier = "id"
         case signature
+        case signedTransaction
     }
 
     let identifier: UInt
     let signature: String
+    let signedTransaction: String?
 }

--- a/novawallet/Modules/DApp/WalletConnect/Model/WalletConnectSignModelFactory.swift
+++ b/novawallet/Modules/DApp/WalletConnect/Model/WalletConnectSignModelFactory.swift
@@ -268,13 +268,18 @@ extension WalletConnectSignModelFactory {
         }
     }
 
-    static func createSigningResponse(for method: WalletConnectMethod, signature: Data) -> AnyCodable {
+    static func createSigningResponse(
+        for method: WalletConnectMethod,
+        signature: Data,
+        modifiedTransaction: Data?
+    ) -> AnyCodable {
         switch method {
         case .polkadotSignTransaction, .polkadotSignMessage:
             let identifier = (0 ... UInt32.max).randomElement() ?? 0
             let result = PolkadotExtensionSignerResult(
                 identifier: UInt(identifier),
-                signature: signature.toHex(includePrefix: true)
+                signature: signature.toHex(includePrefix: true),
+                signedTransaction: modifiedTransaction?.toHex(includePrefix: true)
             )
 
             return AnyCodable(result)

--- a/novawallet/Modules/DApp/WalletConnect/States/WalletConnectStateSigning.swift
+++ b/novawallet/Modules/DApp/WalletConnect/States/WalletConnectStateSigning.swift
@@ -33,7 +33,8 @@ extension WalletConnectStateSigning: WalletConnectStateProtocol {
             let method = WalletConnectMethod(rawValue: request.method) {
             let result = WalletConnectSignModelFactory.createSigningResponse(
                 for: method,
-                signature: signature
+                signature: signature,
+                modifiedTransaction: response.modifiedTransaction
             )
 
             stateMachine.emit(

--- a/novawalletTests/Modules/DApps/DAppOperationConfirm/DAppOperationConfirmTests.swift
+++ b/novawalletTests/Modules/DApps/DAppOperationConfirm/DAppOperationConfirmTests.swift
@@ -19,6 +19,8 @@ class DAppOperationConfirmTests: XCTestCase {
         specVersion: BigUInt(9260).serialize().toHex(includePrefix: true),
         tip: "0x00000000000000000000000000000000",
         transactionVersion: "0x00000003",
+        metadataHash: nil,
+        withSignedTransaction: nil,
         signedExtensions: [
             "CheckNonZeroSender",
             "CheckSpecVersion",
@@ -119,13 +121,21 @@ class DAppOperationConfirmTests: XCTestCase {
             operationQueue: operationQueue
         )
 
+        let  storageFacade = SubstrateStorageTestFacade()
         let feeEstimationRegistry = ExtrinsicFeeEstimationRegistry(
             chain: chain,
             estimatingWrapperFactory: feeEstimatingWrapperFactory,
             connection: connection,
             runtimeProvider: runtimeProvider,
             userStorageFacade: UserDataStorageTestFacade(),
-            substrateStorageFacade: SubstrateStorageTestFacade(),
+            substrateStorageFacade: storageFacade,
+            operationQueue: operationQueue
+        )
+        
+        let metadataHashFactory = MetadataHashOperationFactory(
+            metadataRepositoryFactory: RuntimeMetadataRepositoryFactory(
+                storageFacade: storageFacade
+            ),
             operationQueue: operationQueue
         )
 
@@ -135,7 +145,8 @@ class DAppOperationConfirmTests: XCTestCase {
             runtimeProvider: runtimeProvider,
             feeEstimationRegistry: feeEstimationRegistry,
             connection: connection,
-            signingWrapperFactory: signingWrapperFactory,
+            signingWrapperFactory: signingWrapperFactory, 
+            metadataHashFactory: metadataHashFactory,
             priceProviderFactory: priceProvider,
             currencyManager: CurrencyManagerStub(),
             operationQueue: operationQueue


### PR DESCRIPTION
## Purpose

- add support for ```withSignedTransaction``` and ```metadataHash``` in the Polkadot Extension signing request
- integrated metadata hash factory to the ```DAppExtrinsicBuilderOperationFactory```
- extended Polkadot Extension signing response with ```signedExtrinsic``` field to allow wallet to replace the extrinsic