### PR TITLE
Refactor validations for swaps

### DIFF
--- a/novawallet/Common/Services/AssetExchange/Common/AssetExchangeQuote.swift
+++ b/novawallet/Common/Services/AssetExchange/Common/AssetExchangeQuote.swift
@@ -18,4 +18,12 @@ struct AssetExchangeQuote {
 
         return subarray.reduce(0, +)
     }
+
+    func hasSamePath(other: AssetExchangeRoute) -> Bool {
+        guard route.items.count == other.items.count else { return false }
+
+        return zip(route.items, other.items).allSatisfy {
+            $0.0.edge.identifier == $0.1.edge.identifier
+        }
+    }
 }

--- a/novawallet/Modules/Swaps/Base/Model/SwapMaxModel.swift
+++ b/novawallet/Modules/Swaps/Base/Model/SwapMaxModel.swift
@@ -30,6 +30,10 @@ struct SwapMaxModel {
 
         return (!receiveAssetExistense.isSelfSufficient || hasConsumers)
     }
+    
+    var needMinBalanceDueConsumers: Bool {
+        accountInfo?.hasConsumers ?? false
+    }
 
     var needMinBalanceDueToPostsubmissionFee: Bool {
         guard
@@ -42,7 +46,9 @@ struct SwapMaxModel {
     }
 
     var shouldKeepMinBalance: Bool {
-        needMinBalanceDueToReceiveInsufficiency || needMinBalanceDueToPostsubmissionFee
+        needMinBalanceDueConsumers ||
+        needMinBalanceDueToPostsubmissionFee ||
+        needMinBalanceDueToReceiveInsufficiency
     }
 
     private func calculateForNativeAsset(_ payChainAsset: ChainAsset, balance: AssetBalance) -> Decimal {

--- a/novawallet/Modules/Swaps/Base/Model/SwapMaxModel.swift
+++ b/novawallet/Modules/Swaps/Base/Model/SwapMaxModel.swift
@@ -30,7 +30,7 @@ struct SwapMaxModel {
 
         return (!receiveAssetExistense.isSelfSufficient || hasConsumers)
     }
-    
+
     var needMinBalanceDueConsumers: Bool {
         accountInfo?.hasConsumers ?? false
     }
@@ -47,8 +47,8 @@ struct SwapMaxModel {
 
     var shouldKeepMinBalance: Bool {
         needMinBalanceDueConsumers ||
-        needMinBalanceDueToPostsubmissionFee ||
-        needMinBalanceDueToReceiveInsufficiency
+            needMinBalanceDueToPostsubmissionFee ||
+            needMinBalanceDueToReceiveInsufficiency
     }
 
     private func calculateForNativeAsset(_ payChainAsset: ChainAsset, balance: AssetBalance) -> Decimal {

--- a/novawallet/Modules/Swaps/Base/SwapBasePresenter.swift
+++ b/novawallet/Modules/Swaps/Base/SwapBasePresenter.swift
@@ -245,13 +245,13 @@ class SwapBasePresenter {
             )
         ]
 
-        // for a single operation validation is covered by canReceive
+        // for last operation validation is covered by canReceive
         if let operations = swapModel.quote?.metaOperations, operations.count > 1 {
             let intermediateEdValidation = dataValidatingFactory.passesIntermediateEDValidation(
                 params: swapModel,
                 remoteValidatingClosure: { closureParams in
                     interactor.requestValidatingIntermediateED(
-                        for: closureParams.operations,
+                        for: closureParams.operations.dropLast(),
                         completion: closureParams.completionClosure
                     )
                 },

--- a/novawallet/Modules/Swaps/Setup/Model/SwapPreferredFeeAssetModel.swift
+++ b/novawallet/Modules/Swaps/Setup/Model/SwapPreferredFeeAssetModel.swift
@@ -71,7 +71,7 @@ extension SwapPreferredFeeAssetModel {
         if isFeeInNativeAsset {
             if canPayFeeInNativeAsset() {
                 return utilityChainAsset
-            } else if hasPayAssetBalance, !feeModel.hasOriginPostSubmissionByAccount {
+            } else if hasPayAssetBalance {
                 return payChainAsset
             } else {
                 return utilityChainAsset

--- a/novawallet/Modules/Swaps/Setup/Model/SwapPreferredFeeAssetModel.swift
+++ b/novawallet/Modules/Swaps/Setup/Model/SwapPreferredFeeAssetModel.swift
@@ -71,13 +71,13 @@ extension SwapPreferredFeeAssetModel {
         if isFeeInNativeAsset {
             if canPayFeeInNativeAsset() {
                 return utilityChainAsset
-            } else if hasPayAssetBalance {
+            } else if hasPayAssetBalance, canPayFeeInPayAsset {
                 return payChainAsset
             } else {
                 return utilityChainAsset
             }
         } else {
-            return hasPayAssetBalance ? payChainAsset : utilityChainAsset
+            return canPayFeeInPayAsset && hasPayAssetBalance ? payChainAsset : utilityChainAsset
         }
     }
 }

--- a/novawallet/Modules/Swaps/Validation/SwapErrorPresentable.swift
+++ b/novawallet/Modules/Swaps/Validation/SwapErrorPresentable.swift
@@ -39,6 +39,12 @@ protocol SwapErrorPresentable: BaseErrorPresentable {
         locale: Locale
     )
 
+    func presentMinBalanceViolatedDueDeliveryFee(
+        from view: ControllerBackedProtocol,
+        minBalance: String,
+        locale: Locale
+    )
+
     func presentIntemediateAmountBelowMinimum(
         from view: ControllerBackedProtocol,
         amount: String,
@@ -122,6 +128,21 @@ extension SwapErrorPresentable where Self: AlertPresentable & ErrorPresentable {
         present(message: message, title: title, closeAction: closeAction, from: view)
     }
 
+    func presentMinBalanceViolatedDueDeliveryFee(
+        from view: ControllerBackedProtocol,
+        minBalance: String,
+        locale: Locale
+    ) {
+        let title = R.string.localizable.commonErrorGeneralTitle(preferredLanguages: locale.rLanguages)
+        let message = R.string.localizable.swapDeliveryFeeErrorMessage(
+            minBalance,
+            preferredLanguages: locale.rLanguages
+        )
+        let closeAction = R.string.localizable.commonClose(preferredLanguages: locale.rLanguages)
+
+        present(message: message, title: title, closeAction: closeAction, from: view)
+    }
+
     func presentInsufficientBalance(
         from view: ControllerBackedProtocol?,
         reason: SwapDisplayError.InsufficientBalance,
@@ -133,18 +154,15 @@ extension SwapErrorPresentable where Self: AlertPresentable & ErrorPresentable {
 
         switch reason {
         case let .dueFeePayAsset(value):
-            message = R.string.localizable.swapsSetupErrorInsufficientBalanceFeeSwapMessage(
-                value.available,
+            message = R.string.localizable.commonNotEnoughToPayFeeMessage(
                 value.fee,
-                value.minBalanceInPayAsset,
-                value.minBalanceInUtilityAsset,
-                value.tokenSymbol,
+                value.available,
                 preferredLanguages: locale.rLanguages
             )
         case let .dueFeeNativeAsset(value):
-            message = R.string.localizable.swapsSetupErrorInsufficientBalanceFeeNativeMessage(
-                value.available,
+            message = R.string.localizable.commonNotEnoughToPayFeeMessage(
                 value.fee,
+                value.available,
                 preferredLanguages: locale.rLanguages
             )
         case let .dueConsumers(value):
@@ -185,17 +203,7 @@ extension SwapErrorPresentable where Self: AlertPresentable & ErrorPresentable {
         let message: String
 
         switch reason {
-        case let .dueFeeSwap(value):
-            message = R.string.localizable.swapsDustRemainsFeePayAssetMessage(
-                value.minBalanceOfPayAsset,
-                value.fee,
-                value.minBalanceInPayAsset,
-                value.minBalanceInUtilityAsset,
-                value.utilitySymbol,
-                value.remaining,
-                preferredLanguages: locale.rLanguages
-            )
-        case let .dueNativeSwap(value):
+        case let .dueSwap(value):
             message = R.string.localizable.swapsDustRemainsFeeNativeAssetMessage(
                 value.minBalance,
                 value.remaining,

--- a/novawallet/Modules/Swaps/Validation/SwapErrorPresentableParams.swift
+++ b/novawallet/Modules/Swaps/Validation/SwapErrorPresentableParams.swift
@@ -2,9 +2,6 @@ enum SwapDisplayError {
     struct InsufficientBalanceDueFeePayAsset {
         let available: String
         let fee: String
-        let minBalanceInPayAsset: String
-        let minBalanceInUtilityAsset: String
-        let tokenSymbol: String
     }
 
     struct InsufficientBalanceDueFeeNativeAsset {
@@ -23,22 +20,12 @@ enum SwapDisplayError {
         case dueConsumers(InsufficientBalanceDueConsumers)
     }
 
-    struct DustRemainsDueNativeSwap {
+    struct DustRemainsDueSwap {
         let remaining: String
         let minBalance: String
     }
 
-    struct DustRemainsDueFeeSwap {
-        let remaining: String
-        let minBalanceOfPayAsset: String
-        let fee: String
-        let minBalanceInPayAsset: String
-        let minBalanceInUtilityAsset: String
-        let utilitySymbol: String
-    }
-
     enum DustRemains {
-        case dueNativeSwap(DustRemainsDueNativeSwap)
-        case dueFeeSwap(DustRemainsDueFeeSwap)
+        case dueSwap(DustRemainsDueSwap)
     }
 }

--- a/novawallet/Modules/Swaps/Validation/SwapModel.swift
+++ b/novawallet/Modules/Swaps/Validation/SwapModel.swift
@@ -140,7 +140,7 @@ struct SwapModel {
         }
 
         let minBalance = utilityAssetExistense?.minBalance ?? 0
-        let feeInNativeToken = feeModel?.totalFeeInAssetIn(utilityChainAsset) ?? 0
+        let feeInNativeToken = feeModel?.originFeeInAsset(utilityChainAsset) ?? 0
 
         let assetDisplayInfo = utilityChainAsset.assetDisplayInfo
 
@@ -175,7 +175,7 @@ struct SwapModel {
         }
 
         let balance = utilityAssetBalance?.transferable ?? 0
-        let fee = feeModel?.totalFeeInAssetIn(utilityChainAsset) ?? 0
+        let fee = feeModel?.originFeeInAsset(utilityChainAsset) ?? 0
 
         guard balance < fee else {
             return nil
@@ -242,7 +242,7 @@ struct SwapModel {
             return payAssetTotalBalanceAfterSwap < minBalance
         }
 
-        let feeInNativeAsset = feeModel?.totalFeeInAssetIn(utilityChainAsset) ?? 0
+        let feeInNativeAsset = feeModel?.originFeeInAsset(utilityChainAsset) ?? 0
 
         guard feeInNativeAsset > 0 else {
             return false

--- a/novawallet/Modules/Swaps/Validation/SwapModel.swift
+++ b/novawallet/Modules/Swaps/Validation/SwapModel.swift
@@ -207,7 +207,7 @@ struct SwapModel {
     func checkCanReceive() -> CannotReceiveReason? {
         // TODO: We need to rewrite the logic to take into account crosschains and swaps
         let isSelfSufficient = receiveAssetExistense?.isSelfSufficient ?? false
-        let amountAfterSwap = (receiveAssetBalance?.freeInPlank ?? 0) + (quote?.route.amountOut ?? 0)
+        let amountAfterSwap = (receiveAssetBalance?.balanceCountingEd ?? 0) + (quote?.route.amountOut ?? 0)
         let feeInReceiveAsset = feeChainAsset.chainAssetId == receiveChainAsset.chainAssetId ?
             (feeModel?.originFeeInAsset(feeChainAsset) ?? 0) : 0
         let minBalance = receiveAssetExistense?.minBalance ?? 0

--- a/novawallet/en.lproj/Localizable.strings
+++ b/novawallet/en.lproj/Localizable.strings
@@ -1783,3 +1783,5 @@
 "swap.intermediate.too.low.amount.to.stay.abow.ed.message" = "During swap execution intermediate receive amount is %@ which is less than minimum balance of %@. Try specifying larger swap amount.";
 "common.fee.amount.prefixed" = "Fee: %@";
 "swap.route.details.subtitle" = "The way that your token will take through different networks to get the desired token.";
+"common.not.enough.to.pay.fee.message" = "You don\'t have enough balance to pay network fee of %@. Current balance is %@";
+"swap.delivery.fee.error.message" = "Due to crosschain restrictions you should have at least %@ after operation";


### PR DESCRIPTION
## Purpose

Current validation logic contained redundant and hard to read checks. Refactored it to remove redundancy and made it more readable. The validations are the following:

- fee loaded;

- has sufficient balance: enough balance to spend, enough balance to spend and pay fee, enough balance to pay fee in native asset, can pay delivery fee, check that account holding not sufficient assets will have at least ed after the swap;

- not violating min native balance paying fee;

- recipient account can receive tokens: final amount is not less than ed, for not self-sufficient asset there is a provider;

- for multihop swaps: all segments except last one must have an outcome that is greater then min balance;

- check for dust remaining

- request quote and compare with current one to detect significant changes