### PR TITLE
Fix self-sufficiency check on cross-chain transfer

### DIFF
--- a/novawallet/Modules/Transfer/TransferConfirm/TransferConfirmCrossChainViewFactory.swift
+++ b/novawallet/Modules/Transfer/TransferConfirm/TransferConfirmCrossChainViewFactory.swift
@@ -49,7 +49,10 @@ struct TransferConfirmCrossChainViewFactory {
             utilityBalanceViewModelFactory = nil
         }
 
-        guard let utilityAssetInfo = originChainAsset.chain.utilityAssets().first?.displayInfo else {
+        guard
+            let utilityAssetInfo = originChainAsset.chain.utilityAssetDisplayInfo(),
+            let destUtilityAssetInfo = destinationAsset.chain.utilityAssetDisplayInfo()
+        else {
             return nil
         }
 
@@ -57,6 +60,7 @@ struct TransferConfirmCrossChainViewFactory {
             presentable: wireframe,
             assetDisplayInfo: originChainAsset.assetDisplayInfo,
             utilityAssetInfo: utilityAssetInfo,
+            destUtilityAssetInfo: destUtilityAssetInfo,
             priceAssetInfoFactory: priceAssetInfoFactory
         )
 

--- a/novawallet/Modules/Transfer/TransferConfirm/TransferConfirmOnChainViewFactory.swift
+++ b/novawallet/Modules/Transfer/TransferConfirm/TransferConfirmOnChainViewFactory.swift
@@ -85,6 +85,7 @@ struct TransferConfirmOnChainViewFactory {
             presentable: wireframe,
             assetDisplayInfo: chainAsset.assetDisplayInfo,
             utilityAssetInfo: utilityAssetInfo,
+            destUtilityAssetInfo: utilityAssetInfo,
             priceAssetInfoFactory: priceAssetInfoFactory
         )
 

--- a/novawallet/Modules/Transfer/TransferSetup/CrossChain/TransferSetupPresenterFactory+CrossChain.swift
+++ b/novawallet/Modules/Transfer/TransferSetup/CrossChain/TransferSetupPresenterFactory+CrossChain.swift
@@ -47,7 +47,10 @@ extension TransferSetupPresenterFactory {
             utilityBalanceViewModelFactory = nil
         }
 
-        guard let utilityAssetInfo = originChainAsset.chain.utilityAssets().first?.displayInfo else {
+        guard
+            let utilityAssetInfo = originChainAsset.chain.utilityAssetDisplayInfo(),
+            let destUtilityAssetInfo = destinationChainAsset.chain.utilityAssetDisplayInfo()
+        else {
             return nil
         }
 
@@ -55,6 +58,7 @@ extension TransferSetupPresenterFactory {
             presentable: wireframe,
             assetDisplayInfo: originChainAsset.assetDisplayInfo,
             utilityAssetInfo: utilityAssetInfo,
+            destUtilityAssetInfo: destUtilityAssetInfo,
             priceAssetInfoFactory: priceAssetInfoFactory
         )
 

--- a/novawallet/Modules/Transfer/TransferSetup/OnChain/TransferSetupPresenterFactory+OnChain.swift
+++ b/novawallet/Modules/Transfer/TransferSetup/OnChain/TransferSetupPresenterFactory+OnChain.swift
@@ -69,7 +69,8 @@ extension TransferSetupPresenterFactory {
         let dataValidatingFactory = TransferDataValidatorFactory(
             presentable: wireframe,
             assetDisplayInfo: chainAsset.assetDisplayInfo,
-            utilityAssetInfo: utilityChainAsset.asset.displayInfo,
+            utilityAssetInfo: utilityChainAsset.assetDisplayInfo,
+            destUtilityAssetInfo: utilityChainAsset.assetDisplayInfo,
             priceAssetInfoFactory: priceAssetInfoFactory
         )
 

--- a/novawallet/Modules/Transfer/Validation/TransferDataValidatorFactory.swift
+++ b/novawallet/Modules/Transfer/Validation/TransferDataValidatorFactory.swift
@@ -81,6 +81,7 @@ final class TransferDataValidatorFactory: TransferDataValidatorFactoryProtocol {
     var basePresentable: BaseErrorPresentable { presentable }
     let assetDisplayInfo: AssetBalanceDisplayInfo
     let utilityAssetInfo: AssetBalanceDisplayInfo
+    let destUtilityAssetInfo: AssetBalanceDisplayInfo
     let priceAssetInfoFactory: PriceAssetInfoFactoryProtocol
 
     let presentable: TransferErrorPresentable
@@ -89,11 +90,13 @@ final class TransferDataValidatorFactory: TransferDataValidatorFactoryProtocol {
         presentable: TransferErrorPresentable,
         assetDisplayInfo: AssetBalanceDisplayInfo,
         utilityAssetInfo: AssetBalanceDisplayInfo,
+        destUtilityAssetInfo: AssetBalanceDisplayInfo,
         priceAssetInfoFactory: PriceAssetInfoFactoryProtocol
     ) {
         self.presentable = presentable
         self.assetDisplayInfo = assetDisplayInfo
         self.utilityAssetInfo = utilityAssetInfo
+        self.destUtilityAssetInfo = destUtilityAssetInfo
         self.priceAssetInfoFactory = priceAssetInfoFactory
     }
 
@@ -160,7 +163,7 @@ final class TransferDataValidatorFactory: TransferDataValidatorFactoryProtocol {
                 return
             }
 
-            let assetInfo = strongSelf.utilityAssetInfo
+            let assetInfo = strongSelf.destUtilityAssetInfo
 
             self?.presentable.presentNoReceiverAccount(
                 for: assetInfo.symbol,


### PR DESCRIPTION
Pass the destination chain utility asset info to `TransferDataValidatorFactory` so it can be used in `receiverHasAccountProvider` instead of the origin utility asset.