### PR TITLE
Fix restore collection view layout on rotations

### DIFF
--- a/novawallet/Modules/AssetList/AssetListProtocols.swift
+++ b/novawallet/Modules/AssetList/AssetListProtocols.swift
@@ -21,6 +21,7 @@ protocol AssetListCollectionManagerProtocol {
         from oldViewModel: AssetListViewModel,
         to newViewModel: AssetListViewModel
     )
+    func invalidateLayout()
     func updateLoadingState()
 }
 

--- a/novawallet/Modules/AssetList/AssetListViewController.swift
+++ b/novawallet/Modules/AssetList/AssetListViewController.swift
@@ -64,6 +64,7 @@ final class AssetListViewController: UIViewController, ViewHolder {
     ) {
         super.willTransition(to: newCollectionEnvironment, with: coordinator)
 
+        // Force layout update after rotation animation completes as a workaround the bug with wrong cell size
         coordinator.animate(alongsideTransition: nil) { [weak self] _ in
             self?.collectionViewManager.invalidateLayout()
         }

--- a/novawallet/Modules/AssetList/AssetListViewController.swift
+++ b/novawallet/Modules/AssetList/AssetListViewController.swift
@@ -58,6 +58,17 @@ final class AssetListViewController: UIViewController, ViewHolder {
         collectionViewManager.updateLoadingState()
     }
 
+    override func willTransition(
+        to newCollectionEnvironment: UITraitCollection,
+        with coordinator: UIViewControllerTransitionCoordinator
+    ) {
+        super.willTransition(to: newCollectionEnvironment, with: coordinator)
+
+        coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+            self?.collectionViewManager.invalidateLayout()
+        }
+    }
+
     private func setupCollectionView() {
         collectionViewManager.setupCollectionView()
     }

--- a/novawallet/Modules/AssetList/View/AssetListCollectionManager/AssetListCollectionManager.swift
+++ b/novawallet/Modules/AssetList/View/AssetListCollectionManager/AssetListCollectionManager.swift
@@ -166,6 +166,10 @@ extension AssetListCollectionManager: AssetListCollectionManagerProtocol {
         }
     }
 
+    func invalidateLayout() {
+        collectionViewLayout?.invalidateLayout()
+    }
+
     func updateGroupsViewModel(with model: AssetListViewModel) {
         replaceViewModel(model)
     }

--- a/novawallet/Modules/Staking/Dashboard/StakingDashboardViewController.swift
+++ b/novawallet/Modules/Staking/Dashboard/StakingDashboardViewController.swift
@@ -49,6 +49,17 @@ final class StakingDashboardViewController: UIViewController, ViewHolder {
         updateLoadingState()
     }
 
+    override func willTransition(
+        to newCollectionEnvironment: UITraitCollection,
+        with coordinator: UIViewControllerTransitionCoordinator
+    ) {
+        super.willTransition(to: newCollectionEnvironment, with: coordinator)
+
+        coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+            self?.rootView.collectionView.collectionViewLayout.invalidateLayout()
+        }
+    }
+
     private func setupCollectionView() {
         rootView.collectionView.registerCellClass(WalletSwitchCollectionViewCell.self)
 

--- a/novawallet/Modules/Staking/Dashboard/StakingDashboardViewController.swift
+++ b/novawallet/Modules/Staking/Dashboard/StakingDashboardViewController.swift
@@ -55,6 +55,7 @@ final class StakingDashboardViewController: UIViewController, ViewHolder {
     ) {
         super.willTransition(to: newCollectionEnvironment, with: coordinator)
 
+        // Force layout update after rotation animation completes as a workaround the bug with wrong cell size
         coordinator.animate(alongsideTransition: nil) { [weak self] _ in
             self?.rootView.collectionView.collectionViewLayout.invalidateLayout()
         }


### PR DESCRIPTION
## Purpose

It seems that there is a bug in iOS that prevents UICollectionView to update cell frame on device rotation in some cases like ours with custom presentation. The PR adds a workaround to address the issue by forcing update of the layout when transition animation ends.