### PR TITLE
Add support for new xcm type

### DIFF
--- a/novawallet/Common/Model/Xcm/XcmAssetTransfer.swift
+++ b/novawallet/Common/Model/Xcm/XcmAssetTransfer.swift
@@ -20,6 +20,7 @@ extension XcmAssetTransfer {
         case xtokens
         case xcmpallet
         case teleport = "xcmpallet-teleport"
+        case xcmpalletTransferAssets = "xcmpallet-transferAssets"
         case unknown
 
         init(from decoder: Decoder) throws {
@@ -34,6 +35,8 @@ extension XcmAssetTransfer {
                 self = .xcmpallet
             case Self.teleport.rawValue:
                 self = .teleport
+            case Self.xcmpalletTransferAssets.rawValue:
+                self = .xcmpalletTransferAssets
             default:
                 self = .unknown
             }

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransferService+Compose.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransferService+Compose.swift
@@ -23,7 +23,7 @@ extension XcmTransferService {
                 xcmTransfers: xcmTransfers,
                 runtimeProvider: runtimeProvider
             )
-        case .xcmpallet, .teleport:
+        case .xcmpallet, .teleport, .xcmpalletTransferAssets:
             let multiassetsVersionWrapper = xcmPalletQueryFactory.createLowestMultiassetsVersionWrapper(
                 for: runtimeProvider
             )
@@ -111,6 +111,14 @@ extension XcmTransferService {
             return createPalletXcmTransferMapping(
                 dependingOn: moduleResolutionOperation,
                 callPathFactory: { Xcm.limitedTeleportAssetsPath(for: $0) },
+                destinationAssetOperation: destinationAssetOperation,
+                maxWeight: maxWeight,
+                runtimeProvider: runtimeProvider
+            )
+        case .xcmpalletTransferAssets:
+            return createPalletXcmTransferMapping(
+                dependingOn: moduleResolutionOperation,
+                callPathFactory: { Xcm.transferAssetsPath(for: $0) },
                 destinationAssetOperation: destinationAssetOperation,
                 maxWeight: maxWeight,
                 runtimeProvider: runtimeProvider

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransferService.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransferService.swift
@@ -44,7 +44,7 @@ final class XcmTransferService {
         switch transferType {
         case .xtokens:
             return xTokensQueryFactory.createModuleNameResolutionWrapper(for: runtimeProvider)
-        case .xcmpallet, .teleport:
+        case .xcmpallet, .teleport, .xcmpalletTransferAssets:
             return xcmPalletQueryFactory.createModuleNameResolutionWrapper(for: runtimeProvider)
         case .unknown:
             return CompoundOperationWrapper.createWithError(XcmAssetTransfer.TransferTypeError.unknownType)

--- a/novawallet/Common/Substrate/Calls/Xcm/XcmPalletTransfer.swift
+++ b/novawallet/Common/Substrate/Calls/Xcm/XcmPalletTransfer.swift
@@ -29,4 +29,8 @@ extension Xcm {
     static func limitedTeleportAssetsPath(for module: String) -> CallCodingPath {
         CallCodingPath(moduleName: module, callName: "limited_teleport_assets")
     }
+
+    static func transferAssetsPath(for module: String) -> CallCodingPath {
+        CallCodingPath(moduleName: module, callName: "transfer_assets")
+    }
 }

--- a/novawallet/Modules/Transfer/TransferSetup/CrossChain/CrossChainTransferSetupPresenter.swift
+++ b/novawallet/Modules/Transfer/TransferSetup/CrossChain/CrossChainTransferSetupPresenter.swift
@@ -310,6 +310,8 @@ final class CrossChainTransferSetupPresenter: CrossChainTransferPresenter,
     override func didReceiveCrossChainFee(result: Result<XcmFeeModelProtocol, Error>) {
         super.didReceiveCrossChainFee(result: result)
 
+        logger?.debug("Did receive result: \(result)")
+
         if case .success = result {
             updateOriginFeeView()
             updateCrossChainFeeView()


### PR DESCRIPTION
## Purpose

Add support for `transfer_assets` xcm type that is currently the way to send xcm transfers from Moonbeam/Moonriver