### PR TITLE
Start staking info screen

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -78,6 +78,11 @@
 		0C0E0AA32B3F01FD00865F10 /* UniquesPallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0E0AA22B3F01FD00865F10 /* UniquesPallet.swift */; };
 		0C0F6D632D38077B00943A7C /* FreezesSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D622D38077B00943A7C /* FreezesSubscription.swift */; };
 		0C0F6D652D3807D200943A7C /* BalancesPallet+Freezes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D642D3807D200943A7C /* BalancesPallet+Freezes.swift */; };
+		0C0F6D672D394AF800943A7C /* MythosMultistakingUpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D662D394AF800943A7C /* MythosMultistakingUpdateService.swift */; };
+		0C0F6D692D394BE000943A7C /* Multistaking+Mythos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D682D394BE000943A7C /* Multistaking+Mythos.swift */; };
+		0C0F6D6C2D394CA200943A7C /* MythosStakingPallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D6B2D394CA200943A7C /* MythosStakingPallet.swift */; };
+		0C0F6D6E2D39549100943A7C /* StakingDashboardMythosMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D6D2D39549100943A7C /* StakingDashboardMythosMapper.swift */; };
+		0C0F6D702D3958CD00943A7C /* MythosStaking+StoragePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D6F2D3958CD00943A7C /* MythosStaking+StoragePath.swift */; };
 		0C11D8522CC9F5F2003EC46D /* HydraOmnipoolExchangeEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C11D8512CC9F5F2003EC46D /* HydraOmnipoolExchangeEdge.swift */; };
 		0C11D8542CC9F82C003EC46D /* HydraStableswapExchangeEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C11D8532CC9F82C003EC46D /* HydraStableswapExchangeEdge.swift */; };
 		0C11D8562CC9F9E6003EC46D /* HydraXYKExchangeEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C11D8552CC9F9E6003EC46D /* HydraXYKExchangeEdge.swift */; };
@@ -5460,6 +5465,11 @@
 		0C0F6D612D37FE0800943A7C /* SubstrateDataModel35.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SubstrateDataModel35.xcdatamodel; sourceTree = "<group>"; };
 		0C0F6D622D38077B00943A7C /* FreezesSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreezesSubscription.swift; sourceTree = "<group>"; };
 		0C0F6D642D3807D200943A7C /* BalancesPallet+Freezes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BalancesPallet+Freezes.swift"; sourceTree = "<group>"; };
+		0C0F6D662D394AF800943A7C /* MythosMultistakingUpdateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MythosMultistakingUpdateService.swift; sourceTree = "<group>"; };
+		0C0F6D682D394BE000943A7C /* Multistaking+Mythos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Multistaking+Mythos.swift"; sourceTree = "<group>"; };
+		0C0F6D6B2D394CA200943A7C /* MythosStakingPallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MythosStakingPallet.swift; sourceTree = "<group>"; };
+		0C0F6D6D2D39549100943A7C /* StakingDashboardMythosMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingDashboardMythosMapper.swift; sourceTree = "<group>"; };
+		0C0F6D6F2D3958CD00943A7C /* MythosStaking+StoragePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MythosStaking+StoragePath.swift"; sourceTree = "<group>"; };
 		0C11D8512CC9F5F2003EC46D /* HydraOmnipoolExchangeEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolExchangeEdge.swift; sourceTree = "<group>"; };
 		0C11D8532CC9F82C003EC46D /* HydraStableswapExchangeEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraStableswapExchangeEdge.swift; sourceTree = "<group>"; };
 		0C11D8552CC9F9E6003EC46D /* HydraXYKExchangeEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraXYKExchangeEdge.swift; sourceTree = "<group>"; };
@@ -11095,6 +11105,15 @@
 			path = Uniques;
 			sourceTree = "<group>";
 		};
+		0C0F6D6A2D394C8E00943A7C /* MythosStaking */ = {
+			isa = PBXGroup;
+			children = (
+				0C0F6D6B2D394CA200943A7C /* MythosStakingPallet.swift */,
+				0C0F6D6F2D3958CD00943A7C /* MythosStaking+StoragePath.swift */,
+			);
+			path = MythosStaking;
+			sourceTree = "<group>";
+		};
 		0C12BC382CEA7E8500AB919D /* Price */ = {
 			isa = PBXGroup;
 			children = (
@@ -16709,6 +16728,7 @@
 		8438E1DC24C18F11001BDB13 /* Types */ = {
 			isa = PBXGroup;
 			children = (
+				0C0F6D6A2D394C8E00943A7C /* MythosStaking */,
 				0CA7CEE52CE0C23B004328F2 /* System */,
 				0C75E2942C3F923A005A6232 /* DelegatedStaking */,
 				0C38B5012B7A86BA00882A8B /* TokensPallet */,
@@ -17271,6 +17291,8 @@
 				844304612A28C9FA00DE36DE /* MultistakingSyncState.swift */,
 				845FB6762A227F050003BCA6 /* MultistakingProviderFactory.swift */,
 				0C1BE1A52A47FC240010933C /* MultistakingSyncServiceFactory.swift */,
+				0C0F6D662D394AF800943A7C /* MythosMultistakingUpdateService.swift */,
+				0C0F6D682D394BE000943A7C /* Multistaking+Mythos.swift */,
 			);
 			path = Multistaking;
 			sourceTree = "<group>";
@@ -17316,6 +17338,7 @@
 				0C37AFC92B5981B900009ECA /* ProxiedSettingsMapper.swift */,
 				2DDEE0EA2CEDD43A002E9289 /* DAppBrowserTabMapper.swift */,
 				770ABB8D2B85593700132465 /* Web3TopicSettingsMapper.swift */,
+				0C0F6D6D2D39549100943A7C /* StakingDashboardMythosMapper.swift */,
 			);
 			path = EntityToModel;
 			sourceTree = "<group>";
@@ -27023,6 +27046,7 @@
 				8831F10028C65B95009F7682 /* AssetLock.swift in Sources */,
 				842B1806286506EE0014CC57 /* CrossChainTransferSetupProtocols.swift in Sources */,
 				84002AA52992516D00A80672 /* GovernanceDelegateState.swift in Sources */,
+				0C0F6D692D394BE000943A7C /* Multistaking+Mythos.swift in Sources */,
 				84D1F2FB260F51770077DDFE /* SwitchAccount.swift in Sources */,
 				2DB18C922C36D1BC00A93C75 /* PreConfiguredChainFetchFactory.swift in Sources */,
 				84E0EE08292D3C2D008B2953 /* GovernanceChainSelectionProtocols.swift in Sources */,
@@ -27552,6 +27576,7 @@
 				2D1A5F572C35A8720073773D /* PartialCustomChainModel.swift in Sources */,
 				779107682AB8CA71000A4B17 /* AssetListSearchEmptyCell.swift in Sources */,
 				84E1CCF5260DCB91001E81B5 /* SwitchAccount+WalletManagementWireframe.swift in Sources */,
+				0C0F6D672D394AF800943A7C /* MythosMultistakingUpdateService.swift in Sources */,
 				8467F4C926B2943A00C5B6F4 /* ImportantFlowNavigationController.swift in Sources */,
 				849ABE6D2627949E00011A2A /* BatchMapper.swift in Sources */,
 				2DDEE0E62CEC8994002E9289 /* DAppBrowserTabManager.swift in Sources */,
@@ -28030,6 +28055,7 @@
 				8468B87024F63D2000B76BC6 /* AddAccount+UsernameSetupWireframe.swift in Sources */,
 				84754CA42513E6DC00854599 /* PrimitiveContextWrapper.swift in Sources */,
 				0CCD18D02BA1F3DA0068D73A /* PrimitiveBalanceViewModelFactoryProtocol.swift in Sources */,
+				0C0F6D702D3958CD00943A7C /* MythosStaking+StoragePath.swift in Sources */,
 				848B3000286EDE3800465BA2 /* ParaIdOperationFactory.swift in Sources */,
 				84F47D4B2666EF1C00F7647A /* KaruraStatementData.swift in Sources */,
 				0CEB6B4D2CA6676900609DC2 /* VoteCardPanState.swift in Sources */,
@@ -29111,6 +29137,7 @@
 				0C883A742CE241CB00CAB4C8 /* AssetConversionEventsMatching.swift in Sources */,
 				847EA1D42A1CA43A00F1CBD8 /* SubqueryNodes.swift in Sources */,
 				8483B15328F940080048B295 /* ReferendumVotersModel.swift in Sources */,
+				0C0F6D6C2D394CA200943A7C /* MythosStakingPallet.swift in Sources */,
 				2736BAABAE1389260A0B28D6 /* AssetListViewFactory.swift in Sources */,
 				88E1E896289C021F00C123A8 /* CurrencyCollectionViewCell.swift in Sources */,
 				0C1D9AAA2B9723A4003CBAB8 /* Web3Alert+ChainId.swift in Sources */,
@@ -29187,6 +29214,7 @@
 				843461EA290C04C400379936 /* Gov2OperationFactory+Protocol.swift in Sources */,
 				8402CC9E275B946100E5BF30 /* DAppItemView.swift in Sources */,
 				FFE19A19E5B4ED67A2C61951 /* DAppSearchProtocols.swift in Sources */,
+				0C0F6D6E2D39549100943A7C /* StakingDashboardMythosMapper.swift in Sources */,
 				881CA22729E3F20B00159C5B /* ChainModel+Equilibrium.swift in Sources */,
 				F88D85C73094F6A1FC494D87 /* DAppSearchWireframe.swift in Sources */,
 				84880C4029016F1500CADB06 /* ReferendumLockChangeViewModel.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -84,6 +84,20 @@
 		0C0F6D6E2D39549100943A7C /* StakingDashboardMythosMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D6D2D39549100943A7C /* StakingDashboardMythosMapper.swift */; };
 		0C0F6D702D3958CD00943A7C /* MythosStaking+StoragePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D6F2D3958CD00943A7C /* MythosStaking+StoragePath.swift */; };
 		0C0F6D722D39698700943A7C /* MythosStakingPallet+Freezes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D712D39698700943A7C /* MythosStakingPallet+Freezes.swift */; };
+		0C0F6D752D3A5C5C00943A7C /* StartStakingInfoMythosPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D742D3A5C5C00943A7C /* StartStakingInfoMythosPresenter.swift */; };
+		0C0F6D772D3A5C9500943A7C /* StartStakingInfoMythosInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D762D3A5C9500943A7C /* StartStakingInfoMythosInteractor.swift */; };
+		0C0F6D792D3A5DAD00943A7C /* StartStakingInfoMythosWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D782D3A5DAD00943A7C /* StartStakingInfoMythosWireframe.swift */; };
+		0C0F6D7B2D3A625400943A7C /* MythosStakingSharedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D7A2D3A625400943A7C /* MythosStakingSharedState.swift */; };
+		0C0F6D7D2D3A6CC200943A7C /* MythosStakingRemoteSubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D7C2D3A6CC200943A7C /* MythosStakingRemoteSubscriptionService.swift */; };
+		0C0F6D7F2D3A6F4100943A7C /* RemoteSubscriptionService+StoragePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D7E2D3A6F4100943A7C /* RemoteSubscriptionService+StoragePath.swift */; };
+		0C0F6D812D3A743C00943A7C /* StartStakingInfoMythosProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D802D3A743C00943A7C /* StartStakingInfoMythosProtocols.swift */; };
+		0C0F6D832D3A7AC800943A7C /* MythosStakingLocalSubscriptionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D822D3A7AC800943A7C /* MythosStakingLocalSubscriptionFactory.swift */; };
+		0C0F6D872D3A8C5500943A7C /* MythosStakingLocalStorageSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D862D3A8C5500943A7C /* MythosStakingLocalStorageSubscriber.swift */; };
+		0C0F6D892D3A8CDB00943A7C /* MythosStakingLocalStorageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D882D3A8CDB00943A7C /* MythosStakingLocalStorageHandler.swift */; };
+		0C0F6D8B2D3A927D00943A7C /* StartStakingInfoViewFactory+Mythos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D8A2D3A927D00943A7C /* StartStakingInfoViewFactory+Mythos.swift */; };
+		0C0F6D8D2D3A943C00943A7C /* BaseStakingServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D8C2D3A943C00943A7C /* BaseStakingServiceFactory.swift */; };
+		0C0F6D902D3A9EA900943A7C /* MythosStakingDurationOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D8F2D3A9EA900943A7C /* MythosStakingDurationOperationFactory.swift */; };
+		0C0F6D922D3AADB600943A7C /* ChainSessionCountdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D912D3AADB600943A7C /* ChainSessionCountdown.swift */; };
 		0C11D8522CC9F5F2003EC46D /* HydraOmnipoolExchangeEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C11D8512CC9F5F2003EC46D /* HydraOmnipoolExchangeEdge.swift */; };
 		0C11D8542CC9F82C003EC46D /* HydraStableswapExchangeEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C11D8532CC9F82C003EC46D /* HydraStableswapExchangeEdge.swift */; };
 		0C11D8562CC9F9E6003EC46D /* HydraXYKExchangeEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C11D8552CC9F9E6003EC46D /* HydraXYKExchangeEdge.swift */; };
@@ -5472,6 +5486,20 @@
 		0C0F6D6D2D39549100943A7C /* StakingDashboardMythosMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingDashboardMythosMapper.swift; sourceTree = "<group>"; };
 		0C0F6D6F2D3958CD00943A7C /* MythosStaking+StoragePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MythosStaking+StoragePath.swift"; sourceTree = "<group>"; };
 		0C0F6D712D39698700943A7C /* MythosStakingPallet+Freezes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MythosStakingPallet+Freezes.swift"; sourceTree = "<group>"; };
+		0C0F6D742D3A5C5C00943A7C /* StartStakingInfoMythosPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartStakingInfoMythosPresenter.swift; sourceTree = "<group>"; };
+		0C0F6D762D3A5C9500943A7C /* StartStakingInfoMythosInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartStakingInfoMythosInteractor.swift; sourceTree = "<group>"; };
+		0C0F6D782D3A5DAD00943A7C /* StartStakingInfoMythosWireframe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartStakingInfoMythosWireframe.swift; sourceTree = "<group>"; };
+		0C0F6D7A2D3A625400943A7C /* MythosStakingSharedState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MythosStakingSharedState.swift; sourceTree = "<group>"; };
+		0C0F6D7C2D3A6CC200943A7C /* MythosStakingRemoteSubscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MythosStakingRemoteSubscriptionService.swift; sourceTree = "<group>"; };
+		0C0F6D7E2D3A6F4100943A7C /* RemoteSubscriptionService+StoragePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSubscriptionService+StoragePath.swift"; sourceTree = "<group>"; };
+		0C0F6D802D3A743C00943A7C /* StartStakingInfoMythosProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartStakingInfoMythosProtocols.swift; sourceTree = "<group>"; };
+		0C0F6D822D3A7AC800943A7C /* MythosStakingLocalSubscriptionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MythosStakingLocalSubscriptionFactory.swift; sourceTree = "<group>"; };
+		0C0F6D862D3A8C5500943A7C /* MythosStakingLocalStorageSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MythosStakingLocalStorageSubscriber.swift; sourceTree = "<group>"; };
+		0C0F6D882D3A8CDB00943A7C /* MythosStakingLocalStorageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MythosStakingLocalStorageHandler.swift; sourceTree = "<group>"; };
+		0C0F6D8A2D3A927D00943A7C /* StartStakingInfoViewFactory+Mythos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StartStakingInfoViewFactory+Mythos.swift"; sourceTree = "<group>"; };
+		0C0F6D8C2D3A943C00943A7C /* BaseStakingServiceFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseStakingServiceFactory.swift; sourceTree = "<group>"; };
+		0C0F6D8F2D3A9EA900943A7C /* MythosStakingDurationOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MythosStakingDurationOperationFactory.swift; sourceTree = "<group>"; };
+		0C0F6D912D3AADB600943A7C /* ChainSessionCountdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainSessionCountdown.swift; sourceTree = "<group>"; };
 		0C11D8512CC9F5F2003EC46D /* HydraOmnipoolExchangeEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolExchangeEdge.swift; sourceTree = "<group>"; };
 		0C11D8532CC9F82C003EC46D /* HydraStableswapExchangeEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraStableswapExchangeEdge.swift; sourceTree = "<group>"; };
 		0C11D8552CC9F9E6003EC46D /* HydraXYKExchangeEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraXYKExchangeEdge.swift; sourceTree = "<group>"; };
@@ -11117,6 +11145,25 @@
 			path = MythosStaking;
 			sourceTree = "<group>";
 		};
+		0C0F6D732D3A5C3100943A7C /* MythosStaking */ = {
+			isa = PBXGroup;
+			children = (
+				0C0F6D742D3A5C5C00943A7C /* StartStakingInfoMythosPresenter.swift */,
+				0C0F6D762D3A5C9500943A7C /* StartStakingInfoMythosInteractor.swift */,
+				0C0F6D782D3A5DAD00943A7C /* StartStakingInfoMythosWireframe.swift */,
+				0C0F6D802D3A743C00943A7C /* StartStakingInfoMythosProtocols.swift */,
+			);
+			path = MythosStaking;
+			sourceTree = "<group>";
+		};
+		0C0F6D8E2D3A9E9200943A7C /* MythosStaking */ = {
+			isa = PBXGroup;
+			children = (
+				0C0F6D8F2D3A9EA900943A7C /* MythosStakingDurationOperationFactory.swift */,
+			);
+			path = MythosStaking;
+			sourceTree = "<group>";
+		};
 		0C12BC382CEA7E8500AB919D /* Price */ = {
 			isa = PBXGroup;
 			children = (
@@ -11737,6 +11784,7 @@
 				0C66102E2A78E9D700E44634 /* RelaychainStartStakingState.swift */,
 				0CAC44AB2A7A7FFD001EDE61 /* RelaychainConsensusStateDepending.swift */,
 				0C9C64372A8D6949004DC078 /* NPoolsStakingSharedState.swift */,
+				0C0F6D7A2D3A625400943A7C /* MythosStakingSharedState.swift */,
 			);
 			path = StakingSharedState;
 			sourceTree = "<group>";
@@ -16035,6 +16083,7 @@
 		841E6B0825EC1B560007DDFE /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				0C0F6D8E2D3A9E9200943A7C /* MythosStaking */,
 				0C2F86872A723E4200593C01 /* NominationPools */,
 				846952A02852A1160083E0B4 /* StakingDuration */,
 				84C3420528314D5A00156569 /* ParachainStaking */,
@@ -16047,6 +16096,7 @@
 				84329ED12832636F0020BC1C /* RoundCountdown.swift */,
 				84DD261329ACA9030032A598 /* VotersInfoOperationFactory.swift */,
 				0C37AFC02B56EBC000009ECA /* MaxNominationsOperationFactory.swift */,
+				0C0F6D912D3AADB600943A7C /* ChainSessionCountdown.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -17586,6 +17636,7 @@
 				842E9E972A2A28A700759972 /* StakingDashboardProviderFactory.swift */,
 				0CC2E5632A6E5C72004092E7 /* NPoolsLocalSubscriptionFactory.swift */,
 				77DF40382B7DC69300ABDB53 /* SettingsLocalSubscriptionFactory.swift */,
+				0C0F6D822D3A7AC800943A7C /* MythosStakingLocalSubscriptionFactory.swift */,
 			);
 			path = DataProvider;
 			sourceTree = "<group>";
@@ -19666,6 +19717,7 @@
 				841E554C282DAA8000C8438F /* ParachainStakingServiceFactory.swift */,
 				84C3420A283187D800156569 /* BlockTimeEstimationService.swift */,
 				0CD846422BE352D10026B5CA /* PreferredValidatorsProvider.swift */,
+				0C0F6D8C2D3A943C00943A7C /* BaseStakingServiceFactory.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -20983,6 +21035,8 @@
 				0CA5BDEC2C41792A000A4CDD /* SubstrateAssetsUpdatingService.swift */,
 				0C1998E92C4A22FD000EBFB8 /* BalancesRemoteSubscriptionService+Protocol.swift */,
 				0CA8AD592CE0789100ED9746 /* WalletRemoteSubscription.swift */,
+				0C0F6D7C2D3A6CC200943A7C /* MythosStakingRemoteSubscriptionService.swift */,
+				0C0F6D7E2D3A6F4100943A7C /* RemoteSubscriptionService+StoragePath.swift */,
 			);
 			path = Substrate;
 			sourceTree = "<group>";
@@ -21312,6 +21366,8 @@
 				0C59E8E62AA61933001E11F3 /* ExternalAssetBalanceSubscriptionHandler.swift */,
 				77DF403A2B7DC8C900ABDB53 /* SettingsSubscriptionHandler.swift */,
 				77DF403C2B7DC91200ABDB53 /* SettingsSubscriber.swift */,
+				0C0F6D862D3A8C5500943A7C /* MythosStakingLocalStorageSubscriber.swift */,
+				0C0F6D882D3A8CDB00943A7C /* MythosStakingLocalStorageHandler.swift */,
 			);
 			path = Subscription;
 			sourceTree = "<group>";
@@ -24150,6 +24206,7 @@
 		CCD822B8B9ED8FF81C834DD5 /* StartStakingInfo */ = {
 			isa = PBXGroup;
 			children = (
+				0C0F6D732D3A5C3100943A7C /* MythosStaking */,
 				7738FB5C2A4C5C3600797439 /* RelaychainStaking */,
 				7738FB5B2A4C5C2000797439 /* ParachainStaking */,
 				77F189452A49BD5E00E8B933 /* Model */,
@@ -24161,6 +24218,7 @@
 				6F5788D702D2B2203949329E /* StartStakingInfoViewController.swift */,
 				694E15BA7E0C59E46D0A6612 /* StartStakingInfoViewFactory.swift */,
 				0CF193D62A861D7E003F12F6 /* StartStakingInfoConstants.swift */,
+				0C0F6D8A2D3A927D00943A7C /* StartStakingInfoViewFactory+Mythos.swift */,
 			);
 			path = StartStakingInfo;
 			sourceTree = "<group>";
@@ -26522,6 +26580,7 @@
 				77C9BCCE2ACD691300022EA2 /* SwapAssetsOperationViewFactory.swift in Sources */,
 				84C6801024D6EE4500006BF5 /* PlusIndicatorView.swift in Sources */,
 				8428765A24ADDE0200D91AD8 /* SettingsViewFactory.swift in Sources */,
+				0C0F6D902D3A9EA900943A7C /* MythosStakingDurationOperationFactory.swift in Sources */,
 				849E17E8279143B2002D1744 /* NavigationBarStyle.swift in Sources */,
 				0CE933952C0488E7000F3EFE /* CloudBackupReviewViewModel.swift in Sources */,
 				77171CAA2A98BC420032B387 /* NominationPoolDataValidatorFactory.swift in Sources */,
@@ -27543,6 +27602,7 @@
 				8407715828CB802C007DBD24 /* ParaStkYieldBoostBaseProtocols.swift in Sources */,
 				84DB4E1E25E93B1700A6DF41 /* Identity.swift in Sources */,
 				F47F5A822626FDB9009BCFF4 /* StakingPayoutViewModel.swift in Sources */,
+				0C0F6D792D3A5DAD00943A7C /* StartStakingInfoMythosWireframe.swift in Sources */,
 				F400A7C2260CE1670061D576 /* StakingRewardStatus.swift in Sources */,
 				843F657126584D2C00829C14 /* JsonSingleProviderSource.swift in Sources */,
 				0CED3A082BD12DFD00B1E994 /* CloudBackupSecretsExporting.swift in Sources */,
@@ -27963,6 +28023,7 @@
 				2D8684602C0086A500A663D2 /* ManualBackupKeyListViewModelFactory.swift in Sources */,
 				0C8AF7BA2B3806B700005AC9 /* ChainModel+Pdc20.swift in Sources */,
 				0C1BE1A62A47FC240010933C /* MultistakingSyncServiceFactory.swift in Sources */,
+				0C0F6D812D3A743C00943A7C /* StartStakingInfoMythosProtocols.swift in Sources */,
 				84E8BA2A2A00EF4C00FD9F40 /* XcmBaseMetadataQueryFactory.swift in Sources */,
 				8454C21D2632A78900657DAD /* EventRecord.swift in Sources */,
 				84AE7AB527D39DCA00495267 /* NetworkViewModel.swift in Sources */,
@@ -28186,6 +28247,7 @@
 				77DAFF6F2B298FFF00D4220C /* WalletView.swift in Sources */,
 				8443CA4A289D04E900FA4A95 /* TransactionSigningPresenting.swift in Sources */,
 				8475B47B289870A4009B90BC /* ProcessStepView.swift in Sources */,
+				0C0F6D772D3A5C9500943A7C /* StartStakingInfoMythosInteractor.swift in Sources */,
 				8465DA41298F05D500C7CFF1 /* GovernanceTrackViewModelFactory.swift in Sources */,
 				0CB261EF2A9E103900287305 /* NPoolsClaimRewardsStrategy.swift in Sources */,
 				AE3983A5272C0BC800BC8A85 /* ImportChainAccount+AccountImportPresenter.swift in Sources */,
@@ -28435,6 +28497,7 @@
 				84592F4A298716140001BB56 /* SubqueryVotingOperationFactory.swift in Sources */,
 				84A59166292B601600BCCF8F /* EvmOnChainTransferInteractor.swift in Sources */,
 				84038FF626FFDF4E00C73F3F /* CrowdloanSharedState.swift in Sources */,
+				0C0F6D7F2D3A6F4100943A7C /* RemoteSubscriptionService+StoragePath.swift in Sources */,
 				773A375A2B3B58DE006AC4AA /* ProxyMessageSheetViewController.swift in Sources */,
 				054C4BCDEC29ED5F74A36E8B /* ExportMnemonicPresenter.swift in Sources */,
 				39218CF5AA701518BD3B0103 /* ExportMnemonicInteractor.swift in Sources */,
@@ -28721,6 +28784,7 @@
 				77E304B02AEFA261006FD6F0 /* FeeAssetSelectSheetLayout.swift in Sources */,
 				88FB7DCF295071B100784E08 /* ContainerViewController.swift in Sources */,
 				841E5536282CDB9E00C8438F /* StakingMainPresenterFactory+Relaychain.swift in Sources */,
+				0C0F6D872D3A8C5500943A7C /* MythosStakingLocalStorageSubscriber.swift in Sources */,
 				8499FEC827BF73F400712589 /* StorageKeyFactory+Size.swift in Sources */,
 				77E304B72AEFC348006FD6F0 /* FeeAssetSelectSheetViewModel.swift in Sources */,
 				0CB0646A2A40572C00BFBA3F /* AmountInputViewModel.swift in Sources */,
@@ -28923,6 +28987,7 @@
 				AE1000F226679886004753B7 /* ChangeTargetsRecommendationWireframe.swift in Sources */,
 				84C9CF3B291AE328002BF328 /* GovernanceV1PolkassemblyOperationFactory.swift in Sources */,
 				8858917429A4BA0A00320896 /* DelegateGroupVotesHeader.swift in Sources */,
+				0C0F6D752D3A5C5C00943A7C /* StartStakingInfoMythosPresenter.swift in Sources */,
 				D886425A55425810AD070AB5 /* ControllerAccountConfirmationWireframe.swift in Sources */,
 				84D17EDE28054CC400F7BAFF /* DAppLocalSubscriptionFactory.swift in Sources */,
 				84E2589F2892B5AF00DC8A51 /* WalletSwitchPresentable.swift in Sources */,
@@ -29302,6 +29367,7 @@
 				84D184EF2A04E2760060C1BD /* WalletConnectSessionViewModel.swift in Sources */,
 				9BADFCBF3AF5186094DB8D67 /* DAppTxDetailsInteractor.swift in Sources */,
 				0CC633542B3009C2001BF257 /* ChainRemoteAccountConfirmService.swift in Sources */,
+				0C0F6D892D3A8CDB00943A7C /* MythosStakingLocalStorageHandler.swift in Sources */,
 				B409644ED1E20062A3EA0316 /* DAppTxDetailsViewController.swift in Sources */,
 				DAD46B2B29A446C19A6ABF2D /* DAppTxDetailsViewLayout.swift in Sources */,
 				2D442CEF2CD0F7DF00A0380F /* AppearanceDepending.swift in Sources */,
@@ -29580,6 +29646,7 @@
 				84E8BA2829FFCA4000FD9F40 /* WalletConnectEthereumTransaction.swift in Sources */,
 				F6F73F4862779FE0B58A7931 /* ParaStkRebondInteractor.swift in Sources */,
 				58D5B4F17DA37C241FF96A5F /* ParaStkRebondViewController.swift in Sources */,
+				0C0F6D922D3AADB600943A7C /* ChainSessionCountdown.swift in Sources */,
 				F5F74CD4110DB94902AA836A /* ParaStkRebondViewLayout.swift in Sources */,
 				C32B85D65D0290A577BFC85F /* ParaStkRebondViewFactory.swift in Sources */,
 				8490110F29E5A4F4005D688B /* URIQRMatcher.swift in Sources */,
@@ -29731,6 +29798,7 @@
 				77A0B2F92A3CA40E00CBF653 /* StakingMoreOptionsSection.swift in Sources */,
 				1EE4FBB79EE6015D7D3EBDC1 /* ParitySignerTxScanWireframe.swift in Sources */,
 				887AFC8728BC95F0002A0422 /* MetaAccountChainResponse.swift in Sources */,
+				0C0F6D7D2D3A6CC200943A7C /* MythosStakingRemoteSubscriptionService.swift in Sources */,
 				042799797DF7E6FD02D1D1E6 /* ParitySignerTxScanPresenter.swift in Sources */,
 				2D32BE192C6A49900047F520 /* ExtrinsicFeeProxy.swift in Sources */,
 				779A8F9B2A050C4400BE31B3 /* StakingRewardDateCell.swift in Sources */,
@@ -29828,6 +29896,7 @@
 				8A23DD1F4146639EA2F7AEF6 /* LocksViewFactory.swift in Sources */,
 				C0A7710415B9C9BA496320E7 /* ParaStkYieldBoostSetupProtocols.swift in Sources */,
 				84E8BA0729FE888C00FD9F40 /* DAppUnknownChain.swift in Sources */,
+				0C0F6D832D3A7AC800943A7C /* MythosStakingLocalSubscriptionFactory.swift in Sources */,
 				7E5ACF8DDF17C054E6E1B3D5 /* ParaStkYieldBoostSetupWireframe.swift in Sources */,
 				7C0135CA49EF6B535030643E /* ParaStkYieldBoostSetupPresenter.swift in Sources */,
 				2D1C5D202C25ACC300E2DBDD /* CustomNetworkInteractorProtocols.swift in Sources */,
@@ -30089,6 +30158,7 @@
 				8846F72929D6BB5300B8B776 /* Data+base16.swift in Sources */,
 				AA3AE7900853DFB4D6FC3F96 /* DelegateVotedReferendaViewFactory.swift in Sources */,
 				179DDEB4F2431F02D60117BD /* GovernanceSelectTracksProtocols.swift in Sources */,
+				0C0F6D8B2D3A927D00943A7C /* StartStakingInfoViewFactory+Mythos.swift in Sources */,
 				A1FA23B8A833B6896104ABA6 /* GovernanceSelectTracksWireframe.swift in Sources */,
 				0CF976752CF082BF001D2801 /* SwapExecutionViewModel.swift in Sources */,
 				A6E762549FF85393D1B69007 /* GovernanceSelectTracksPresenter.swift in Sources */,
@@ -30207,6 +30277,7 @@
 				F0C3DCA3CD4F850C16406716 /* GovernanceDelegateSearchViewFactory.swift in Sources */,
 				0C13DFD52AFA4F1500E5F355 /* SwapIssueCheckParams.swift in Sources */,
 				77A502F12B63E3830062FA51 /* ProxyAccountSubscription.swift in Sources */,
+				0C0F6D8D2D3A943C00943A7C /* BaseStakingServiceFactory.swift in Sources */,
 				C98A02D4DEAC6E4CACB9E47E /* StakingRebagConfirmProtocols.swift in Sources */,
 				B09F155D14D146377FB2952A /* StakingRebagConfirmWireframe.swift in Sources */,
 				840AE2E329C9A715008FF665 /* OptionStringCodable+Empty.swift in Sources */,
@@ -30393,6 +30464,7 @@
 				78D63EC7EC5F7427335A025E /* NPoolsClaimRewardsViewLayout.swift in Sources */,
 				43D58563868FA362F47B7D92 /* NPoolsClaimRewardsViewFactory.swift in Sources */,
 				6E58D665BB280CD332DC9F5E /* NPoolsRedeemProtocols.swift in Sources */,
+				0C0F6D7B2D3A625400943A7C /* MythosStakingSharedState.swift in Sources */,
 				FD322DC05438902ED369E8FA /* NPoolsRedeemWireframe.swift in Sources */,
 				93B64E378DDDCC7F20FF78A2 /* NPoolsRedeemPresenter.swift in Sources */,
 				B959E423181234E82B0695DF /* NPoolsRedeemInteractor.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		0C0F6D6C2D394CA200943A7C /* MythosStakingPallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D6B2D394CA200943A7C /* MythosStakingPallet.swift */; };
 		0C0F6D6E2D39549100943A7C /* StakingDashboardMythosMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D6D2D39549100943A7C /* StakingDashboardMythosMapper.swift */; };
 		0C0F6D702D3958CD00943A7C /* MythosStaking+StoragePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D6F2D3958CD00943A7C /* MythosStaking+StoragePath.swift */; };
+		0C0F6D722D39698700943A7C /* MythosStakingPallet+Freezes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F6D712D39698700943A7C /* MythosStakingPallet+Freezes.swift */; };
 		0C11D8522CC9F5F2003EC46D /* HydraOmnipoolExchangeEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C11D8512CC9F5F2003EC46D /* HydraOmnipoolExchangeEdge.swift */; };
 		0C11D8542CC9F82C003EC46D /* HydraStableswapExchangeEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C11D8532CC9F82C003EC46D /* HydraStableswapExchangeEdge.swift */; };
 		0C11D8562CC9F9E6003EC46D /* HydraXYKExchangeEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C11D8552CC9F9E6003EC46D /* HydraXYKExchangeEdge.swift */; };
@@ -5470,6 +5471,7 @@
 		0C0F6D6B2D394CA200943A7C /* MythosStakingPallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MythosStakingPallet.swift; sourceTree = "<group>"; };
 		0C0F6D6D2D39549100943A7C /* StakingDashboardMythosMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingDashboardMythosMapper.swift; sourceTree = "<group>"; };
 		0C0F6D6F2D3958CD00943A7C /* MythosStaking+StoragePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MythosStaking+StoragePath.swift"; sourceTree = "<group>"; };
+		0C0F6D712D39698700943A7C /* MythosStakingPallet+Freezes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MythosStakingPallet+Freezes.swift"; sourceTree = "<group>"; };
 		0C11D8512CC9F5F2003EC46D /* HydraOmnipoolExchangeEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolExchangeEdge.swift; sourceTree = "<group>"; };
 		0C11D8532CC9F82C003EC46D /* HydraStableswapExchangeEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraStableswapExchangeEdge.swift; sourceTree = "<group>"; };
 		0C11D8552CC9F9E6003EC46D /* HydraXYKExchangeEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraXYKExchangeEdge.swift; sourceTree = "<group>"; };
@@ -11110,6 +11112,7 @@
 			children = (
 				0C0F6D6B2D394CA200943A7C /* MythosStakingPallet.swift */,
 				0C0F6D6F2D3958CD00943A7C /* MythosStaking+StoragePath.swift */,
+				0C0F6D712D39698700943A7C /* MythosStakingPallet+Freezes.swift */,
 			);
 			path = MythosStaking;
 			sourceTree = "<group>";
@@ -28726,6 +28729,7 @@
 				5869563D0EA593FBD02C169C /* StakingPayoutConfirmationProtocols.swift in Sources */,
 				846B749828B4BA0500C39B93 /* LedgerAccountsStore.swift in Sources */,
 				844ADE7728CA7F7100EE29F7 /* ParaStkYieldBoostSetupPresenter+ViewUpdate.swift in Sources */,
+				0C0F6D722D39698700943A7C /* MythosStakingPallet+Freezes.swift in Sources */,
 				8499FED627BFB12600712589 /* UniquesSyncService.swift in Sources */,
 				841E556B282EAC3600C8438F /* ParachainStakingDelegatorState.swift in Sources */,
 				880E40FF298CF1ED0077B18B /* VotesProtocols.swift in Sources */,

--- a/novawallet/Common/DataProvider/MythosStakingLocalSubscriptionFactory.swift
+++ b/novawallet/Common/DataProvider/MythosStakingLocalSubscriptionFactory.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Operation_iOS
+
+extension MythosStakingPallet {
+    typealias DecodedUserStake = ChainStorageDecodedItem<MythosStakingPallet.UserStake>
+}
+
+protocol MythosStakingLocalSubscriptionFactoryProtocol {
+    func getMinStakeProvider(
+        for chainId: ChainModel.Id
+    ) throws -> AnyDataProvider<DecodedBigUInt>
+
+    func getCurrentSessionProvider(
+        for chainId: ChainModel.Id
+    ) throws -> AnyDataProvider<DecodedU32>
+
+    func getUserStakeProvider(
+        for chainId: ChainModel.Id,
+        accountId: AccountId
+    ) throws -> AnyDataProvider<MythosStakingPallet.DecodedUserStake>
+}
+
+final class MythosStakingLocalSubscriptionFactory: SubstrateLocalSubscriptionFactory,
+    MythosStakingLocalSubscriptionFactoryProtocol {
+    func getMinStakeProvider(
+        for chainId: ChainModel.Id
+    ) throws -> AnyDataProvider<DecodedBigUInt> {
+        try getPlainProvider(
+            for: chainId,
+            storagePath: MythosStakingPallet.minStakePath
+        )
+    }
+
+    func getCurrentSessionProvider(
+        for chainId: ChainModel.Id
+    ) throws -> AnyDataProvider<DecodedU32> {
+        try getPlainProvider(
+            for: chainId,
+            storagePath: MythosStakingPallet.currentSessionPath
+        )
+    }
+
+    func getUserStakeProvider(
+        for chainId: ChainModel.Id,
+        accountId: AccountId
+    ) throws -> AnyDataProvider<MythosStakingPallet.DecodedUserStake> {
+        try getAccountProvider(
+            for: chainId,
+            accountId: accountId,
+            storagePath: MythosStakingPallet.userStakePath
+        )
+    }
+}

--- a/novawallet/Common/DataProvider/ParachainStakingLocalSubscriptionFactory.swift
+++ b/novawallet/Common/DataProvider/ParachainStakingLocalSubscriptionFactory.swift
@@ -69,42 +69,6 @@ protocol ParachainStakingLocalSubscriptionFactoryProtocol {
 
 final class ParachainStakingLocalSubscriptionFactory: SubstrateLocalSubscriptionFactory,
     ParachainStakingLocalSubscriptionFactoryProtocol {
-    private func getPlainProvider<T: Equatable & Decodable>(
-        for chainId: ChainModel.Id,
-        storagePath: StorageCodingPath
-    ) throws -> AnyDataProvider<ChainStorageDecodedItem<T>> {
-        let localKey = try LocalStorageKeyFactory().createFromStoragePath(
-            storagePath,
-            chainId: chainId
-        )
-
-        return try getDataProvider(
-            for: localKey,
-            chainId: chainId,
-            storageCodingPath: storagePath,
-            shouldUseFallback: false
-        )
-    }
-
-    private func getAccountProvider<T: Equatable & Decodable>(
-        for chainId: ChainModel.Id,
-        accountId: AccountId,
-        storagePath: StorageCodingPath
-    ) throws -> AnyDataProvider<ChainStorageDecodedItem<T>> {
-        let localKey = try LocalStorageKeyFactory().createFromStoragePath(
-            storagePath,
-            accountId: accountId,
-            chainId: chainId
-        )
-
-        return try getDataProvider(
-            for: localKey,
-            chainId: chainId,
-            storageCodingPath: storagePath,
-            shouldUseFallback: false
-        )
-    }
-
     func getRoundProvider(
         for chainId: ChainModel.Id
     ) throws -> AnyDataProvider<ParachainStaking.DecodedRoundInfo> {

--- a/novawallet/Common/DataProvider/Subscription/MythosStakingLocalStorageHandler.swift
+++ b/novawallet/Common/DataProvider/Subscription/MythosStakingLocalStorageHandler.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+protocol MythosStakingLocalStorageHandler {
+    func handleMinStake(
+        result: Result<Balance?, Error>,
+        chainId: ChainModel.Id
+    )
+
+    func handleCurrentSession(
+        result: Result<SessionIndex?, Error>,
+        chainId: ChainModel.Id
+    )
+
+    func handleUserStake(
+        result: Result<MythosStakingPallet.UserStake?, Error>,
+        chainId: ChainModel.Id,
+        accountId: AccountId
+    )
+}
+
+extension MythosStakingLocalStorageHandler {
+    func handleMinStake(
+        result _: Result<Balance?, Error>,
+        chainId _: ChainModel.Id
+    ) {}
+
+    func handleCurrentSession(
+        result _: Result<SessionIndex?, Error>,
+        chainId _: ChainModel.Id
+    ) {}
+
+    func handleUserStake(
+        result _: Result<MythosStakingPallet.UserStake?, Error>,
+        chainId _: ChainModel.Id,
+        accountId _: AccountId
+    ) {}
+}

--- a/novawallet/Common/DataProvider/Subscription/MythosStakingLocalStorageSubscriber.swift
+++ b/novawallet/Common/DataProvider/Subscription/MythosStakingLocalStorageSubscriber.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Operation_iOS
+
+protocol MythosStakingLocalStorageSubscriber: LocalStorageProviderObserving {
+    var stakingLocalSubscriptionFactory: MythosStakingLocalSubscriptionFactoryProtocol { get }
+
+    var stakingLocalSubscriptionHandler: MythosStakingLocalStorageHandler { get }
+
+    func subscribeToMinStake(
+        for chainId: ChainModel.Id
+    ) -> AnyDataProvider<DecodedBigUInt>?
+
+    func subscribeToCurrentSession(
+        for chainId: ChainModel.Id
+    ) -> AnyDataProvider<DecodedU32>?
+
+    func subscribeToUserState(
+        for chainId: ChainModel.Id,
+        accountId: AccountId
+    ) -> AnyDataProvider<MythosStakingPallet.DecodedUserStake>?
+}
+
+extension MythosStakingLocalStorageSubscriber {
+    func subscribeToMinStake(
+        for chainId: ChainModel.Id
+    ) -> AnyDataProvider<DecodedBigUInt>? {
+        guard let provider = try? stakingLocalSubscriptionFactory.getMinStakeProvider(for: chainId) else {
+            return nil
+        }
+
+        addDataProviderObserver(
+            for: provider,
+            updateClosure: { [weak self] valueMapper in
+                self?.stakingLocalSubscriptionHandler.handleMinStake(
+                    result: .success(valueMapper?.value),
+                    chainId: chainId
+                )
+            },
+            failureClosure: { [weak self] error in
+                self?.stakingLocalSubscriptionHandler.handleMinStake(
+                    result: .failure(error),
+                    chainId: chainId
+                )
+            }
+        )
+
+        return provider
+    }
+
+    func subscribeToCurrentSession(
+        for chainId: ChainModel.Id
+    ) -> AnyDataProvider<DecodedU32>? {
+        guard let provider = try? stakingLocalSubscriptionFactory.getCurrentSessionProvider(for: chainId) else {
+            return nil
+        }
+
+        addDataProviderObserver(
+            for: provider,
+            updateClosure: { [weak self] valueMapper in
+                self?.stakingLocalSubscriptionHandler.handleCurrentSession(
+                    result: .success(valueMapper?.value),
+                    chainId: chainId
+                )
+            },
+            failureClosure: { [weak self] error in
+                self?.stakingLocalSubscriptionHandler.handleCurrentSession(
+                    result: .failure(error),
+                    chainId: chainId
+                )
+            }
+        )
+
+        return provider
+    }
+
+    func subscribeToUserState(
+        for chainId: ChainModel.Id,
+        accountId: AccountId
+    ) -> AnyDataProvider<MythosStakingPallet.DecodedUserStake>? {
+        guard let provider = try? stakingLocalSubscriptionFactory.getUserStakeProvider(
+            for: chainId,
+            accountId: accountId
+        ) else {
+            return nil
+        }
+
+        addDataProviderObserver(
+            for: provider,
+            updateClosure: { [weak self] value in
+                self?.stakingLocalSubscriptionHandler.handleUserStake(
+                    result: .success(value),
+                    chainId: chainId,
+                    accountId: accountId
+                )
+            },
+            failureClosure: { [weak self] error in
+                self?.stakingLocalSubscriptionHandler.handleUserStake(
+                    result: .failure(error),
+                    chainId: chainId,
+                    accountId: accountId
+                )
+            }
+        )
+
+        return provider
+    }
+}
+
+extension MythosStakingLocalStorageSubscriber where Self: MythosStakingLocalStorageHandler {
+    var stakingLocalSubscriptionHandler: MythosStakingLocalStorageHandler { self }
+}

--- a/novawallet/Common/DataProvider/SubstrateLocalSubscriptionFactory.swift
+++ b/novawallet/Common/DataProvider/SubstrateLocalSubscriptionFactory.swift
@@ -60,6 +60,42 @@ class SubstrateLocalSubscriptionFactory {
         providers = providers.filter { $0.value.target != nil }
     }
 
+    func getPlainProvider<T: Equatable & Decodable>(
+        for chainId: ChainModel.Id,
+        storagePath: StorageCodingPath
+    ) throws -> AnyDataProvider<ChainStorageDecodedItem<T>> {
+        let localKey = try LocalStorageKeyFactory().createFromStoragePath(
+            storagePath,
+            chainId: chainId
+        )
+
+        return try getDataProvider(
+            for: localKey,
+            chainId: chainId,
+            storageCodingPath: storagePath,
+            shouldUseFallback: false
+        )
+    }
+
+    func getAccountProvider<T: Equatable & Decodable>(
+        for chainId: ChainModel.Id,
+        accountId: AccountId,
+        storagePath: StorageCodingPath
+    ) throws -> AnyDataProvider<ChainStorageDecodedItem<T>> {
+        let localKey = try LocalStorageKeyFactory().createFromStoragePath(
+            storagePath,
+            accountId: accountId,
+            chainId: chainId
+        )
+
+        return try getDataProvider(
+            for: localKey,
+            chainId: chainId,
+            storageCodingPath: storagePath,
+            shouldUseFallback: false
+        )
+    }
+
     func getDataProvider<T>(
         for localKey: String,
         chainId: ChainModel.Id,

--- a/novawallet/Common/Extension/Foundation/TimeInterval+Localization.swift
+++ b/novawallet/Common/Extension/Foundation/TimeInterval+Localization.swift
@@ -2,6 +2,32 @@ import Foundation
 import SoraFoundation
 
 extension TimeInterval {
+    func localizedDaysHoursOrFallbackMinutes(
+        for locale: Locale,
+        preposition: String? = nil,
+        separator: String = " ",
+        shortcutHandler: PredefinedTimeShortcutProtocol? = nil,
+        roundsDown: Bool = true
+    ) -> String {
+        let (days, hours) = getDaysAndHours(roundingDown: roundsDown)
+
+        guard days > 0 || hours > 0 else {
+            return localizedDaysHoursMinutes(
+                for: locale,
+                preposition: preposition ?? "",
+                separator: separator
+            )
+        }
+
+        return localizedDaysHours(
+            for: locale,
+            preposition: preposition,
+            separator: separator,
+            shortcutHandler: shortcutHandler,
+            roundsDown: roundsDown
+        )
+    }
+
     func localizedDaysHours(
         for locale: Locale,
         preposition: String? = nil,

--- a/novawallet/Common/Services/Multistaking/Multistaking+Model.swift
+++ b/novawallet/Common/Services/Multistaking/Multistaking+Model.swift
@@ -47,6 +47,11 @@ extension Multistaking {
         let state: Multistaking.NominationPoolState?
     }
 
+    struct DashboardItemMythosStakingPart {
+        let stakingOption: OptionWithWallet
+        let state: Multistaking.MythosStakingState?
+    }
+
     struct DashboardItemOffchainPart {
         let stakingOption: OptionWithWallet
         let maxApy: Decimal

--- a/novawallet/Common/Services/Multistaking/Multistaking+Model.swift
+++ b/novawallet/Common/Services/Multistaking/Multistaking+Model.swift
@@ -49,7 +49,7 @@ extension Multistaking {
 
     struct DashboardItemMythosStakingPart {
         let stakingOption: OptionWithWallet
-        let state: Multistaking.MythosStakingState?
+        let state: Multistaking.MythosStakingState
     }
 
     struct DashboardItemOffchainPart {
@@ -85,6 +85,20 @@ extension Multistaking {
 
             if parachainState.shouldHaveActiveCollator {
                 return .waiting
+            } else {
+                return .bonded
+            }
+        }
+
+        static func from(mythosState: Multistaking.MythosStakingState) -> DashboardItemOnchainState? {
+            let hasStakingFreeze = mythosState.freezes?.getMythosStakingAmount() != nil
+
+            guard hasStakingFreeze else {
+                return nil
+            }
+
+            if mythosState.userStake != nil {
+                return .active
             } else {
                 return .bonded
             }

--- a/novawallet/Common/Services/Multistaking/Multistaking+Mythos.swift
+++ b/novawallet/Common/Services/Multistaking/Multistaking+Mythos.swift
@@ -1,0 +1,44 @@
+import Foundation
+import SubstrateSdk
+
+extension Multistaking {
+    struct MythosStakingState {
+        let userStake: MythosStakingPallet.UserStake?
+        let freezes: BalancesPallet.Freezes?
+
+        func applying(change: MythosStakingStateChange) -> MythosStakingState {
+            let newStake = change.userStake.valueWhenDefined(else: userStake)
+            let newFreezes = change.freezes.valueWhenDefined(else: freezes)
+
+            return .init(userStake: newStake, freezes: newFreezes)
+        }
+    }
+
+    struct MythosStakingStateChange: BatchStorageSubscriptionResult {
+        enum Key: String {
+            case userStake
+            case freezes
+        }
+
+        let userStake: UncertainStorage<MythosStakingPallet.UserStake?>
+        let freezes: UncertainStorage<BalancesPallet.Freezes?>
+
+        init(
+            values: [BatchStorageSubscriptionResultValue],
+            blockHashJson _: JSON,
+            context: [CodingUserInfoKey: Any]?
+        ) throws {
+            userStake = try UncertainStorage(
+                values: values,
+                mappingKey: Key.userStake.rawValue,
+                context: context
+            )
+
+            freezes = try UncertainStorage(
+                values: values,
+                mappingKey: Key.freezes.rawValue,
+                context: context
+            )
+        }
+    }
+}

--- a/novawallet/Common/Services/Multistaking/MultistakingRepositoryFactory.swift
+++ b/novawallet/Common/Services/Multistaking/MultistakingRepositoryFactory.swift
@@ -27,6 +27,9 @@ protocol MultistakingRepositoryFactoryProtocol {
 
     func createNominationPoolsRepository(
     ) -> AnyDataProviderRepository<Multistaking.DashboardItemNominationPoolPart>
+
+    func createMythosRepository(
+    ) -> AnyDataProviderRepository<Multistaking.DashboardItemMythosStakingPart>
 }
 
 final class MultistakingRepositoryFactory {
@@ -83,6 +86,12 @@ extension MultistakingRepositoryFactory: MultistakingRepositoryFactoryProtocol {
     func createParachainRepository(
     ) -> AnyDataProviderRepository<Multistaking.DashboardItemParachainPart> {
         let mapper = StakingDashboardParachainMapper()
+        let repository = storageFacade.createRepository(mapper: AnyCoreDataMapper(mapper))
+        return AnyDataProviderRepository(repository)
+    }
+
+    func createMythosRepository() -> AnyDataProviderRepository<Multistaking.DashboardItemMythosStakingPart> {
+        let mapper = StakingDashboardMythosMapper()
         let repository = storageFacade.createRepository(mapper: AnyCoreDataMapper(mapper))
         return AnyDataProviderRepository(repository)
     }

--- a/novawallet/Common/Services/Multistaking/MultistakingServices.swift
+++ b/novawallet/Common/Services/Multistaking/MultistakingServices.swift
@@ -14,7 +14,7 @@ extension MultistakingOffchainOperationFactoryProtocol {
         defaultAccountResponse: ChainAccountResponse
     ) -> AccountId? {
         switch option.type {
-        case .relaychain, .auraRelaychain, .azero, .parachain, .turing, .unsupported:
+        case .relaychain, .auraRelaychain, .azero, .parachain, .turing, .mythos, .unsupported:
             return accounts[option] ?? defaultAccountResponse.accountId
         case .nominationPools:
             // we don't want to use default account as it might be connected to direct staking

--- a/novawallet/Common/Services/Multistaking/MythosMultistakingUpdateService.swift
+++ b/novawallet/Common/Services/Multistaking/MythosMultistakingUpdateService.swift
@@ -57,6 +57,7 @@ final class MythosMultistakingUpdateService: ObservableSyncService {
     }
 
     private func clearSubscriptions() {
+        stateSubscription?.unsubscribe()
         stateSubscription = nil
     }
 
@@ -103,6 +104,9 @@ final class MythosMultistakingUpdateService: ObservableSyncService {
 
                 self?.mutex.unlock()
             }
+
+            stateSubscription?.subscribe()
+
         } catch {
             logger.error("Subscription error: \(error)")
 
@@ -116,10 +120,10 @@ final class MythosMultistakingUpdateService: ObservableSyncService {
             markSyncingImmediate()
 
             logger.debug("Change: \(change)")
-            
+
             if let state = updateState(from: change) {
                 logger.debug("Saving: \(state)")
-                
+
                 saveState(state)
             }
 

--- a/novawallet/Common/Services/Multistaking/MythosMultistakingUpdateService.swift
+++ b/novawallet/Common/Services/Multistaking/MythosMultistakingUpdateService.swift
@@ -1,0 +1,190 @@
+import Foundation
+import SubstrateSdk
+import Operation_iOS
+
+final class MythosMultistakingUpdateService: ObservableSyncService {
+    let accountId: AccountId
+    let walletId: MetaAccountModel.Id
+    let chainAsset: ChainAsset
+    let stakingType: StakingType
+    let connection: JSONRPCEngine
+    let runtimeService: RuntimeCodingServiceProtocol
+    let dashboardRepository: AnyDataProviderRepository<Multistaking.DashboardItemMythosStakingPart>
+    let cacheRepository: AnyDataProviderRepository<ChainStorageItem>
+    let workingQueue: DispatchQueue
+    let operationQueue: OperationQueue
+
+    private var stateSubscription: CallbackBatchStorageSubscription<Multistaking.MythosStakingStateChange>?
+
+    private var state: Multistaking.MythosStakingState?
+
+    private var saveCallStore = CancellableCallStore()
+
+    init(
+        walletId: MetaAccountModel.Id,
+        accountId: AccountId,
+        chainAsset: ChainAsset,
+        stakingType: StakingType,
+        dashboardRepository: AnyDataProviderRepository<Multistaking.DashboardItemMythosStakingPart>,
+        cacheRepository: AnyDataProviderRepository<ChainStorageItem>,
+        connection: JSONRPCEngine,
+        runtimeService: RuntimeCodingServiceProtocol,
+        operationQueue: OperationQueue,
+        workingQueue: DispatchQueue,
+        logger: LoggerProtocol
+    ) {
+        self.walletId = walletId
+        self.accountId = accountId
+        self.chainAsset = chainAsset
+        self.stakingType = stakingType
+        self.dashboardRepository = dashboardRepository
+        self.cacheRepository = cacheRepository
+        self.connection = connection
+        self.runtimeService = runtimeService
+        self.workingQueue = workingQueue
+        self.operationQueue = operationQueue
+
+        super.init(logger: logger)
+    }
+
+    override func performSyncUp() {
+        clearSubscriptions()
+        makeSubscription(for: accountId, chainId: chainAsset.chain.chainId)
+    }
+
+    override func stopSyncUp() {
+        clearSubscriptions()
+    }
+
+    private func clearSubscriptions() {
+        stateSubscription = nil
+    }
+
+    private func makeSubscription(for accountId: AccountId, chainId: ChainModel.Id) {
+        do {
+            let localKeyFactory = LocalStorageKeyFactory()
+            let localKey = try localKeyFactory.createFromStoragePath(
+                MythosStakingPallet.userStakePath,
+                encodableElement: accountId,
+                chainId: chainId
+            )
+
+            let userStakeRequest = BatchStorageSubscriptionRequest(
+                innerRequest: MapSubscriptionRequest(
+                    storagePath: MythosStakingPallet.userStakePath,
+                    localKey: localKey
+                ) {
+                    BytesCodable(wrappedValue: accountId)
+                },
+                mappingKey: Multistaking.MythosStakingStateChange.Key.userStake.rawValue
+            )
+
+            let freezesRequest = BatchStorageSubscriptionRequest(
+                innerRequest: MapSubscriptionRequest(
+                    storagePath: BalancesPallet.freezesPath,
+                    localKey: ""
+                ) {
+                    BytesCodable(wrappedValue: accountId)
+                },
+                mappingKey: Multistaking.MythosStakingStateChange.Key.freezes.rawValue
+            )
+
+            stateSubscription = CallbackBatchStorageSubscription(
+                requests: [userStakeRequest, freezesRequest],
+                connection: connection,
+                runtimeService: runtimeService,
+                repository: cacheRepository,
+                operationQueue: operationQueue,
+                callbackQueue: workingQueue
+            ) { [weak self] result in
+                self?.mutex.lock()
+
+                self?.handleStateChange(result: result)
+
+                self?.mutex.unlock()
+            }
+        } catch {
+            logger.error("Subscription error: \(error)")
+
+            completeImmediate(error)
+        }
+    }
+
+    private func handleStateChange(result: Result<Multistaking.MythosStakingStateChange, Error>) {
+        switch result {
+        case let .success(change):
+            markSyncingImmediate()
+
+            logger.debug("Change: \(change)")
+            
+            if let state = updateState(from: change) {
+                logger.debug("Saving: \(state)")
+                
+                saveState(state)
+            }
+
+        case let .failure(error):
+            completeImmediate(error)
+        }
+    }
+
+    private func updateState(from change: Multistaking.MythosStakingStateChange) -> Multistaking.MythosStakingState? {
+        if let currentState = state {
+            let newState = currentState.applying(change: change)
+            state = newState
+            return newState
+        } else if
+            case let .defined(userStake) = change.userStake,
+            case let .defined(freezes) = change.freezes {
+            let state = Multistaking.MythosStakingState(
+                userStake: userStake,
+                freezes: freezes
+            )
+
+            self.state = state
+
+            return state
+        } else {
+            return nil
+        }
+    }
+
+    private func saveState(_ state: Multistaking.MythosStakingState) {
+        let stakingOption = Multistaking.OptionWithWallet(
+            walletId: walletId,
+            option: .init(chainAssetId: chainAsset.chainAssetId, type: stakingType)
+        )
+
+        let dashboardItem = Multistaking.DashboardItemMythosStakingPart(
+            stakingOption: stakingOption,
+            state: state
+        )
+
+        let saveOperation = dashboardRepository.saveOperation({
+            [dashboardItem]
+        }, {
+            []
+        })
+
+        let wrapper = CompoundOperationWrapper(targetOperation: saveOperation)
+
+        if let pendingOperations = saveCallStore.operatingCall?.allOperations {
+            wrapper.addDependency(operations: pendingOperations)
+        }
+
+        executeCancellable(
+            wrapper: wrapper,
+            inOperationQueue: operationQueue,
+            backingCallIn: saveCallStore,
+            runningCallbackIn: workingQueue,
+            mutex: mutex
+        ) { [weak self] result in
+            switch result {
+            case .success:
+                self?.completeImmediate(nil)
+            case let .failure(error):
+                self?.completeImmediate(error)
+            }
+        }
+    }
+}

--- a/novawallet/Common/Services/Multistaking/MythosMultistakingUpdateService.swift
+++ b/novawallet/Common/Services/Multistaking/MythosMultistakingUpdateService.swift
@@ -66,7 +66,7 @@ final class MythosMultistakingUpdateService: ObservableSyncService {
             let localKeyFactory = LocalStorageKeyFactory()
             let localKey = try localKeyFactory.createFromStoragePath(
                 MythosStakingPallet.userStakePath,
-                encodableElement: accountId,
+                accountId: accountId,
                 chainId: chainId
             )
 

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/MythosStakingRemoteSubscriptionService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/MythosStakingRemoteSubscriptionService.swift
@@ -1,0 +1,38 @@
+import Foundation
+import SubstrateSdk
+
+final class MythosStakingRemoteSubscriptionService: RemoteSubscriptionService,
+    StakingRemoteSubscriptionServiceProtocol {
+    private static let globalDataStoragePaths: [StorageCodingPath] = [
+        MythosStakingPallet.minStakePath,
+        MythosStakingPallet.currentSessionPath
+    ]
+
+    func attachToGlobalData(
+        for chainId: ChainModel.Id,
+        queue: DispatchQueue?,
+        closure: RemoteSubscriptionClosure?
+    ) -> UUID? {
+        attachToGlobalDataWithStoragePaths(
+            Self.globalDataStoragePaths,
+            chainId: chainId,
+            queue: queue,
+            closure: closure
+        )
+    }
+
+    func detachFromGlobalData(
+        for subscriptionId: UUID,
+        chainId: ChainModel.Id,
+        queue: DispatchQueue?,
+        closure: RemoteSubscriptionClosure?
+    ) {
+        detachFromGlobalDataStoragePaths(
+            Self.globalDataStoragePaths,
+            subscriptionId: subscriptionId,
+            chainId: chainId,
+            queue: queue,
+            closure: closure
+        )
+    }
+}

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/ParachainStakingRemoteSubscriptionService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/ParachainStakingRemoteSubscriptionService.swift
@@ -15,52 +15,17 @@ extension ParachainStaking {
             ParachainStaking.parachainBondInfoPath
         ]
 
-        private static func globalDataParamsCacheKey(for chainId: ChainModel.Id) throws -> String {
-            let storageKeyFactory = StorageKeyFactory()
-            let cacheKeyData = try globalDataStoragePaths.reduce(Data()) { result, storagePath in
-                let storageKeyData = try storageKeyFactory.createStorageKey(
-                    moduleName: storagePath.moduleName,
-                    storageName: storagePath.itemName
-                )
-
-                return result + storageKeyData
-            }
-
-            return try LocalStorageKeyFactory().createKey(from: cacheKeyData, chainId: chainId)
-        }
-
         func attachToGlobalData(
             for chainId: ChainModel.Id,
             queue: DispatchQueue?,
             closure: RemoteSubscriptionClosure?
         ) -> UUID? {
-            do {
-                let localKeyFactory = LocalStorageKeyFactory()
-
-                let localKeys = try Self.globalDataStoragePaths.map { storagePath in
-                    try localKeyFactory.createFromStoragePath(
-                        storagePath,
-                        chainId: chainId
-                    )
-                }
-
-                let cacheKey = try Self.globalDataParamsCacheKey(for: chainId)
-
-                let requests = zip(Self.globalDataStoragePaths, localKeys).map {
-                    UnkeyedSubscriptionRequest(storagePath: $0.0, localKey: $0.1)
-                }
-
-                return attachToSubscription(
-                    with: requests,
-                    chainId: chainId,
-                    cacheKey: cacheKey,
-                    queue: queue,
-                    closure: closure
-                )
-            } catch {
-                callbackClosureIfProvided(closure, queue: queue, result: .failure(error))
-                return nil
-            }
+            attachToGlobalDataWithStoragePaths(
+                Self.globalDataStoragePaths,
+                chainId: chainId,
+                queue: queue,
+                closure: closure
+            )
         }
 
         func detachFromGlobalData(
@@ -69,18 +34,13 @@ extension ParachainStaking {
             queue: DispatchQueue?,
             closure: RemoteSubscriptionClosure?
         ) {
-            do {
-                let cacheKey = try Self.globalDataParamsCacheKey(for: chainId)
-
-                detachFromSubscription(
-                    cacheKey,
-                    subscriptionId: subscriptionId,
-                    queue: queue,
-                    closure: closure
-                )
-            } catch {
-                callbackClosureIfProvided(closure, queue: queue, result: .failure(error))
-            }
+            detachFromGlobalDataStoragePaths(
+                Self.globalDataStoragePaths,
+                subscriptionId: subscriptionId,
+                chainId: chainId,
+                queue: queue,
+                closure: closure
+            )
         }
     }
 }

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/RemoteSubscriptionService+StoragePath.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/RemoteSubscriptionService+StoragePath.swift
@@ -1,0 +1,77 @@
+import Foundation
+import SubstrateSdk
+
+extension RemoteSubscriptionService {
+    private static func globalDataParamsCacheKey(
+        for paths: [StorageCodingPath],
+        chainId: ChainModel.Id
+    ) throws -> String {
+        let storageKeyFactory = StorageKeyFactory()
+        let cacheKeyData = try paths.reduce(Data()) { result, storagePath in
+            let storageKeyData = try storageKeyFactory.createStorageKey(
+                moduleName: storagePath.moduleName,
+                storageName: storagePath.itemName
+            )
+
+            return result + storageKeyData
+        }
+
+        return try LocalStorageKeyFactory().createKey(from: cacheKeyData, chainId: chainId)
+    }
+
+    func attachToGlobalDataWithStoragePaths(
+        _ paths: [StorageCodingPath],
+        chainId: ChainModel.Id,
+        queue: DispatchQueue?,
+        closure: RemoteSubscriptionClosure?
+    ) -> UUID? {
+        do {
+            let localKeyFactory = LocalStorageKeyFactory()
+
+            let localKeys = try paths.map { storagePath in
+                try localKeyFactory.createFromStoragePath(
+                    storagePath,
+                    chainId: chainId
+                )
+            }
+
+            let cacheKey = try Self.globalDataParamsCacheKey(for: paths, chainId: chainId)
+
+            let requests = zip(paths, localKeys).map {
+                UnkeyedSubscriptionRequest(storagePath: $0.0, localKey: $0.1)
+            }
+
+            return attachToSubscription(
+                with: requests,
+                chainId: chainId,
+                cacheKey: cacheKey,
+                queue: queue,
+                closure: closure
+            )
+        } catch {
+            callbackClosureIfProvided(closure, queue: queue, result: .failure(error))
+            return nil
+        }
+    }
+
+    func detachFromGlobalDataStoragePaths(
+        _ paths: [StorageCodingPath],
+        subscriptionId: UUID,
+        chainId: ChainModel.Id,
+        queue: DispatchQueue?,
+        closure: RemoteSubscriptionClosure?
+    ) {
+        do {
+            let cacheKey = try Self.globalDataParamsCacheKey(for: paths, chainId: chainId)
+
+            detachFromSubscription(
+                cacheKey,
+                subscriptionId: subscriptionId,
+                queue: queue,
+                closure: closure
+            )
+        } catch {
+            callbackClosureIfProvided(closure, queue: queue, result: .failure(error))
+        }
+    }
+}

--- a/novawallet/Common/Storage/EntityToModel/StakingDashboardMythosMapper.swift
+++ b/novawallet/Common/Storage/EntityToModel/StakingDashboardMythosMapper.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Operation_iOS
+import CoreData
+
+extension Multistaking.DashboardItemMythosStakingPart: Identifiable {
+    var identifier: String { stakingOption.stringValue }
+}
+
+final class StakingDashboardMythosMapper {
+    var entityIdentifierFieldName: String { #keyPath(CDStakingDashboardItem.identifier) }
+
+    typealias DataProviderModel = Multistaking.DashboardItemMythosStakingPart
+    typealias CoreDataEntity = CDStakingDashboardItem
+}
+
+extension StakingDashboardMythosMapper: CoreDataMapperProtocol {
+    func populate(
+        entity _: CoreDataEntity,
+        from _: DataProviderModel,
+        using _: NSManagedObjectContext
+    ) throws {}
+
+    func transform(entity _: CoreDataEntity) throws -> DataProviderModel {
+        // we only can write partial state but not read
+        fatalError("Unsupported method")
+    }
+}

--- a/novawallet/Common/Substrate/Types/BalancesPallet/BalancesPallet+Freezes.swift
+++ b/novawallet/Common/Substrate/Types/BalancesPallet/BalancesPallet+Freezes.swift
@@ -27,4 +27,6 @@ extension BalancesPallet {
         let freezeId: FreezeId
         @StringCodable var amount: BigUInt
     }
+
+    typealias Freezes = [Freeze]
 }

--- a/novawallet/Common/Substrate/Types/MythosStaking/MythosStaking+StoragePath.swift
+++ b/novawallet/Common/Substrate/Types/MythosStaking/MythosStaking+StoragePath.swift
@@ -1,0 +1,8 @@
+import Foundation
+import SubstrateSdk
+
+extension MythosStakingPallet {
+    static var userStakePath: StorageCodingPath {
+        StorageCodingPath(moduleName: Self.name, itemName: "UserStake")
+    }
+}

--- a/novawallet/Common/Substrate/Types/MythosStaking/MythosStaking+StoragePath.swift
+++ b/novawallet/Common/Substrate/Types/MythosStaking/MythosStaking+StoragePath.swift
@@ -5,4 +5,16 @@ extension MythosStakingPallet {
     static var userStakePath: StorageCodingPath {
         StorageCodingPath(moduleName: Self.name, itemName: "UserStake")
     }
+
+    static var minStakePath: StorageCodingPath {
+        StorageCodingPath(moduleName: Self.name, itemName: "MinStake")
+    }
+
+    static var currentSessionPath: StorageCodingPath {
+        StorageCodingPath(moduleName: Self.name, itemName: "CurrentSession")
+    }
+
+    static var stakeUnlockDelayPath: ConstantCodingPath {
+        ConstantCodingPath(moduleName: Self.name, constantName: "StakeUnlockDelay")
+    }
 }

--- a/novawallet/Common/Substrate/Types/MythosStaking/MythosStakingPallet+Freezes.swift
+++ b/novawallet/Common/Substrate/Types/MythosStaking/MythosStakingPallet+Freezes.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension MythosStakingPallet {
+    static let freezeModule = "CollatorStaking"
+    static let stakingFreezeType = "Staking"
+    static let releasingFreezeType = "Releasing"
+}
+
+extension BalancesPallet.Freezes {
+    func getMythosStakingAmount() -> Balance? {
+        let stakingReasons = [MythosStakingPallet.stakingFreezeType, MythosStakingPallet.releasingFreezeType]
+
+        return filter { freeze in
+            freeze.freezeId.module == MythosStakingPallet.freezeModule &&
+                stakingReasons.contains(freeze.freezeId.reason)
+        }
+        .map(\.amount)
+        .max()
+    }
+}

--- a/novawallet/Common/Substrate/Types/MythosStaking/MythosStakingPallet.swift
+++ b/novawallet/Common/Substrate/Types/MythosStaking/MythosStakingPallet.swift
@@ -1,0 +1,10 @@
+import Foundation
+import SubstrateSdk
+
+enum MythosStakingPallet {
+    static let name = "CollatorStaking"
+
+    struct UserStake: Codable {
+        @StringCodable var stake: Balance
+    }
+}

--- a/novawallet/Common/Substrate/Types/MythosStaking/MythosStakingPallet.swift
+++ b/novawallet/Common/Substrate/Types/MythosStaking/MythosStakingPallet.swift
@@ -4,7 +4,7 @@ import SubstrateSdk
 enum MythosStakingPallet {
     static let name = "CollatorStaking"
 
-    struct UserStake: Codable {
+    struct UserStake: Codable, Equatable {
         @StringCodable var stake: Balance
     }
 }

--- a/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModelFactory.swift
+++ b/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModelFactory.swift
@@ -141,7 +141,7 @@ final class StakingDashboardViewModelFactory {
                 title: R.string.localizable.stakingPool(preferredLanguages: locale.rLanguages).uppercased(),
                 icon: R.image.iconStakingPool()
             )
-        case .parachain, .turing, .unsupported:
+        case .parachain, .turing, .mythos, .unsupported:
             return nil
         }
     }

--- a/novawallet/Modules/Staking/Model/ConsesusType.swift
+++ b/novawallet/Modules/Staking/Model/ConsesusType.swift
@@ -13,7 +13,7 @@ enum ConsensusType {
             self = .auraGeneral
         case .azero:
             self = .auraAzero
-        case .parachain, .turing, .unsupported, .nominationPools:
+        case .parachain, .turing, .mythos, .unsupported, .nominationPools:
             return nil
         }
     }

--- a/novawallet/Modules/Staking/Model/StakingSharedState/MythosStakingSharedState.swift
+++ b/novawallet/Modules/Staking/Model/StakingSharedState/MythosStakingSharedState.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+protocol MythosStakingSharedStateProtocol {
+    var stakingOption: Multistaking.ChainAssetOption { get }
+    var chainRegistry: ChainRegistryProtocol { get }
+    var stakingLocalSubscriptionFactory: MythosStakingLocalSubscriptionFactoryProtocol { get }
+    var generalLocalSubscriptionFactory: GeneralStorageSubscriptionFactoryProtocol { get }
+    var blockTimeService: BlockTimeEstimationServiceProtocol { get }
+
+    var logger: LoggerProtocol { get }
+
+    var sharedOperation: SharedOperationProtocol? { get }
+
+    func setup(for accountId: AccountId?)
+    func throttle()
+    func startSharedOperation() -> SharedOperationProtocol
+}
+
+final class MythosStakingSharedState {
+    let stakingOption: Multistaking.ChainAssetOption
+    let chainRegistry: ChainRegistryProtocol
+    let blockTimeService: BlockTimeEstimationServiceProtocol
+    let globalRemoteSubscriptionService: StakingRemoteSubscriptionServiceProtocol
+    let generalLocalSubscriptionFactory: GeneralStorageSubscriptionFactoryProtocol
+    let stakingLocalSubscriptionFactory: MythosStakingLocalSubscriptionFactoryProtocol
+    let logger: LoggerProtocol
+
+    weak var sharedOperation: SharedOperationProtocol?
+
+    private var globalRemoteSubscription: UUID?
+
+    init(
+        stakingOption: Multistaking.ChainAssetOption,
+        chainRegistry: ChainRegistryProtocol,
+        stakingLocalSubscriptionFactory: MythosStakingLocalSubscriptionFactoryProtocol,
+        globalRemoteSubscriptionService: StakingRemoteSubscriptionServiceProtocol,
+        blockTimeService: BlockTimeEstimationServiceProtocol,
+        generalLocalSubscriptionFactory: GeneralStorageSubscriptionFactoryProtocol,
+        logger: LoggerProtocol
+    ) {
+        self.stakingOption = stakingOption
+        self.chainRegistry = chainRegistry
+        self.stakingLocalSubscriptionFactory = stakingLocalSubscriptionFactory
+        self.globalRemoteSubscriptionService = globalRemoteSubscriptionService
+        self.blockTimeService = blockTimeService
+        self.generalLocalSubscriptionFactory = generalLocalSubscriptionFactory
+        self.logger = logger
+    }
+}
+
+extension MythosStakingSharedState: MythosStakingSharedStateProtocol {
+    func setup(for _: AccountId?) {
+        let chainId = stakingOption.chainAsset.chain.chainId
+
+        globalRemoteSubscription = globalRemoteSubscriptionService.attachToGlobalData(
+            for: chainId,
+            queue: .main
+        ) { [weak self] result in
+            switch result {
+            case .success:
+                self?.logger.debug("Mythos staking global remote subscription succeeded")
+            case let .failure(error):
+                self?.logger.error("Mythos staking global remote subscription failed: \(error)")
+            }
+        }
+
+        blockTimeService.setup()
+    }
+
+    func throttle() {
+        let chainId = stakingOption.chainAsset.chain.chainId
+
+        if let globalRemoteSubscription = globalRemoteSubscription {
+            globalRemoteSubscriptionService.detachFromGlobalData(
+                for: globalRemoteSubscription,
+                chainId: chainId,
+                queue: nil,
+                closure: nil
+            )
+        }
+
+        blockTimeService.throttle()
+    }
+
+    func startSharedOperation() -> SharedOperationProtocol {
+        let operation = SharedOperation()
+        sharedOperation = operation
+        return operation
+    }
+}

--- a/novawallet/Modules/Staking/Model/StakingType.swift
+++ b/novawallet/Modules/Staking/Model/StakingType.swift
@@ -7,6 +7,7 @@ enum StakingType: String, Codable, Equatable, Hashable {
     case auraRelaychain = "aura-relaychain"
     case turing
     case nominationPools = "nomination-pools"
+    case mythos
     case unsupported
 
     init(rawType: String?) {
@@ -46,7 +47,7 @@ enum StakingClass {
         switch stakingType {
         case .relaychain, .azero, .auraRelaychain:
             self = .relaychain
-        case .parachain, .turing:
+        case .parachain, .turing, .mythos:
             self = .parachain
         case .nominationPools:
             self = .nominationPools

--- a/novawallet/Modules/Staking/Operations/ChainSessionCountdown.swift
+++ b/novawallet/Modules/Staking/Operations/ChainSessionCountdown.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+struct ChainSessionInfo: Equatable {
+    let offset: BlockNumber
+    let length: SessionIndex
+}
+
+struct ChainSessionCountdown {
+    let currentSession: SessionIndex
+    let info: ChainSessionInfo
+    let blockTime: TimeInterval
+    let currentBlock: BlockNumber
+    let createdAtDate: Date
+
+    var currentSessionStart: BlockNumber {
+        guard currentBlock >= info.offset else {
+            return info.offset
+        }
+
+        let sessionProgress = (currentBlock - info.offset) % info.length
+
+        return currentBlock - sessionProgress
+    }
+}
+
+extension ChainSessionCountdown {
+    func timeIntervalTillStart(targetSession: SessionIndex) -> TimeInterval {
+        guard info.length > 0 else {
+            return 0
+        }
+
+        let currentBlockNumber = max(currentSessionStart, currentBlock)
+
+        let progressInSessions = (currentBlockNumber - currentSessionStart) / info.length
+
+        guard currentSession + progressInSessions < targetSession else {
+            return 0
+        }
+
+        let remainedSessions = targetSession - (currentSession + progressInSessions)
+        let progressInBlocks = (currentBlockNumber - currentSessionStart) % info.length
+        let sessionProgress = TimeInterval(progressInBlocks) * blockTime
+
+        let remainedTime = TimeInterval(remainedSessions * info.length) * blockTime - sessionProgress
+        let timerSpent = Date().timeIntervalSince(createdAtDate)
+
+        return max(remainedTime - timerSpent, 0)
+    }
+
+    func timeIntervalTillNextSessionStart() -> TimeInterval {
+        timeIntervalTillStart(targetSession: currentSession + 1)
+    }
+}

--- a/novawallet/Modules/Staking/Operations/MythosStaking/MythosStakingDurationOperationFactory.swift
+++ b/novawallet/Modules/Staking/Operations/MythosStaking/MythosStakingDurationOperationFactory.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Operation_iOS
+import SubstrateSdk
+
+struct MythosStakingDuration: Equatable {
+    let block: TimeInterval
+    let session: TimeInterval
+    let unstaking: TimeInterval
+    let sessionInfo: ChainSessionInfo
+}
+
+protocol MythosStkDurationOperationFactoryProtocol {
+    func createDurationOperation(
+        for chainId: ChainModel.Id,
+        blockTimeEstimationService: BlockTimeEstimationServiceProtocol
+    ) -> CompoundOperationWrapper<MythosStakingDuration>
+}
+
+enum MythosStkDurationOperationFactoryError: Error {
+    case sessionLengthMissing
+}
+
+final class MythosStkDurationOperationFactory {
+    let chainRegistry: ChainRegistryProtocol
+    let blockTimeOperationFactory: BlockTimeOperationFactoryProtocol
+
+    init(
+        chainRegistry: ChainRegistryProtocol,
+        blockTimeOperationFactory: BlockTimeOperationFactoryProtocol
+    ) {
+        self.chainRegistry = chainRegistry
+        self.blockTimeOperationFactory = blockTimeOperationFactory
+    }
+}
+
+extension MythosStkDurationOperationFactory: MythosStkDurationOperationFactoryProtocol {
+    func createDurationOperation(
+        for chainId: ChainModel.Id,
+        blockTimeEstimationService: BlockTimeEstimationServiceProtocol
+    ) -> CompoundOperationWrapper<MythosStakingDuration> {
+        do {
+            let chain = try chainRegistry.getChainOrError(for: chainId)
+
+            guard let blocksInSession = chain.additional?.sessionLength?.unsignedIntValue else {
+                throw MythosStkDurationOperationFactoryError.sessionLengthMissing
+            }
+
+            let runtimeService = try chainRegistry.getRuntimeProviderOrError(for: chain.chainId)
+
+            let codingFactoryOperation = runtimeService.fetchCoderFactoryOperation()
+
+            let unstakingPeriodOperation: BaseOperation<BlockNumber> = PrimitiveConstantOperation.operation(
+                for: MythosStakingPallet.stakeUnlockDelayPath,
+                dependingOn: codingFactoryOperation
+            )
+
+            unstakingPeriodOperation.addDependency(codingFactoryOperation)
+
+            let blockTimeWrapper = blockTimeOperationFactory.createBlockTimeOperation(
+                from: runtimeService,
+                blockTimeEstimationService: blockTimeEstimationService
+            )
+
+            let mapOperation = ClosureOperation<MythosStakingDuration> {
+                let blockTime = try blockTimeWrapper.targetOperation.extractNoCancellableResultData()
+                let unstakingBlocks = try unstakingPeriodOperation.extractNoCancellableResultData()
+
+                let blockTimeInterval = TimeInterval(blockTime).seconds
+                let sessionDuration = TimeInterval(blocksInSession) * blockTimeInterval
+                let unstakingDuration = TimeInterval(unstakingBlocks) * blockTimeInterval
+
+                return MythosStakingDuration(
+                    block: blockTimeInterval,
+                    session: sessionDuration,
+                    unstaking: unstakingDuration,
+                    sessionInfo: ChainSessionInfo(
+                        offset: 0, // TODO: Check whether we need to fetch for production
+                        length: SessionIndex(blocksInSession)
+                    )
+                )
+            }
+
+            mapOperation.addDependency(blockTimeWrapper.targetOperation)
+            mapOperation.addDependency(unstakingPeriodOperation)
+
+            return blockTimeWrapper
+                .insertingHead(operations: [codingFactoryOperation, unstakingPeriodOperation])
+                .insertingTail(operation: mapOperation)
+        } catch {
+            return .createWithError(error)
+        }
+    }
+}

--- a/novawallet/Modules/Staking/Services/BaseStakingServiceFactory.swift
+++ b/novawallet/Modules/Staking/Services/BaseStakingServiceFactory.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+class BaseStakingServiceFactory {
+    let chainRegisty: ChainRegistryProtocol
+    let storageFacade: StorageFacadeProtocol
+    let eventCenter: EventCenterProtocol
+    let operationQueue: OperationQueue
+    let logger: LoggerProtocol
+
+    init(
+        chainRegisty: ChainRegistryProtocol,
+        storageFacade: StorageFacadeProtocol,
+        eventCenter: EventCenterProtocol,
+        operationQueue: OperationQueue,
+        logger: LoggerProtocol
+    ) {
+        self.chainRegisty = chainRegisty
+        self.storageFacade = storageFacade
+        self.eventCenter = eventCenter
+        self.operationQueue = operationQueue
+        self.logger = logger
+    }
+
+    func createBlockTimeService(for chainId: ChainModel.Id) throws -> BlockTimeEstimationServiceProtocol {
+        let runtimeService = try chainRegisty.getRuntimeProviderOrError(for: chainId)
+        let connection = try chainRegisty.getConnectionOrError(for: chainId)
+
+        let repositoryFactory = SubstrateRepositoryFactory(storageFacade: storageFacade)
+
+        let repository = repositoryFactory.createChainStorageItemRepository()
+
+        return BlockTimeEstimationService(
+            chainId: chainId,
+            connection: connection,
+            runtimeService: runtimeService,
+            repository: repository,
+            eventCenter: eventCenter,
+            operationQueue: operationQueue,
+            logger: logger
+        )
+    }
+}

--- a/novawallet/Modules/Staking/StakingMain/StakingMainPresenterFactory.swift
+++ b/novawallet/Modules/Staking/StakingMain/StakingMainPresenterFactory.swift
@@ -31,7 +31,7 @@ extension StakingMainPresenterFactory: StakingMainPresenterFactoryProtocol {
             return createParachainPresenter(for: stakingOption, view: view)
         case .nominationPools:
             return createNominationPoolsPresenter(for: stakingOption.chainAsset, view: view)
-        case .unsupported:
+        case .unsupported, .mythos:
             return nil
         }
     }

--- a/novawallet/Modules/Staking/StakingSetupAmount/Model/StakingTypeBalanceFactory.swift
+++ b/novawallet/Modules/Staking/StakingSetupAmount/Model/StakingTypeBalanceFactory.swift
@@ -29,7 +29,7 @@ final class StakingTypeBalanceFactory: StakingTypeBalanceFactoryProtocol {
 
     var stakingTypeAllowsLocks: Bool {
         switch stakingType {
-        case .relaychain, .auraRelaychain, .azero, .none, .parachain, .turing:
+        case .relaychain, .auraRelaychain, .azero, .none, .parachain, .turing, .mythos:
             return true
         case .nominationPools, .unsupported:
             return false

--- a/novawallet/Modules/Staking/StartStakingInfo/Model/StartStakingStateProtocol.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/Model/StartStakingStateProtocol.swift
@@ -2,9 +2,9 @@ import BigInt
 
 protocol StartStakingStateProtocol {
     var minStake: BigUInt? { get }
-    var eraDuration: TimeInterval? { get }
+    var rewardTime: TimeInterval? { get }
     var unstakingTime: TimeInterval? { get }
-    var nextEraStartTime: TimeInterval? { get }
+    var rewardDelay: TimeInterval? { get }
     var maxApy: Decimal? { get }
     var rewardsAutoPayoutThresholdAmount: BigUInt? { get }
     var govThresholdAmount: BigUInt? { get }

--- a/novawallet/Modules/Staking/StartStakingInfo/Model/StartStakingViewModelFactory.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/Model/StartStakingViewModelFactory.swift
@@ -10,7 +10,7 @@ protocol StartStakingViewModelFactoryProtocol {
     ) -> AccentTextModel
     func stakeModel(
         minStake: BigUInt?,
-        nextEra: TimeInterval,
+        rewardStartDelay: TimeInterval,
         chainAsset: ChainAsset,
         locale: Locale
     ) -> ParagraphView.Model
@@ -18,7 +18,7 @@ protocol StartStakingViewModelFactoryProtocol {
     func rewardModel(
         amount: BigUInt?,
         chainAsset: ChainAsset,
-        eraDuration: TimeInterval,
+        rewardTimeInterval: TimeInterval,
         destination: DefaultStakingRewardDestination,
         locale: Locale
     ) -> ParagraphView.Model
@@ -73,13 +73,13 @@ struct StartStakingViewModelFactory: StartStakingViewModelFactoryProtocol {
 
     func stakeModel(
         minStake: BigUInt?,
-        nextEra: TimeInterval,
+        rewardStartDelay: TimeInterval,
         chainAsset: ChainAsset,
         locale: Locale
     ) -> ParagraphView.Model {
         let separator = R.string.localizable.commonAnd(preferredLanguages: locale.rLanguages)
         let timePreposition = R.string.localizable.commonTimeIn(preferredLanguages: locale.rLanguages)
-        let time = nextEra.localizedDaysHours(
+        let time = rewardStartDelay.localizedDaysHoursOrFallbackMinutes(
             for: locale,
             preposition: timePreposition,
             separator: separator,
@@ -122,7 +122,7 @@ struct StartStakingViewModelFactory: StartStakingViewModelFactoryProtocol {
     ) -> ParagraphView.Model {
         let separator = R.string.localizable.commonAnd(preferredLanguages: locale.rLanguages)
         let preposition = R.string.localizable.commonTimePeriodAfter(preferredLanguages: locale.rLanguages)
-        let unstakePeriodString = unstakePeriod.localizedDaysHours(
+        let unstakePeriodString = unstakePeriod.localizedDaysHoursOrFallbackMinutes(
             for: locale,
             preposition: preposition,
             separator: separator,
@@ -143,13 +143,13 @@ struct StartStakingViewModelFactory: StartStakingViewModelFactoryProtocol {
     func rewardModel(
         amount: BigUInt?,
         chainAsset: ChainAsset,
-        eraDuration: TimeInterval,
+        rewardTimeInterval: TimeInterval,
         destination: DefaultStakingRewardDestination,
         locale: Locale
     ) -> ParagraphView.Model {
         let separator = R.string.localizable.commonAnd(preferredLanguages: locale.rLanguages)
         let preposition = R.string.localizable.commonTimePeriodEvery(preferredLanguages: locale.rLanguages)
-        let rewardIntervals = eraDuration.localizedDaysHours(
+        let rewardIntervals = rewardTimeInterval.localizedDaysHoursOrFallbackMinutes(
             for: locale,
             preposition: preposition,
             separator: separator,

--- a/novawallet/Modules/Staking/StartStakingInfo/MythosStaking/StartStakingInfoMythosInteractor.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/MythosStaking/StartStakingInfoMythosInteractor.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Operation_iOS
+
+final class StartStakingInfoMythosInteractor: StartStakingInfoBaseInteractor {
+    var presenter: StartStakingInfoMythosInteractorOutputProtocol? {
+        get {
+            basePresenter as? StartStakingInfoMythosInteractorOutputProtocol
+        }
+
+        set {
+            basePresenter = newValue
+        }
+    }
+
+    var chainRegistry: ChainRegistryProtocol { state.chainRegistry }
+
+    var generalLocalSubscriptionFactory: GeneralStorageSubscriptionFactoryProtocol {
+        state.generalLocalSubscriptionFactory
+    }
+
+    var stakingLocalSubscriptionFactory: MythosStakingLocalSubscriptionFactoryProtocol {
+        state.stakingLocalSubscriptionFactory
+    }
+
+    var chain: ChainModel {
+        state.stakingOption.chainAsset.chain
+    }
+
+    let state: MythosStakingSharedStateProtocol
+    let durationOperationFactory: MythosStkDurationOperationFactoryProtocol
+    let eventCenter: EventCenterProtocol
+    let logger: LoggerProtocol
+
+    private var blockNumberProvider: AnyDataProvider<DecodedBlockNumber>?
+    private var minStakeProvider: AnyDataProvider<DecodedBigUInt>?
+    private var currentSessionProvider: AnyDataProvider<DecodedU32>?
+
+    init(
+        state: MythosStakingSharedStateProtocol,
+        selectedWalletSettings: SelectedWalletSettings,
+        walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol,
+        priceLocalSubscriptionFactory: PriceProviderFactoryProtocol,
+        stakingDashboardProviderFactory: StakingDashboardProviderFactoryProtocol,
+        durationOperationFactory: MythosStkDurationOperationFactoryProtocol,
+        currencyManager: CurrencyManagerProtocol,
+        sharedOperation: SharedOperationProtocol,
+        operationQueue: OperationQueue,
+        eventCenter: EventCenterProtocol,
+        logger: LoggerProtocol
+    ) {
+        self.state = state
+        self.durationOperationFactory = durationOperationFactory
+        self.eventCenter = eventCenter
+        self.logger = logger
+
+        super.init(
+            selectedWalletSettings: selectedWalletSettings,
+            selectedChainAsset: state.stakingOption.chainAsset,
+            selectedStakingType: state.stakingOption.type,
+            sharedOperation: sharedOperation,
+            walletLocalSubscriptionFactory: walletLocalSubscriptionFactory,
+            priceLocalSubscriptionFactory: priceLocalSubscriptionFactory,
+            stakingDashboardProviderFactory: stakingDashboardProviderFactory,
+            currencyManager: currencyManager,
+            operationQueue: operationQueue
+        )
+    }
+
+    private func performBlockNumberSubscription() {
+        let chainId = selectedChainAsset.chain.chainId
+        blockNumberProvider = subscribeToBlockNumber(for: chainId)
+    }
+
+    private func performMinStakeSubscription() {
+        let chainId = selectedChainAsset.chain.chainId
+        minStakeProvider = subscribeToMinStake(for: chainId)
+    }
+
+    private func performCurrentSessionSubscription() {
+        let chainId = selectedChainAsset.chain.chainId
+        currentSessionProvider = subscribeToCurrentSession(for: chainId)
+    }
+
+    private func provideStakingDuration() {
+        let wrapper = durationOperationFactory.createDurationOperation(
+            for: chain.chainId,
+            blockTimeEstimationService: state.blockTimeService
+        )
+
+        execute(
+            wrapper: wrapper,
+            inOperationQueue: operationQueue,
+            runningCallbackIn: .main
+        ) { [weak self] result in
+            switch result {
+            case let .success(duration):
+                self?.presenter?.didReceive(duration: duration)
+            case let .failure(error):
+                self?.logger.error("Unexpected duration error: \(error)")
+            }
+        }
+    }
+
+    override func setup() {
+        super.setup()
+
+        state.setup(for: selectedAccount?.chainAccount.accountId)
+        eventCenter.add(observer: self, dispatchIn: .main)
+
+        performMinStakeSubscription()
+        performCurrentSessionSubscription()
+        performBlockNumberSubscription()
+        provideStakingDuration()
+    }
+}
+
+extension StartStakingInfoMythosInteractor: StartStakingInfoMythosInteractorInputProtocol {}
+
+extension StartStakingInfoMythosInteractor: EventVisitorProtocol {
+    func processBlockTimeChanged(event: BlockTimeChanged) {
+        guard chain.chainId == event.chainId else { return }
+
+        provideStakingDuration()
+    }
+}
+
+extension StartStakingInfoMythosInteractor: MythosStakingLocalStorageSubscriber, MythosStakingLocalStorageHandler {
+    func handleMinStake(
+        result: Result<Balance?, Error>,
+        chainId _: ChainModel.Id
+    ) {
+        switch result {
+        case let .success(minStake):
+            if let minStake {
+                presenter?.didReceive(minStake: minStake)
+            }
+        case let .failure(error):
+            logger.error("Min stake unexpected error: \(error)")
+        }
+    }
+
+    func handleCurrentSession(
+        result: Result<SessionIndex?, Error>,
+        chainId _: ChainModel.Id
+    ) {
+        switch result {
+        case let .success(session):
+            if let session {
+                presenter?.didReceive(currentSession: session)
+            }
+        case let .failure(error):
+            logger.error("Current session unexpected error: \(error)")
+        }
+    }
+}
+
+extension StartStakingInfoMythosInteractor: GeneralLocalStorageSubscriber, GeneralLocalStorageHandler {
+    func handleBlockNumber(
+        result: Result<BlockNumber?, Error>,
+        chainId: ChainModel.Id
+    ) {
+        guard selectedChainAsset.chain.chainId == chainId else {
+            return
+        }
+
+        switch result {
+        case let .success(blockNumber):
+            presenter?.didReceive(blockNumber: blockNumber)
+        case let .failure(error):
+            logger.error("Block number unexpected error: \(error)")
+        }
+    }
+}

--- a/novawallet/Modules/Staking/StartStakingInfo/MythosStaking/StartStakingInfoMythosProtocols.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/MythosStaking/StartStakingInfoMythosProtocols.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+protocol StartStakingInfoMythosInteractorInputProtocol: StartStakingInfoInteractorInputProtocol {}
+
+protocol StartStakingInfoMythosInteractorOutputProtocol: StartStakingInfoInteractorOutputProtocol {
+    func didReceive(duration: MythosStakingDuration)
+    func didReceive(minStake: Balance)
+    func didReceive(currentSession: SessionIndex)
+    func didReceive(blockNumber: BlockNumber?)
+}

--- a/novawallet/Modules/Staking/StartStakingInfo/MythosStaking/StartStakingInfoMythosWireframe.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/MythosStaking/StartStakingInfoMythosWireframe.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+final class StartStakingInfoMythosWireframe: StartStakingInfoWireframe {}

--- a/novawallet/Modules/Staking/StartStakingInfo/ParachainStaking/StartStakingInfoParachainPresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/ParachainStaking/StartStakingInfoParachainPresenter.swift
@@ -131,7 +131,7 @@ extension StartStakingInfoParachainPresenter {
 
         var rewardsAutoPayoutThresholdAmount: BigUInt? { nil }
 
-        var nextEraStartTime: TimeInterval? {
+        var rewardDelay: TimeInterval? {
             guard let roundCountdown = roundCountdown,
                   let roundInfo = roundInfo,
                   let rewardPaymentDelay = rewardPaymentDelay else {
@@ -163,7 +163,7 @@ extension StartStakingInfoParachainPresenter {
             return stakingDuration.unstaking
         }
 
-        var eraDuration: TimeInterval? {
+        var rewardTime: TimeInterval? {
             guard let stakingDuration = stakingDuration else {
                 return nil
             }

--- a/novawallet/Modules/Staking/StartStakingInfo/RelaychainStaking/StartStakingInfoRelaychainPresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/RelaychainStaking/StartStakingInfoRelaychainPresenter.swift
@@ -136,7 +136,7 @@ extension StartStakingInfoRelaychainPresenter {
             }
         }
 
-        var nextEraStartTime: TimeInterval? {
+        var rewardDelay: TimeInterval? {
             guard let eraCountdown = eraCountdown else {
                 return nil
             }
@@ -144,7 +144,7 @@ extension StartStakingInfoRelaychainPresenter {
             return eraCountdown.timeIntervalTillStart(targetEra: eraCountdown.currentEra + 2)
         }
 
-        var eraDuration: TimeInterval? {
+        var rewardTime: TimeInterval? {
             guard let eraCountdown = eraCountdown else {
                 return nil
             }

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
@@ -85,9 +85,9 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
         self.state = state
 
         guard
-            let eraDuration = state.eraDuration,
+            let rewardTime = state.rewardTime,
             let unstakingTime = state.unstakingTime,
-            let nextEraStartTime = state.nextEraStartTime,
+            let rewardDelay = state.rewardDelay,
             let minStake = state.minStake,
             let maxApy = state.maxApy else {
             return
@@ -122,7 +122,7 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
             testnetModel,
             startStakingViewModelFactory.stakeModel(
                 minStake: minStake,
-                nextEra: nextEraStartTime,
+                rewardStartDelay: rewardDelay,
                 chainAsset: chainAsset,
                 locale: selectedLocale
             ),
@@ -130,7 +130,7 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
             startStakingViewModelFactory.rewardModel(
                 amount: state.rewardsAutoPayoutThresholdAmount,
                 chainAsset: chainAsset,
-                eraDuration: eraDuration,
+                rewardTimeInterval: rewardTime,
                 destination: state.rewardsDestination,
                 locale: selectedLocale
             ),

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory+Mythos.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory+Mythos.swift
@@ -1,0 +1,98 @@
+import Foundation
+import SoraFoundation
+
+extension StartStakingInfoViewFactory {
+    static func createMythosView(
+        for stakingOption: Multistaking.ChainAssetOption
+    ) -> StartStakingInfoViewProtocol? {
+        let operationQueue = OperationManagerFacade.sharedDefaultQueue
+
+        let stateFactory = StakingSharedStateFactory(
+            storageFacade: SubstrateDataStorageFacade.shared,
+            chainRegistry: ChainRegistryFacade.sharedRegistry,
+            proxySyncService: nil,
+            eventCenter: EventCenter.shared,
+            syncOperationQueue: operationQueue,
+            repositoryOperationQueue: operationQueue,
+            applicationConfig: ApplicationConfig.shared,
+            logger: Logger.shared
+        )
+
+        guard
+            let state = try? stateFactory.createMythosStaking(for: stakingOption),
+            let currencyManager = CurrencyManager.shared else {
+            return nil
+        }
+
+        let interactor = createMythosInteractor(state: state, currencyManager: currencyManager)
+
+        let wireframe = StartStakingInfoMythosWireframe()
+
+        let balanceViewModelFactory = BalanceViewModelFactory(
+            targetAssetInfo: stakingOption.chainAsset.assetDisplayInfo,
+            priceAssetInfoFactory: PriceAssetInfoFactory(currencyManager: currencyManager)
+        )
+
+        let startStakingViewModelFactory = StartStakingViewModelFactory(
+            balanceViewModelFactory: balanceViewModelFactory,
+            estimatedEarningsFormatter: NumberFormatter.percentBase.localizableResource()
+        )
+
+        let presenter = StartStakingInfoMythosPresenter(
+            chainAsset: stakingOption.chainAsset,
+            interactor: interactor,
+            wireframe: wireframe,
+            startStakingViewModelFactory: startStakingViewModelFactory,
+            balanceDerivationFactory: StakingTypeBalanceFactory(stakingType: stakingOption.type),
+            localizationManager: LocalizationManager.shared,
+            applicationConfig: ApplicationConfig.shared,
+            logger: Logger.shared
+        )
+
+        let view = StartStakingInfoViewController(
+            presenter: presenter,
+            localizationManager: LocalizationManager.shared,
+            themeColor: stakingOption.chainAsset.chain.themeColor ?? R.color.colorPolkadotBrand()!
+        )
+
+        presenter.view = view
+        interactor.presenter = presenter
+
+        return view
+    }
+
+    private static func createMythosInteractor(
+        state: MythosStakingSharedStateProtocol,
+        currencyManager: CurrencyManagerProtocol
+    ) -> StartStakingInfoMythosInteractor {
+        let selectedWalletSettings = SelectedWalletSettings.shared
+        let walletLocalSubscriptionFactory = WalletLocalSubscriptionFactory.shared
+        let priceLocalSubscriptionFactory = PriceProviderFactory.shared
+
+        let stakingDashboardProviderFactory = StakingDashboardProviderFactory(
+            chainRegistry: ChainRegistryFacade.sharedRegistry,
+            storageFacade: SubstrateDataStorageFacade.shared,
+            operationManager: OperationManagerFacade.sharedManager,
+            logger: Logger.shared
+        )
+
+        let durationOperationFactory = MythosStkDurationOperationFactory(
+            chainRegistry: state.chainRegistry,
+            blockTimeOperationFactory: BlockTimeOperationFactory(chain: state.stakingOption.chainAsset.chain)
+        )
+
+        return StartStakingInfoMythosInteractor(
+            state: state,
+            selectedWalletSettings: selectedWalletSettings,
+            walletLocalSubscriptionFactory: walletLocalSubscriptionFactory,
+            priceLocalSubscriptionFactory: priceLocalSubscriptionFactory,
+            stakingDashboardProviderFactory: stakingDashboardProviderFactory,
+            durationOperationFactory: durationOperationFactory,
+            currencyManager: currencyManager,
+            sharedOperation: state.startSharedOperation(),
+            operationQueue: OperationManagerFacade.sharedDefaultQueue,
+            eventCenter: EventCenter.shared,
+            logger: Logger.shared
+        )
+    }
+}

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
@@ -39,7 +39,14 @@ struct StartStakingInfoViewFactory {
                     type: selectedStakingType ?? mainStakingType
                 )
             )
-        case .unsupported, .nominationPools, .mythos:
+        case .mythos:
+            return createMythosView(
+                for: .init(
+                    chainAsset: chainAsset,
+                    type: selectedStakingType ?? mainStakingType
+                )
+            )
+        case .unsupported, .nominationPools:
             return nil
         }
     }

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
@@ -39,7 +39,7 @@ struct StartStakingInfoViewFactory {
                     type: selectedStakingType ?? mainStakingType
                 )
             )
-        case .unsupported, .nominationPools:
+        case .unsupported, .nominationPools, .mythos:
             return nil
         }
     }


### PR DESCRIPTION
## Purpose

- Add staking global subscription service. Currently, it syncs minimum stake and current staking session;
- Add data providers for the staking;
- Implement `MythosStkDurationFactory` to get duration of the main staking parameters: block, unstaking period and staking session;
- Implement notion of time in Mythos network and logic of time calculation between sessions - `ChainSessionCountdown`;
- Implement start staking info screen for Mythos Staking;

##

![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-17 at 17 34 12](https://github.com/user-attachments/assets/781ec5b8-9874-4d61-8a1b-3006cb404ff3)

