### PR TITLE
add dapp icons for browser widget and tabs manager

### DIFF
--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListViewFactory.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListViewFactory.swift
@@ -30,11 +30,15 @@ struct DAppBrowserTabListViewFactory {
 
         let localizationManager = LocalizationManager.shared
 
+        let dappIconViewModelFactory = DAppIconViewModelFactory()
         let imageViewModelFactory = WebViewRenderImageViewModelFactory(
             fileRepository: FileRepository(),
             renderFetchOperationQueue: operationQueue
         )
-        let viewModelFactory = DAppBrowserTabListViewModelFactory(imageViewModelFactory: imageViewModelFactory)
+        let viewModelFactory = DAppBrowserTabListViewModelFactory(
+            imageViewModelFactory: imageViewModelFactory,
+            dAppIconViewModelFactory: dappIconViewModelFactory
+        )
 
         let wallet: MetaAccountModel = SelectedWalletSettings.shared.value
 

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/View/DAppBrowserTabListViewModelFactory.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/View/DAppBrowserTabListViewModelFactory.swift
@@ -10,22 +10,22 @@ protocol DAppBrowserTabListViewModelFactoryProtocol {
 
 struct DAppBrowserTabListViewModelFactory {
     private let imageViewModelFactory: WebViewRenderImageViewModelFactoryProtocol
+    private let dAppIconViewModelFactory: DAppIconViewModelFactoryProtocol
 
-    init(imageViewModelFactory: WebViewRenderImageViewModelFactoryProtocol) {
+    init(
+        imageViewModelFactory: WebViewRenderImageViewModelFactoryProtocol,
+        dAppIconViewModelFactory: DAppIconViewModelFactoryProtocol
+    ) {
         self.imageViewModelFactory = imageViewModelFactory
+        self.dAppIconViewModelFactory = dAppIconViewModelFactory
     }
 
     private func createViewModel(
         for tab: DAppBrowserTab,
         locale: Locale
     ) -> DAppBrowserTabViewModel {
-        let iconViewModel: ImageViewModelProtocol? = {
-            guard let iconUrl = tab.icon else { return nil }
-
-            return RemoteImageViewModel(url: iconUrl)
-        }()
-
-        let renderViewModel: ImageViewModelProtocol? = imageViewModelFactory.createViewModel(for: tab.uuid)
+        let iconViewModel = dAppIconViewModelFactory.createIconViewModel(for: tab)
+        let renderViewModel = imageViewModelFactory.createViewModel(for: tab.uuid)
 
         let url = tab.url.host
 

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetViewController.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetViewController.swift
@@ -92,7 +92,7 @@ extension DAppBrowserWidgetViewController: DAppBrowserWidgetViewProtocol {
     }
 
     func didReceive(_ browserWidgetModel: DAppBrowserWidgetModel) {
-        rootView.browserWidgetView.title.text = browserWidgetModel.title
+        rootView.browserWidgetView.bind(viewModel: browserWidgetModel)
 
         guard state != browserWidgetModel.widgetState else { return }
 

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetViewFactory.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetViewFactory.swift
@@ -7,10 +7,14 @@ struct DAppBrowserWidgetViewFactory {
 
         let wireframe = DAppBrowserWidgetWireframe()
 
+        let viewModelFactory = DAppBrowserWidgetViewModelFactory(
+            dAppIconViewModelFactory: DAppIconViewModelFactory()
+        )
+
         let presenter = DAppBrowserWidgetPresenter(
             interactor: interactor,
             wireframe: wireframe,
-            browserTabsViewModelFactory: DAppBrowserWidgetViewModelFactory(),
+            browserTabsViewModelFactory: viewModelFactory,
             localizationManager: LocalizationManager.shared
         )
 

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/Model/DAppBrowserWidgetModel.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/Model/DAppBrowserWidgetModel.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct DAppBrowserWidgetModel {
     let title: String?
+    let icon: ImageViewModelProtocol?
     let widgetState: DAppBrowserWidgetState
     let transitionBuilder: DAppBrowserWidgetTransitionBuilder?
 }

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/Model/DAppBrowserWidgetViewModelFactory.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/Model/DAppBrowserWidgetViewModelFactory.swift
@@ -9,7 +9,17 @@ protocol DAppBrowserWidgetViewModelFactoryProtocol {
     ) -> DAppBrowserWidgetModel
 }
 
-class DAppBrowserWidgetViewModelFactory: DAppBrowserWidgetViewModelFactoryProtocol {
+class DAppBrowserWidgetViewModelFactory {
+    private let dAppIconViewModelFactory: DAppIconViewModelFactoryProtocol
+
+    init(dAppIconViewModelFactory: DAppIconViewModelFactoryProtocol) {
+        self.dAppIconViewModelFactory = dAppIconViewModelFactory
+    }
+}
+
+// MARK: DAppBrowserWidgetViewModelFactoryProtocol
+
+extension DAppBrowserWidgetViewModelFactory: DAppBrowserWidgetViewModelFactoryProtocol {
     func createViewModel(
         for tabs: [UUID: DAppBrowserTab],
         state: DAppBrowserWidgetState,
@@ -27,8 +37,15 @@ class DAppBrowserWidgetViewModelFactory: DAppBrowserWidgetViewModelFactoryProtoc
             tabs.values.first?.name ?? tabs.values.first?.url.absoluteString
         }
 
+        let iconViewModel: ImageViewModelProtocol? = if tabs.count == 1, let tab = tabs.values.first {
+            dAppIconViewModelFactory.createIconViewModel(for: tab)
+        } else {
+            nil
+        }
+
         return DAppBrowserWidgetModel(
             title: title,
+            icon: iconViewModel,
             widgetState: state,
             transitionBuilder: transitionBuilder
         )

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/View/DAppBrowserWidgetView.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/View/DAppBrowserWidgetView.swift
@@ -16,9 +16,10 @@ class DAppBrowserWidgetView: UIView {
         view.imageWithTitleView?.iconImage = R.image.iconClose()
     }
 
-    let title: UILabel = .create { view in
-        view.apply(style: .semiboldBodyPrimary)
-        view.textAlignment = .center
+    let title: IconDetailsView = .create { view in
+        view.detailsLabel.apply(style: .semiboldBodyPrimary)
+        view.detailsLabel.textAlignment = .center
+        view.spacing = 7.0
     }
 
     override init(frame: CGRect) {
@@ -31,6 +32,25 @@ class DAppBrowserWidgetView: UIView {
     @available(*, unavailable)
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func bind(viewModel: DAppBrowserWidgetModel) {
+        title.detailsLabel.text = viewModel.title
+
+        if let iconModel = viewModel.icon {
+            title.iconWidth = Constants.iconSize.width
+            title.spacing = Constants.titleIconSpacing
+
+            iconModel.loadImage(
+                on: title.imageView,
+                targetSize: Constants.iconSize,
+                animated: true
+            )
+        } else {
+            title.spacing = 0
+            title.iconWidth = 0
+            title.imageView.image = nil
+        }
     }
 }
 
@@ -80,5 +100,7 @@ private extension DAppBrowserWidgetView {
         static let closeButtonLeadingInset: CGFloat = UIConstants.horizontalInset
         static let titleHeight: CGFloat = 22.0
         static let titleTopInset: CGFloat = 9.0
+        static let iconSize = CGSize(width: 16.0, height: 16.0)
+        static let titleIconSpacing = 7.0
     }
 }

--- a/novawallet/Modules/DApp/DAppList/ViewModel/DAppListViewModelFactory/DAppIconViewModelFactory.swift
+++ b/novawallet/Modules/DApp/DAppList/ViewModel/DAppListViewModelFactory/DAppIconViewModelFactory.swift
@@ -4,6 +4,7 @@ protocol DAppIconViewModelFactoryProtocol {
     func createIconViewModel(for favorite: DAppFavorite) -> ImageViewModelProtocol
     func createIconViewModel(for dApp: DApp) -> ImageViewModelProtocol
     func createIconViewModel(for dAppAuthRequest: DAppAuthRequest) -> ImageViewModelProtocol
+    func createIconViewModel(for dAppBrowserTab: DAppBrowserTab) -> ImageViewModelProtocol
 }
 
 class DAppIconViewModelFactory {
@@ -91,6 +92,13 @@ extension DAppIconViewModelFactory: DAppIconViewModelFactoryProtocol {
         return createImageViewModel(
             for: dAppAuthRequest.dAppIcon,
             dAppURL: dAppURL
+        )
+    }
+
+    func createIconViewModel(for dAppBrowserTab: DAppBrowserTab) -> ImageViewModelProtocol {
+        createImageViewModel(
+            for: dAppBrowserTab.icon,
+            dAppURL: dAppBrowserTab.url
         )
     }
 }


### PR DESCRIPTION
## SUMMARY

PR adds support for icons (or favicons) for both `DAppBrowserWidget` and `DAppBrowserTabList` modules.

## SOLUTION SCREENSHOTS

<img width="226" alt="Image name" src=https://github.com/user-attachments/assets/36109fd3-3b3e-4e0c-b3f4-07d8e9990568>
<img width="226" alt="Image name" src=https://github.com/user-attachments/assets/54dca585-d37f-48e8-98f1-1ff6e4d9352a>

