### PR TITLE
Improve validation before Cloud backup application

### DIFF
--- a/novawallet/Common/Services/CloudBackup/CloudBackupServiceFactory.swift
+++ b/novawallet/Common/Services/CloudBackup/CloudBackupServiceFactory.swift
@@ -56,6 +56,7 @@ extension ICloudBackupServiceFactory: CloudBackupServiceFactoryProtocol {
         CloudBackupSecretsExporter(
             walletConverter: CloudBackupFileModelConverter(),
             cryptoManager: createCryptoManager(),
+            validator: ICloudBackupValidator(),
             keychain: keychain
         )
     }

--- a/novawallet/Common/Services/CloudBackup/Model/CloudBackupValidating.swift
+++ b/novawallet/Common/Services/CloudBackup/Model/CloudBackupValidating.swift
@@ -7,14 +7,58 @@ protocol CloudBackupValidating {
     ) -> Bool
 }
 
-final class ICloudBackupValidator {}
+final class ICloudBackupValidator {
+    private func validateSecrets(
+        privateInfo: CloudBackup.DecryptedFileModel.WalletPrivateInfo
+    ) -> Bool {
+        privateInfo.substrate?.keypair != nil ||
+            privateInfo.ethereum?.keypair != nil ||
+            privateInfo.chainAccounts.contains { $0.keypair != nil }
+    }
+
+    private func validateLedger(privateInfo: CloudBackup.DecryptedFileModel.WalletPrivateInfo) -> Bool {
+        privateInfo.chainAccounts.contains { $0.derivationPath != nil }
+    }
+
+    private func validateGenericLedger(privateInfo: CloudBackup.DecryptedFileModel.WalletPrivateInfo) -> Bool {
+        privateInfo.substrate?.derivationPath != nil
+    }
+}
 
 extension ICloudBackupValidator: CloudBackupValidating {
     func validate(
-        publicData _: CloudBackup.PublicData,
-        matches _: CloudBackup.DecryptedFileModel.PrivateData
+        publicData: CloudBackup.PublicData,
+        matches: CloudBackup.DecryptedFileModel.PrivateData
     ) -> Bool {
-        // TODO: Implement validation
-        true
+        let privateDataDict = matches.wallets.reduce(
+            into: [MetaAccountModel.Id: CloudBackup.DecryptedFileModel.WalletPrivateInfo]()
+        ) {
+            $0[$1.walletId] = $1
+        }
+
+        return publicData.wallets.allSatisfy { wallet in
+            switch wallet.type {
+            case .secrets:
+                guard let privateInfo = privateDataDict[wallet.walletId] else {
+                    return false
+                }
+
+                return validateSecrets(privateInfo: privateInfo)
+            case .ledger:
+                guard let privateInfo = privateDataDict[wallet.walletId] else {
+                    return false
+                }
+
+                return validateLedger(privateInfo: privateInfo)
+            case .genericLedger:
+                guard let privateInfo = privateDataDict[wallet.walletId] else {
+                    return false
+                }
+
+                return validateGenericLedger(privateInfo: privateInfo)
+            case .watchOnly, .paritySigner, .polkadotVault:
+                return true
+            }
+        }
     }
 }

--- a/novawalletTests/Common/Services/CloudBackup/MockCloudBackupOperationFactory.swift
+++ b/novawalletTests/Common/Services/CloudBackup/MockCloudBackupOperationFactory.swift
@@ -23,7 +23,7 @@ extension MockCloudBackupOperationFactory: CloudBackupOperationFactoryProtocol {
         dataClosure: @escaping () throws -> Data
     ) -> BaseOperation<Void> {
         ClosureOperation {
-            self.data = try? dataClosure()
+            self.data = try dataClosure()
         }
     }
     

--- a/novawalletTests/Common/Services/CloudBackup/MockCloudBackupServiceFactory.swift
+++ b/novawalletTests/Common/Services/CloudBackup/MockCloudBackupServiceFactory.swift
@@ -52,6 +52,7 @@ extension MockCloudBackupServiceFactory: CloudBackupServiceFactoryProtocol {
         CloudBackupSecretsExporter(
             walletConverter: CloudBackupFileModelConverter(),
             cryptoManager: createCryptoManager(),
+            validator: ICloudBackupValidator(),
             keychain: keychain
         )
     }


### PR DESCRIPTION
## Purpose

- ensure that a wallet participating in the backup with ```.secret``` type has private key
- ensure that a wallet participating in the backup with ```.ledger``` type has derivation path in the one of the chain accounts
- ensure that a wallet participating in the backup with ```.genericLedger``` type has substrate derivation path
- if broken wallet is detected then backup is not applied

##

![broken-backup](https://github.com/user-attachments/assets/f1466e3b-8007-4022-8d79-bb9ee4784c37)
