### PR TITLE
Derive fee type from runtime api instead of hardcoding value

### DIFF
--- a/novawallet/Common/Network/JSONRPC/RemoteStateCallRequest.swift
+++ b/novawallet/Common/Network/JSONRPC/RemoteStateCallRequest.swift
@@ -2,6 +2,8 @@ import Foundation
 
 enum StateCallRpc {
     static var method: String { "state_call" }
+    static var feeBuiltInModule: String { "TransactionPaymentApi" }
+    static var feeBuiltInMethod: String { "query_info" }
     static var feeBuiltIn: String { "TransactionPaymentApi_query_info" }
     static var feeResultType: String { "RuntimeDispatchInfo" }
 

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/FeeManaging/ExtrinsicNativeFeeEstimator.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/FeeManaging/ExtrinsicNativeFeeEstimator.swift
@@ -115,14 +115,20 @@ final class ExtrinsicNativeFeeEstimator {
         connection: JSONRPCEngine
     ) -> CompoundOperationWrapper<RuntimeDispatchInfo> {
         if chain.feeViaRuntimeCall {
-            createStateCallFeeWrapper(
+            let feeApi = coderFactory.metadata.getRuntimeApiMethod(
+                for: StateCallRpc.feeBuiltInModule, methodName: StateCallRpc.feeBuiltInMethod
+            )
+
+            let feeTypeName = feeApi.map { String($0.method.output) } ?? StateCallRpc.feeResultType
+
+            return createStateCallFeeWrapper(
                 for: coderFactory,
-                type: StateCallRpc.feeResultType,
+                type: feeTypeName,
                 extrinsic: extrinsic,
                 connection: connection
             )
         } else {
-            createApiFeeWrapper(
+            return createApiFeeWrapper(
                 extrinsic: extrinsic,
                 connection: connection
             )


### PR DESCRIPTION
## Purpose

New runtime upgrade on wested broke fee calculation due to type rename. This PR uses type derivation from v15 metadata runtime api and fallbacks to hardcoded one in case there is no v15 metadata support