### PR TITLE
Remove cyclic proxieds

### DIFF
--- a/novawallet/Common/Services/Proxy/ChainProxySyncService.swift
+++ b/novawallet/Common/Services/Proxy/ChainProxySyncService.swift
@@ -191,7 +191,7 @@ final class ChainProxySyncService: ObservableSyncService, ChainProxySyncServiceP
             var proxies: [ProxiedAccountId: [ProxyAccount]] = [:]
 
             repeat {
-                // We only need remote proxieds for current proxies and we don't support delaed proxies
+                // We only need remote proxieds for current proxies and we don't support delayed proxies
                 proxies = proxyList.compactMapValues { accounts in
                     accounts.filter {
                         !$0.hasDelay && possibleProxiesIds.contains($0.accountId)

--- a/novawalletTests/Helper/AccountGenerator.swift
+++ b/novawalletTests/Helper/AccountGenerator.swift
@@ -49,10 +49,11 @@ enum AccountGenerator {
     }
     
     static func generateProxiedChainAccount(
-        for model: ProxyAccountModel
+        for model: ProxyAccountModel,
+        chainId: ChainModel.Id
     ) -> ChainAccountModel {
         ChainAccountModel(
-            chainId: Data.random(of: 32)!.toHex(),
+            chainId: chainId,
             accountId: Data.random(of: 32)!,
             publicKey: Data.random(of: 32)!,
             cryptoType: 0,


### PR DESCRIPTION
## Purpose

Current issue was that if nested proxies are added that point to each other (cyclic dependecy) the removal algorithm didn't remove them since each of the wallets had existing wallet that used it. Now we remove a proxied wallet if there is no non proxied wallet reachable from it that is not also being removed.