### PR TITLE
Feature/tabs for wallet

### DIFF
--- a/novawallet/Common/DataProvider/Subscription/WalletListLocalStorageSubscriptionHandler.swift
+++ b/novawallet/Common/DataProvider/Subscription/WalletListLocalStorageSubscriptionHandler.swift
@@ -4,9 +4,11 @@ import Operation_iOS
 protocol WalletListLocalSubscriptionHandler {
     func handleAllWallets(result: Result<[DataProviderChange<ManagedMetaAccountModel>], Error>)
     func handleWallet(result: Result<ManagedMetaAccountModel?, Error>, for walletId: String)
+    func handleSelectedWallet(result: Result<ManagedMetaAccountModel?, Error>)
 }
 
 extension WalletListLocalSubscriptionHandler {
     func handleAllWallets(result _: Result<[DataProviderChange<ManagedMetaAccountModel>], Error>) {}
     func handleWallet(result _: Result<ManagedMetaAccountModel?, Error>, for _: String) {}
+    func handleSelectedWallet(result _: Result<ManagedMetaAccountModel?, Error>) {}
 }

--- a/novawallet/Common/Extension/Foundation/Predicate/NSPredicate+Filter.swift
+++ b/novawallet/Common/Extension/Foundation/Predicate/NSPredicate+Filter.swift
@@ -310,6 +310,10 @@ extension NSPredicate {
         NSPredicate(format: "%K == %@", #keyPath(CDDAppFavorite.identifier), identifier)
     }
 
+    static func filterDAppBrowserTabs(by metaId: String) -> NSPredicate {
+        NSPredicate(format: "%K == %@", #keyPath(CDDAppBrowserTab.metaId), metaId)
+    }
+
     static func filterAuthorizedBrowserDApps(by metaId: String) -> NSPredicate {
         let metaId = NSPredicate(format: "%K == %@", #keyPath(CDDAppSettings.metaId), metaId)
         let source = NSPredicate(format: "%K = nil", #keyPath(CDDAppSettings.source))

--- a/novawallet/Common/Storage/EntityToModel/DAppBrowserTabMapper.swift
+++ b/novawallet/Common/Storage/EntityToModel/DAppBrowserTabMapper.swift
@@ -16,6 +16,7 @@ extension DAppBrowserTabMapper: CoreDataMapperProtocol {
             uuid: UUID(uuidString: entity.identifier!)!,
             name: entity.label,
             url: entity.url!,
+            metaId: entity.metaId!,
             createdAt: entity.createdAt!,
             renderModifiedAt: entity.renderModifiedAt,
             icon: entity.icon,
@@ -31,6 +32,7 @@ extension DAppBrowserTabMapper: CoreDataMapperProtocol {
         entity.identifier = model.identifier
         entity.label = model.name
         entity.url = model.url
+        entity.metaId = model.metaId
         entity.createdAt = model.createdAt
         entity.renderModifiedAt = model.renderModifiedAt
         entity.icon = model.icon

--- a/novawallet/Common/Storage/UserDataModel.xcdatamodeld/MultiassetUserDataModel14.xcdatamodel/contents
+++ b/novawallet/Common/Storage/UserDataModel.xcdatamodeld/MultiassetUserDataModel14.xcdatamodel/contents
@@ -22,6 +22,7 @@
         <attribute name="icon" optional="YES" attributeType="String"/>
         <attribute name="identifier" optional="YES" attributeType="String"/>
         <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="metaId" attributeType="String"/>
         <attribute name="renderModifiedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="url" optional="YES" attributeType="URI"/>
     </entity>

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserInteractor.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserInteractor.swift
@@ -330,7 +330,10 @@ private extension DAppBrowserInteractor {
     }
 
     func proceedWithNewTab(opening dApp: DApp) {
-        let newTab = DAppBrowserTab(from: dApp)
+        let newTab = DAppBrowserTab(
+            from: dApp,
+            metaId: dataSource.wallet.metaId
+        )
 
         let states = transports.compactMap { $0.makeOpaqueState() }
 

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListPresenter.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListPresenter.swift
@@ -7,6 +7,8 @@ final class DAppBrowserTabListPresenter {
     let interactor: DAppBrowserTabListInteractorInputProtocol
     let localizationManager: LocalizationManagerProtocol
 
+    let metaId: MetaAccountModel.Id
+
     private let viewModelFactory: DAppBrowserTabListViewModelFactoryProtocol
 
     private var tabs: [DAppBrowserTab] = []
@@ -15,11 +17,13 @@ final class DAppBrowserTabListPresenter {
         interactor: DAppBrowserTabListInteractorInputProtocol,
         wireframe: DAppBrowserTabListWireframeProtocol,
         viewModelFactory: DAppBrowserTabListViewModelFactoryProtocol,
+        metaId: MetaAccountModel.Id,
         localizationManager: LocalizationManagerProtocol
     ) {
         self.interactor = interactor
         self.wireframe = wireframe
         self.viewModelFactory = viewModelFactory
+        self.metaId = metaId
         self.localizationManager = localizationManager
     }
 }
@@ -98,7 +102,7 @@ extension DAppBrowserTabListPresenter: DAppBrowserTabListInteractorOutputProtoco
 
 extension DAppBrowserTabListPresenter: DAppSearchDelegate {
     func didCompleteDAppSearchResult(_ result: DAppSearchResult) {
-        guard let tab = DAppBrowserTab(from: result) else {
+        guard let tab = DAppBrowserTab(from: result, metaId: metaId) else {
             return
         }
 

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListViewFactory.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListViewFactory.swift
@@ -36,10 +36,13 @@ struct DAppBrowserTabListViewFactory {
         )
         let viewModelFactory = DAppBrowserTabListViewModelFactory(imageViewModelFactory: imageViewModelFactory)
 
+        let wallet: MetaAccountModel = SelectedWalletSettings.shared.value
+
         let presenter = DAppBrowserTabListPresenter(
             interactor: interactor,
             wireframe: wireframe,
             viewModelFactory: viewModelFactory,
+            metaId: wallet.metaId,
             localizationManager: localizationManager
         )
 

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetInteractor.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetInteractor.swift
@@ -5,14 +5,9 @@ final class DAppBrowserWidgetInteractor {
     weak var presenter: DAppBrowserWidgetInteractorOutputProtocol?
 
     private let tabManager: DAppBrowserTabManagerProtocol
-    private let eventCenter: EventCenterProtocol
 
-    init(
-        tabManager: DAppBrowserTabManagerProtocol,
-        eventCenter: EventCenterProtocol
-    ) {
+    init(tabManager: DAppBrowserTabManagerProtocol) {
         self.tabManager = tabManager
-        self.eventCenter = eventCenter
     }
 }
 
@@ -23,10 +18,6 @@ extension DAppBrowserWidgetInteractor: DAppBrowserWidgetInteractorInputProtocol 
         tabManager.addObserver(
             self,
             sendOnSubscription: false
-        )
-        eventCenter.add(
-            observer: self,
-            dispatchIn: .main
         )
     }
 
@@ -42,13 +33,5 @@ extension DAppBrowserWidgetInteractor: DAppBrowserTabsObserver {
         let tabsById = tabs.reduce(into: [UUID: DAppBrowserTab]()) { $0[$1.uuid] = $1 }
 
         presenter?.didReceive(tabsById)
-    }
-}
-
-// MARK: EventVisitorProtocol
-
-extension DAppBrowserWidgetInteractor: EventVisitorProtocol {
-    func processSelectedWalletChanged(event _: SelectedWalletSwitched) {
-        presenter?.didReceiveWalletChanged()
     }
 }

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetPresenter.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetPresenter.swift
@@ -146,16 +146,14 @@ extension DAppBrowserWidgetPresenter: DAppBrowserWidgetInteractorOutputProtocol 
         case .disabled where !browserTabs.isEmpty:
             state = .closed
             view?.didReceiveRequestForMinimizing()
+        case .closed where !browserTabs.isEmpty:
+            view?.didReceiveRequestForMinimizing()
         case .miniature where browserTabs.isEmpty:
             state = .closed
             provideModel()
         default:
             break
         }
-    }
-
-    func didReceiveWalletChanged() {
-        view?.didChangeWallet()
     }
 }
 

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetProtocols.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetProtocols.swift
@@ -19,7 +19,6 @@ protocol DAppBrowserWidgetProtocol {
 protocol DAppBrowserWidgetViewProtocol: ControllerBackedProtocol {
     func didReceive(_ browserWidgetModel: DAppBrowserWidgetModel)
     func didReceiveRequestForMinimizing()
-    func didChangeWallet()
 }
 
 // MARK: VIEW -> PRESENTER
@@ -47,7 +46,6 @@ protocol DAppBrowserWidgetInteractorInputProtocol: AnyObject {
 
 protocol DAppBrowserWidgetInteractorOutputProtocol: AnyObject {
     func didReceive(_ browserTabs: [UUID: DAppBrowserTab])
-    func didReceiveWalletChanged()
 }
 
 // MARK: PRESENTER -> WIREFRAME

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetViewController.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetViewController.swift
@@ -87,10 +87,6 @@ private extension DAppBrowserWidgetViewController {
 // MARK: DAppBrowserWidgetViewProtocol
 
 extension DAppBrowserWidgetViewController: DAppBrowserWidgetViewProtocol {
-    func didChangeWallet() {
-        webViewPoolEraser.removeAll()
-    }
-
     func didReceiveRequestForMinimizing() {
         minimize()
     }

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetViewFactory.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetViewFactory.swift
@@ -3,10 +3,7 @@ import SoraFoundation
 
 struct DAppBrowserWidgetViewFactory {
     static func createView() -> DAppBrowserWidgetViewProtocol? {
-        let interactor = DAppBrowserWidgetInteractor(
-            tabManager: DAppBrowserTabManager.shared,
-            eventCenter: EventCenter.shared
-        )
+        let interactor = DAppBrowserWidgetInteractor(tabManager: DAppBrowserTabManager.shared)
 
         let wireframe = DAppBrowserWidgetWireframe()
 

--- a/novawallet/Modules/DApp/DAppBrowser/Model/DAppBrowserTab.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/Model/DAppBrowserTab.swift
@@ -5,6 +5,7 @@ struct DAppBrowserTab {
     let uuid: UUID
     let name: String?
     let url: URL
+    let metaId: MetaAccountModel.Id
     let createdAt: Date
     let renderModifiedAt: Date?
     let transportStates: [DAppTransportState]?
@@ -16,6 +17,7 @@ struct DAppBrowserTab {
             uuid: uuid,
             name: name,
             url: url,
+            metaId: metaId,
             createdAt: createdAt,
             renderModifiedAt: renderModifiedAt,
             icon: icon?.absoluteString,
@@ -27,6 +29,7 @@ struct DAppBrowserTab {
         uuid: UUID,
         name: String?,
         url: URL,
+        metaId: MetaAccountModel.Id,
         createdAt: Date,
         renderModifiedAt: Date?,
         transportStates: [DAppTransportState]?,
@@ -36,6 +39,7 @@ struct DAppBrowserTab {
         self.uuid = uuid
         self.name = name
         self.url = url
+        self.metaId = metaId
         self.createdAt = createdAt
         self.renderModifiedAt = renderModifiedAt
         self.transportStates = transportStates
@@ -43,16 +47,22 @@ struct DAppBrowserTab {
         self.icon = icon
     }
 
-    init?(from searchResult: DAppSearchResult) {
+    init?(
+        from searchResult: DAppSearchResult,
+        metaId: MetaAccountModel.Id
+    ) {
         switch searchResult {
         case let .query(query):
-            self.init(from: query)
+            self.init(from: query, metaId: metaId)
         case let .dApp(dApp):
-            self.init(from: dApp)
+            self.init(from: dApp, metaId: metaId)
         }
     }
 
-    init?(from query: String) {
+    init?(
+        from query: String,
+        metaId: MetaAccountModel.Id
+    ) {
         guard let url = DAppBrowserTab.resolveUrl(for: query) else {
             return nil
         }
@@ -65,9 +75,13 @@ struct DAppBrowserTab {
         name = nil
         icon = nil
         self.url = url
+        self.metaId = metaId
     }
 
-    init(from dApp: DApp) {
+    init(
+        from dApp: DApp,
+        metaId: MetaAccountModel.Id
+    ) {
         uuid = UUID()
         createdAt = Date()
         renderModifiedAt = nil
@@ -76,6 +90,7 @@ struct DAppBrowserTab {
         name = dApp.name
         url = dApp.url
         icon = dApp.icon
+        self.metaId = metaId
     }
 
     func updating(
@@ -89,6 +104,7 @@ struct DAppBrowserTab {
             uuid: uuid,
             name: name ?? self.name,
             url: url,
+            metaId: metaId,
             createdAt: createdAt,
             renderModifiedAt: renderModifiedAt ?? self.renderModifiedAt,
             transportStates: transportStates ?? self.transportStates,
@@ -113,6 +129,7 @@ struct DAppBrowserTab {
             uuid: uuid,
             name: dApp.name,
             url: dApp.url,
+            metaId: metaId,
             createdAt: createdAt,
             renderModifiedAt: renderModifiedAt,
             transportStates: nil,
@@ -126,6 +143,7 @@ struct DAppBrowserTab {
             uuid: uuid,
             name: nil,
             url: url,
+            metaId: metaId,
             createdAt: createdAt,
             renderModifiedAt: renderModifiedAt,
             transportStates: nil,
@@ -139,6 +157,7 @@ struct DAppBrowserTab {
             uuid: uuid,
             name: name,
             url: url,
+            metaId: metaId,
             createdAt: createdAt,
             renderModifiedAt: renderModifiedAt,
             transportStates: nil,
@@ -177,6 +196,7 @@ extension DAppBrowserTab {
         let uuid: UUID
         let name: String?
         let url: URL
+        let metaId: String
         let createdAt: Date
         let renderModifiedAt: Date?
         let icon: String?

--- a/novawallet/Modules/DApp/DAppBrowser/Tabs/DAppBrowserTabManager/DAppBrowserTabManager+Singleton.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/Tabs/DAppBrowserTabManager/DAppBrowserTabManager+Singleton.swift
@@ -2,8 +2,6 @@ import Foundation
 import Operation_iOS
 
 extension DAppBrowserTabManager {
-    private static let readWriteQueueLabel = "\(String(describing: DAppBrowserTabManager.self)) sync queue"
-
     static let shared: DAppBrowserTabManager = {
         let mapper = DAppBrowserTabMapper()
         let storageFacade = UserDataStorageFacade.shared
@@ -22,15 +20,23 @@ extension DAppBrowserTabManager {
         let operationQueue = OperationManagerFacade.sharedDefaultQueue
         let logger = Logger.shared
 
+        let tabsSubscriptionFactory = PersistentTabLocalSubscriptionFactory(
+            storageFacade: storageFacade,
+            operationQueue: operationQueue,
+            logger: logger
+        )
+
+        let walletListLocalSubscriptionFactory = WalletListLocalSubscriptionFactory(
+            storageFacade: storageFacade,
+            operationManager: OperationManagerFacade.sharedManager,
+            logger: logger
+        )
+
         return DAppBrowserTabManager(
             fileRepository: renderFilesRepository,
-            tabsSubscriptionFactory: PersistentTabLocalSubscriptionFactory(
-                storageFacade: storageFacade,
-                operationQueue: operationQueue,
-                logger: logger
-            ),
+            tabsSubscriptionFactory: tabsSubscriptionFactory,
+            walletListLocalSubscriptionFactory: walletListLocalSubscriptionFactory,
             repository: AnyDataProviderRepository(coreDataRepository),
-            eventCenter: EventCenter.shared,
             operationQueue: operationQueue,
             logger: logger
         )

--- a/novawallet/Modules/DApp/DAppBrowser/Tabs/DAppBrowserTabManager/DAppBrowserTabManager.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/Tabs/DAppBrowserTabManager/DAppBrowserTabManager.swift
@@ -225,6 +225,7 @@ private extension DAppBrowserTabManager {
             uuid: persistenceModel.uuid,
             name: persistenceModel.name,
             url: persistenceModel.url,
+            metaId: persistenceModel.metaId,
             createdAt: persistenceModel.createdAt,
             renderModifiedAt: persistenceModel.renderModifiedAt,
             transportStates: transportStates.fetchValue(for: persistenceModel.uuid),
@@ -258,7 +259,7 @@ extension DAppBrowserTabManager: DAppBrowserTabManagerProtocol {
         retrieveWrapper(for: id)
     }
 
-    func getAllTabs() -> CompoundOperationWrapper<[DAppBrowserTab]> {
+    func getAllTabs(for metaId: MetaAccountModel.Id) -> CompoundOperationWrapper<[DAppBrowserTab]> {
         let currentTabs = observableTabs.state.fetchAllValues()
 
         guard currentTabs.isEmpty else {
@@ -334,7 +335,7 @@ extension DAppBrowserTabManager: DAppBrowserTabManagerProtocol {
         return resultWrapper.insertingTail(operation: voidResultOperation)
     }
 
-    func removeAll() {
+    func removeAll(for metaId: MetaAccountModel.Id) {
         let wrapper = removeAllWrapper()
 
         execute(

--- a/novawallet/Modules/DApp/DAppBrowser/Tabs/DAppBrowserTabManager/DAppBrowserTabManagerProtocol.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/Tabs/DAppBrowserTabManager/DAppBrowserTabManagerProtocol.swift
@@ -7,7 +7,7 @@ protocol DAppBrowserTabsObserver: AnyObject {
 
 protocol DAppBrowserTabManagerProtocol {
     func retrieveTab(with id: UUID) -> CompoundOperationWrapper<DAppBrowserTab?>
-    func getAllTabs() -> CompoundOperationWrapper<[DAppBrowserTab]>
+    func getAllTabs(for metaId: MetaAccountModel.Id) -> CompoundOperationWrapper<[DAppBrowserTab]>
 
     func updateTab(_ tab: DAppBrowserTab) -> CompoundOperationWrapper<DAppBrowserTab>
 
@@ -18,7 +18,7 @@ protocol DAppBrowserTabManagerProtocol {
 
     func removeTab(with id: UUID)
 
-    func removeAll()
+    func removeAll(for metaId: MetaAccountModel.Id)
 
     func addObserver(
         _ observer: DAppBrowserTabsObserver,

--- a/novawallet/Modules/DApp/DAppBrowser/Tabs/DAppBrowserTabManager/DAppBrowserTabManagerProtocol.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/Tabs/DAppBrowserTabManager/DAppBrowserTabManagerProtocol.swift
@@ -7,7 +7,7 @@ protocol DAppBrowserTabsObserver: AnyObject {
 
 protocol DAppBrowserTabManagerProtocol {
     func retrieveTab(with id: UUID) -> CompoundOperationWrapper<DAppBrowserTab?>
-    func getAllTabs(for metaId: MetaAccountModel.Id) -> CompoundOperationWrapper<[DAppBrowserTab]>
+    func getAllTabs() -> CompoundOperationWrapper<[DAppBrowserTab]>
 
     func updateTab(_ tab: DAppBrowserTab) -> CompoundOperationWrapper<DAppBrowserTab>
 
@@ -18,7 +18,7 @@ protocol DAppBrowserTabManagerProtocol {
 
     func removeTab(with id: UUID)
 
-    func removeAll(for metaId: MetaAccountModel.Id)
+    func removeAll()
 
     func addObserver(
         _ observer: DAppBrowserTabsObserver,

--- a/novawallet/Modules/DApp/DAppBrowser/Tabs/DAppBrowserTabManager/PersistentTabLocalSubscriptionFactory/DAppBrowserTabLocalSibscriber.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/Tabs/DAppBrowserTabManager/PersistentTabLocalSubscriptionFactory/DAppBrowserTabLocalSibscriber.swift
@@ -7,15 +7,15 @@ protocol DAppBrowserTabLocalSubscriber: AnyObject {
     var tabsLocalSubscriptionHandler: DAppBrowserTabLocalSubscriptionHandler { get }
 
     func subscribeToBrowserTabs(
-        _ identifier: UUID?
+        _ metaId: MetaAccountModel.Id?
     ) -> StreamableProvider<DAppBrowserTab.PersistenceModel>
 }
 
 extension DAppBrowserTabLocalSubscriber {
     func subscribeToBrowserTabs(
-        _ identifier: UUID?
+        _ metaId: MetaAccountModel.Id?
     ) -> StreamableProvider<DAppBrowserTab.PersistenceModel> {
-        let provider = tabsSubscriptionFactory.getTabsProvider(identifier)
+        let provider = tabsSubscriptionFactory.getTabsProvider(metaId)
 
         let updateClosure = {
             [weak self] (changes: [DataProviderChange<DAppBrowserTab.PersistenceModel>]) in

--- a/novawallet/Modules/DApp/DAppFavorites/DAppFavoritesPresenter.swift
+++ b/novawallet/Modules/DApp/DAppFavorites/DAppFavoritesPresenter.swift
@@ -10,6 +10,8 @@ final class DAppFavoritesPresenter {
     let localizationManager: LocalizationManagerProtocol
     let logger: LoggerProtocol
 
+    let metaId: MetaAccountModel.Id
+
     private var favorites: [String: DAppFavorite] = [:]
     private var dAppList: DAppList?
 
@@ -17,12 +19,14 @@ final class DAppFavoritesPresenter {
         interactor: DAppFavoritesInteractorInputProtocol,
         wireframe: DAppFavoritesWireframeProtocol,
         viewModelFactory: DAppListViewModelFactoryProtocol,
+        metaId: MetaAccountModel.Id,
         localizationManager: LocalizationManagerProtocol,
         logger: LoggerProtocol
     ) {
         self.interactor = interactor
         self.wireframe = wireframe
         self.viewModelFactory = viewModelFactory
+        self.metaId = metaId
         self.localizationManager = localizationManager
         self.logger = logger
     }
@@ -73,9 +77,9 @@ extension DAppFavoritesPresenter: DAppFavoritesPresenterProtocol {
         guard let dAppList else { return }
 
         let tab: DAppBrowserTab? = if let dApp = dAppList.dApps.first(where: { $0.identifier == id }) {
-            DAppBrowserTab(from: dApp)
+            DAppBrowserTab(from: dApp, metaId: metaId)
         } else {
-            DAppBrowserTab(from: id)
+            DAppBrowserTab(from: id, metaId: metaId)
         }
 
         guard let tab else { return }

--- a/novawallet/Modules/DApp/DAppFavorites/DAppFavoritesViewFactory.swift
+++ b/novawallet/Modules/DApp/DAppFavorites/DAppFavoritesViewFactory.swift
@@ -33,10 +33,13 @@ struct DAppFavoritesViewFactory {
             dappCategoriesViewModelFactory: categoriesViewModelFactory
         )
 
+        let wallet: MetaAccountModel = SelectedWalletSettings.shared.value
+
         let presenter = DAppFavoritesPresenter(
             interactor: interactor,
             wireframe: wireframe,
             viewModelFactory: viewModelFactory,
+            metaId: wallet.metaId,
             localizationManager: localizationManager,
             logger: logger
         )

--- a/novawallet/Modules/DApp/DAppList/DAppListPresenter.swift
+++ b/novawallet/Modules/DApp/DAppList/DAppListPresenter.swift
@@ -85,12 +85,15 @@ extension DAppListPresenter: DAppListPresenterProtocol {
     }
 
     func selectDApp(with id: String) {
-        guard case let .success(dAppList) = dAppsResult else { return }
+        guard
+            let wallet,
+            case let .success(dAppList) = dAppsResult
+        else { return }
 
         let tab: DAppBrowserTab? = if let dApp = dAppList.dApps.first(where: { $0.identifier == id }) {
-            DAppBrowserTab(from: dApp)
+            DAppBrowserTab(from: dApp, metaId: wallet.metaId)
         } else if let dApp = favorites?[id] {
-            DAppBrowserTab(from: dApp.identifier)
+            DAppBrowserTab(from: dApp.identifier, metaId: wallet.metaId)
         } else {
             nil
         }
@@ -157,7 +160,9 @@ extension DAppListPresenter: DAppListInteractorOutputProtocol {
 
 extension DAppListPresenter: DAppSearchDelegate {
     func didCompleteDAppSearchResult(_ result: DAppSearchResult) {
-        guard let tab = DAppBrowserTab(from: result) else {
+        guard let wallet else { return }
+
+        guard let tab = DAppBrowserTab(from: result, metaId: wallet.metaId) else {
             return
         }
 

--- a/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsPresenter.swift
+++ b/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsPresenter.swift
@@ -8,6 +8,8 @@ final class StakingMoreOptionsPresenter {
     let interactor: StakingMoreOptionsInteractorInputProtocol
     let logger: LoggerProtocol
 
+    let metaId: MetaAccountModel.Id
+
     private var moreOptions: [StakingDashboardItemModel] = []
     private var dApps: [DApp] = []
 
@@ -15,12 +17,14 @@ final class StakingMoreOptionsPresenter {
         interactor: StakingMoreOptionsInteractorInputProtocol,
         viewModelFactory: StakingMoreOptionsViewModelFactoryProtocol,
         wireframe: StakingMoreOptionsWireframeProtocol,
+        metaId: MetaAccountModel.Id,
         localizationManager: LocalizationManagerProtocol,
         logger: LoggerProtocol
     ) {
         self.interactor = interactor
         self.viewModelFactory = viewModelFactory
         self.wireframe = wireframe
+        self.metaId = metaId
         self.logger = logger
         self.localizationManager = localizationManager
     }
@@ -69,7 +73,9 @@ extension StakingMoreOptionsPresenter: StakingMoreOptionsPresenterProtocol {
         guard let dApp = dApps[safe: index] else {
             return
         }
-        wireframe.showBrowser(from: view, for: dApp)
+
+        let tab = DAppBrowserTab(from: dApp, metaId: metaId)
+        wireframe.showBrowser(from: view, with: tab)
     }
 }
 

--- a/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsProtocols.swift
+++ b/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsProtocols.swift
@@ -20,7 +20,10 @@ protocol StakingMoreOptionsInteractorOutputProtocol: AnyObject {
 }
 
 protocol StakingMoreOptionsWireframeProtocol: ErrorPresentable, AlertPresentable, CommonRetryable {
-    func showBrowser(from view: ControllerBackedProtocol?, for dApp: DApp)
+    func showBrowser(
+        from view: ControllerBackedProtocol?,
+        with tab: DAppBrowserTab
+    )
 
     func showStartStaking(
         from view: StakingMoreOptionsViewProtocol?,

--- a/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsViewFactory.swift
+++ b/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsViewFactory.swift
@@ -2,7 +2,9 @@ import Foundation
 import SoraFoundation
 
 struct StakingMoreOptionsViewFactory {
-    static func createView(stateObserver: Observable<StakingDashboardModel>) -> StakingMoreOptionsViewProtocol? {
+    static func createView(
+        stateObserver: Observable<StakingDashboardModel>
+    ) -> StakingMoreOptionsViewProtocol? {
         guard let currencyManager = CurrencyManager.shared else {
             return nil
         }
@@ -25,10 +27,13 @@ struct StakingMoreOptionsViewFactory {
             estimatedEarningsFormatter: NumberFormatter.percentBase.localizableResource()
         )
 
+        let wallet: MetaAccountModel = SelectedWalletSettings.shared.value
+
         let presenter = StakingMoreOptionsPresenter(
             interactor: interactor,
             viewModelFactory: viewModelFactory,
             wireframe: wireframe,
+            metaId: wallet.metaId,
             localizationManager: LocalizationManager.shared,
             logger: Logger.shared
         )

--- a/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsWireframe.swift
+++ b/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsWireframe.swift
@@ -1,9 +1,10 @@
 import Foundation
 
 final class StakingMoreOptionsWireframe: StakingMoreOptionsWireframeProtocol {
-    func showBrowser(from view: ControllerBackedProtocol?, for dApp: DApp) {
-        let tab = DAppBrowserTab(from: dApp)
-
+    func showBrowser(
+        from view: ControllerBackedProtocol?,
+        with tab: DAppBrowserTab
+    ) {
         guard let browserView = DAppBrowserViewFactory.createView(selectedTab: tab) else {
             return
         }

--- a/novawallet/Modules/Vote/Governance/ReferendumDetails/ReferendumDetailsPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/ReferendumDetails/ReferendumDetailsPresenter.swift
@@ -495,7 +495,7 @@ extension ReferendumDetailsPresenter: ReferendumDetailsPresenterProtocol {
         guard
             let dApp = dApps?[index],
             let url = try? dApp.extractFullUrl(for: referendum.index, governanceType: governanceType),
-            let tab = DAppBrowserTab(from: url.absoluteString)
+            let tab = DAppBrowserTab(from: url.absoluteString, metaId: wallet.metaId)
         else {
             return
         }


### PR DESCRIPTION
## Purpose
Opened browser tabs (i.e., dApps) are meant to be associated with the wallet that was selected at the time. This PR adds:

- `metaId` property to the `CDDAppBrowserTab` entity
- Changes to the logic in `DAppBrowserTabManager` for handling tab persistence and state
- Use `StreamableProvider` to subscribe to selected wallet changes instead of using `EventCenter`

https://github.com/user-attachments/assets/1b3c57ff-7155-420c-a600-c1a4cd6036b7

