### PR TITLE
Fix ModalPicker

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1291,6 +1291,8 @@
 		2DB5B1122D3FDF3E0075EB3F /* DAppListNavigationTaskFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB5B1112D3FDF3E0075EB3F /* DAppListNavigationTaskFactory.swift */; };
 		2DB5B1152D3FECB00075EB3F /* DAppListNavigationTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB5B1142D3FECB00075EB3F /* DAppListNavigationTask.swift */; };
 		2DB5B1172D3FEF600075EB3F /* CollectionViewRotationHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB5B1162D3FEF600075EB3F /* CollectionViewRotationHandling.swift */; };
+		2DB5B1192D400EBF0075EB3F /* ModalPickerPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB5B1182D400EBF0075EB3F /* ModalPickerPresentationController.swift */; };
+		2DB5B11B2D40184A0075EB3F /* ModalPickerPresentationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB5B11A2D40184A0075EB3F /* ModalPickerPresentationFactory.swift */; };
 		2DBB28852CD2811200DFA0AD /* QRCodeWithLogoFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB28842CD2811200DFA0AD /* QRCodeWithLogoFactory.swift */; };
 		2DBB28872CD2934500DFA0AD /* AssetIconURLFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB28862CD2934500DFA0AD /* AssetIconURLFactory.swift */; };
 		2DBB28892CD42ACB00DFA0AD /* QRCreationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB28882CD42ACB00DFA0AD /* QRCreationOperation.swift */; };
@@ -6728,6 +6730,8 @@
 		2DB5B1112D3FDF3E0075EB3F /* DAppListNavigationTaskFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppListNavigationTaskFactory.swift; sourceTree = "<group>"; };
 		2DB5B1142D3FECB00075EB3F /* DAppListNavigationTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppListNavigationTask.swift; sourceTree = "<group>"; };
 		2DB5B1162D3FEF600075EB3F /* CollectionViewRotationHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewRotationHandling.swift; sourceTree = "<group>"; };
+		2DB5B1182D400EBF0075EB3F /* ModalPickerPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPickerPresentationController.swift; sourceTree = "<group>"; };
+		2DB5B11A2D40184A0075EB3F /* ModalPickerPresentationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPickerPresentationFactory.swift; sourceTree = "<group>"; };
 		2DBB28842CD2811200DFA0AD /* QRCodeWithLogoFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeWithLogoFactory.swift; sourceTree = "<group>"; };
 		2DBB28862CD2934500DFA0AD /* AssetIconURLFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetIconURLFactory.swift; sourceTree = "<group>"; };
 		2DBB28882CD42ACB00DFA0AD /* QRCreationOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCreationOperation.swift; sourceTree = "<group>"; };
@@ -21619,6 +21623,8 @@
 				84D8F15924D8135200AF43E9 /* ViewModel */,
 				84D8F15824D8134E00AF43E9 /* Cell */,
 				84D8F15424D80CA100AF43E9 /* ModalPickerViewController.swift */,
+				2DB5B1182D400EBF0075EB3F /* ModalPickerPresentationController.swift */,
+				2DB5B11A2D40184A0075EB3F /* ModalPickerPresentationFactory.swift */,
 				84D8F15624D80D5500AF43E9 /* ModalPickerViewController.xib */,
 				84D8F16A24D8263300AF43E9 /* ModalPickerFactory.swift */,
 				84D8F16C24D82C7E00AF43E9 /* ModalPickerConfiguration.swift */,
@@ -28952,6 +28958,7 @@
 				84E8BA0D29FF898600FD9F40 /* BaseExtrinsicOperationFactory.swift in Sources */,
 				270C21973CB61F0BF3D2D1E3 /* CrowdloanListProtocols.swift in Sources */,
 				0C11D85E2CCA470D003EC46D /* AssetsExchangeRouteManager.swift in Sources */,
+				2DB5B11B2D40184A0075EB3F /* ModalPickerPresentationFactory.swift in Sources */,
 				6D61E43A79BDF5EA6CA9E85D /* CrowdloanListWireframe.swift in Sources */,
 				A090FF206B56A0E465C62072 /* CrowdloanListPresenter.swift in Sources */,
 				0CF5F68A2CC7AF84007BAAC5 /* AssetExchangeGraphPath.swift in Sources */,
@@ -29287,6 +29294,7 @@
 				849976CE27B3921800B14A6C /* DAppMetamaskAuthorizedState.swift in Sources */,
 				8445F41328C8C6E0009E61C4 /* ParaStkYieldBoostInitState.swift in Sources */,
 				C122F2FE976FEE9A609A1A93 /* DAppOperationConfirmPresenter.swift in Sources */,
+				2DB5B1192D400EBF0075EB3F /* ModalPickerPresentationController.swift in Sources */,
 				3155B51D1CF150FAFADE88AF /* DAppOperationConfirmInteractor.swift in Sources */,
 				9F3E2D64D77BF89B474BF1E3 /* DAppOperationConfirmViewController.swift in Sources */,
 				7BD09D3022967C4D90AB4693 /* DAppOperationConfirmViewLayout.swift in Sources */,

--- a/novawallet/Common/ViewController/ModalPicker/ModalPickerFactory.swift
+++ b/novawallet/Common/ViewController/ModalPicker/ModalPickerFactory.swift
@@ -28,7 +28,7 @@ enum ModalPickerFactory {
 
         viewController.viewModels = actions
 
-        let factory = ModalSheetPresentationFactory(configuration: ModalSheetPresentationConfiguration.nova)
+        let factory = ModalPickerPresentationFactory(configuration: ModalSheetPresentationConfiguration.nova)
         viewController.modalTransitioningFactory = factory
 
         let height = viewController.headerHeight + CGFloat(actions.count) * viewController.cellHeight +
@@ -74,7 +74,7 @@ enum ModalPickerFactory {
             }
         }
 
-        let factory = ModalSheetPresentationFactory(configuration: ModalSheetPresentationConfiguration.nova)
+        let factory = ModalPickerPresentationFactory(configuration: ModalSheetPresentationConfiguration.nova)
         viewController.modalTransitioningFactory = factory
 
         let height = viewController.headerHeight + CGFloat(options.count) * viewController.cellHeight +
@@ -121,7 +121,7 @@ enum ModalPickerFactory {
             }
         }
 
-        let factory = ModalSheetPresentationFactory(configuration: ModalSheetPresentationConfiguration.nova)
+        let factory = ModalPickerPresentationFactory(configuration: ModalSheetPresentationConfiguration.nova)
         viewController.modalTransitioningFactory = factory
 
         let height = viewController.headerHeight + CGFloat(options.count) * viewController.cellHeight +
@@ -170,7 +170,7 @@ enum ModalPickerFactory {
             }
         }
 
-        let factory = ModalSheetPresentationFactory(configuration: ModalSheetPresentationConfiguration.nova)
+        let factory = ModalPickerPresentationFactory(configuration: ModalSheetPresentationConfiguration.nova)
         viewController.modalTransitioningFactory = factory
 
         let height = viewController.headerHeight + CGFloat(types.count) * viewController.cellHeight +
@@ -218,7 +218,7 @@ enum ModalPickerFactory {
             return optViewModel.map { viewModel in LocalizableResource { _ in viewModel } }
         }
 
-        let factory = ModalSheetPresentationFactory(configuration: .nova)
+        let factory = ModalPickerPresentationFactory(configuration: .nova)
         viewController.modalTransitioningFactory = factory
 
         let height = viewController.headerHeight + CGFloat(accounts.count) * viewController.cellHeight +
@@ -261,7 +261,7 @@ enum ModalPickerFactory {
             }
         }
 
-        let factory = ModalSheetPresentationFactory(configuration: .nova)
+        let factory = ModalPickerPresentationFactory(configuration: .nova)
         viewController.modalTransitioningFactory = factory
 
         let height = viewController.headerHeight + CGFloat(items.count) * viewController.cellHeight +
@@ -302,7 +302,7 @@ enum ModalPickerFactory {
 
         viewController.viewModels = items
 
-        let factory = ModalSheetPresentationFactory(configuration: .nova)
+        let factory = ModalPickerPresentationFactory(configuration: .nova)
         viewController.modalTransitioningFactory = factory
 
         let height = viewController.headerHeight + CGFloat(items.count) * viewController.cellHeight +
@@ -380,7 +380,7 @@ enum ModalPickerFactory {
 
         viewController.viewModels = items
 
-        let factory = ModalSheetPresentationFactory(configuration: .nova)
+        let factory = ModalPickerPresentationFactory(configuration: .nova)
         viewController.modalTransitioningFactory = factory
 
         let itemsCount = actionViewModel != nil ? items.count + 1 : items.count
@@ -425,7 +425,7 @@ enum ModalPickerFactory {
 
         viewController.viewModels = items
 
-        let factory = ModalSheetPresentationFactory(configuration: .nova)
+        let factory = ModalPickerPresentationFactory(configuration: .nova)
         viewController.modalTransitioningFactory = factory
 
         let height = viewController.headerHeight + CGFloat(items.count) * viewController.cellHeight +
@@ -460,7 +460,7 @@ extension ModalPickerFactory {
         viewController.viewModels = items
         viewController.selectedIndex = selectedIndex
 
-        let factory = ModalSheetPresentationFactory(configuration: .nova)
+        let factory = ModalPickerPresentationFactory(configuration: .nova)
         viewController.modalTransitioningFactory = factory
 
         let height = viewController.headerHeight + CGFloat(items.count) * viewController.cellHeight +
@@ -497,7 +497,7 @@ extension ModalPickerFactory {
         viewController.selectedIndex = selectedIndex ?? NSNotFound
         viewController.context = context
 
-        let factory = ModalSheetPresentationFactory(configuration: .nova)
+        let factory = ModalPickerPresentationFactory(configuration: .nova)
         viewController.modalTransitioningFactory = factory
 
         let height = viewController.headerHeight + CGFloat(items.count) * viewController.cellHeight +
@@ -552,7 +552,7 @@ extension ModalPickerFactory {
             }
         }
 
-        let factory = ModalSheetPresentationFactory(configuration: ModalSheetPresentationConfiguration.nova)
+        let factory = ModalPickerPresentationFactory(configuration: ModalSheetPresentationConfiguration.nova)
         viewController.modalTransitioningFactory = factory
 
         let height = viewController.headerHeight + CGFloat(operations.count) * viewController.cellHeight +

--- a/novawallet/Common/ViewController/ModalPicker/ModalPickerPresentationController.swift
+++ b/novawallet/Common/ViewController/ModalPicker/ModalPickerPresentationController.swift
@@ -1,0 +1,315 @@
+import UIKit
+import SoraUI
+
+// TODO: Remove after migration to UIKit-iOS
+class ModalPickerPresentationController: UIPresentationController {
+    let configuration: ModalSheetPresentationConfiguration
+
+    private var backgroundView: UIView?
+    private var headerView: RoundedView?
+    private var headerIndicatorView: RoundedView?
+
+    var interactiveDismissal: UIPercentDrivenInteractiveTransition?
+    var initialTranslation: CGPoint = .zero
+
+    var presenterDelegate: ModalPresenterDelegate? {
+        (presentedViewController as? ModalPresenterDelegate) ??
+            (presentedView as? ModalPresenterDelegate) ??
+            (presentedViewController.view as? ModalPresenterDelegate)
+    }
+
+    var sheetPresenterDelegate: ModalSheetPresenterDelegate? {
+        presenterDelegate as? ModalSheetPresenterDelegate
+    }
+
+    var inputView: ModalViewProtocol? {
+        (presentedViewController as? ModalViewProtocol) ??
+            (presentedView as? ModalViewProtocol) ??
+            (presentedViewController.view as? ModalViewProtocol)
+    }
+
+    init(
+        presentedViewController: UIViewController,
+        presenting presentingViewController: UIViewController?,
+        configuration: ModalSheetPresentationConfiguration
+    ) {
+        self.configuration = configuration
+
+        super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
+
+        if let modalInputView = inputView {
+            modalInputView.presenter = self
+        }
+    }
+
+    private func configureBackgroundView(on view: UIView) {
+        if let currentBackgroundView = backgroundView {
+            view.insertSubview(currentBackgroundView, at: 0)
+        } else {
+            let newBackgroundView = UIView(frame: view.bounds)
+
+            newBackgroundView.backgroundColor = configuration.style.backdropColor
+
+            view.insertSubview(newBackgroundView, at: 0)
+            backgroundView = newBackgroundView
+        }
+
+        backgroundView?.frame = view.bounds
+    }
+
+    private func configureHeaderView(on view: UIView, style: ModalSheetPresentationHeaderStyle) {
+        let width = containerView?.bounds.width ?? view.bounds.width
+
+        if let headerView = headerView {
+            view.insertSubview(headerView, at: 0)
+        } else {
+            let baseView = RoundedView()
+            baseView.cornerRadius = style.cornerRadius
+            baseView.roundingCorners = [.topLeft, .topRight]
+            baseView.fillColor = style.backgroundColor
+            baseView.highlightedFillColor = style.backgroundColor
+            baseView.shadowOpacity = 0.0
+
+            let indicator = RoundedView()
+            indicator.roundingCorners = .allCorners
+            indicator.cornerRadius = style.indicatorSize.height / 2.0
+            indicator.fillColor = style.indicatorColor
+            indicator.highlightedFillColor = style.indicatorColor
+            indicator.shadowOpacity = 0.0
+
+            baseView.addSubview(indicator)
+
+            view.insertSubview(baseView, at: 0)
+
+            headerIndicatorView = indicator
+            headerView = baseView
+        }
+
+        configureHeaderFrame(for: style, preferredWidth: width)
+    }
+
+    private func configureHeaderFrame(for style: ModalSheetPresentationHeaderStyle, preferredWidth: CGFloat) {
+        let indicatorX = preferredWidth / 2.0 - style.indicatorSize.width / 2.0
+        headerIndicatorView?.frame = CGRect(origin: CGPoint(x: indicatorX, y: style.indicatorVerticalOffset), size: style.indicatorSize)
+
+        headerView?.frame = CGRect(
+            x: 0.0,
+            y: -style.preferredHeight + 0.5,
+            width: preferredWidth,
+            height: style.preferredHeight
+        )
+    }
+
+    private func attachCancellationGesture() {
+        let cancellationGesture = UITapGestureRecognizer(
+            target: self,
+            action: #selector(actionDidCancel(gesture:))
+        )
+        backgroundView?.addGestureRecognizer(cancellationGesture)
+    }
+
+    private func attachPanGesture() {
+        let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(didPan(sender:)))
+        containerView?.addGestureRecognizer(panGestureRecognizer)
+        panGestureRecognizer.delegate = self
+    }
+
+    // MARK: Presentation overridings
+
+    override func presentationTransitionWillBegin() {
+        guard let containerView = containerView else {
+            return
+        }
+
+        configureBackgroundView(on: containerView)
+
+        if let headerStyle = configuration.style.headerStyle {
+            configureHeaderView(on: presentedViewController.view, style: headerStyle)
+        }
+
+        attachCancellationGesture()
+        attachPanGesture()
+
+        animateBackgroundAlpha(fromValue: 0.0, toValue: 1.0)
+    }
+
+    override func dismissalTransitionWillBegin() {
+        animateBackgroundAlpha(fromValue: 1.0, toValue: 0.0)
+    }
+
+    override func containerViewWillLayoutSubviews() {
+        super.containerViewWillLayoutSubviews()
+
+        guard let containerView = containerView else {
+            return
+        }
+
+        backgroundView?.frame = containerView.bounds
+
+        if let headerStyle = configuration.style.headerStyle {
+            configureHeaderFrame(for: headerStyle, preferredWidth: containerView.bounds.width)
+        }
+
+        let presentedFrame = frameOfPresentedViewInContainerView
+        presentedViewController.view.frame = presentedFrame
+    }
+
+    override var frameOfPresentedViewInContainerView: CGRect {
+        guard let containerView = containerView else {
+            return .zero
+        }
+
+        let layoutFrame: CGRect
+        let bottomOffset: CGFloat
+        var maximumHeight = containerView.frame.size.height
+        if #available(iOS 11.0, *) {
+            if configuration.extendUnderSafeArea {
+                layoutFrame = containerView.bounds
+                bottomOffset = containerView.safeAreaInsets.bottom
+                maximumHeight -= containerView.safeAreaInsets.top
+            } else {
+                layoutFrame = containerView.safeAreaLayoutGuide.layoutFrame
+                bottomOffset = 0.0
+            }
+        } else {
+            layoutFrame = containerView.bounds
+            bottomOffset = 0.0
+        }
+        maximumHeight -= bottomOffset
+
+        let preferredSize = presentedViewController.preferredContentSize
+        let layoutWidth = preferredSize.width > 0.0 ? preferredSize.width : layoutFrame.width
+        let layoutHeight = preferredSize.height > 0.0 ? preferredSize.height + bottomOffset : layoutFrame.height
+        let height = min(layoutHeight, maximumHeight)
+
+        return CGRect(
+            x: layoutFrame.minX,
+            y: layoutFrame.maxY - height,
+            width: layoutWidth,
+            height: height
+        )
+    }
+
+    // MARK: Animation
+
+    func animateBackgroundAlpha(fromValue: CGFloat, toValue: CGFloat) {
+        backgroundView?.alpha = fromValue
+
+        let animationBlock: (UIViewControllerTransitionCoordinatorContext) -> Void = { _ in
+            self.backgroundView?.alpha = toValue
+        }
+
+        presentingViewController.transitionCoordinator?
+            .animate(alongsideTransition: animationBlock, completion: nil)
+    }
+
+    func dismiss(animated: Bool, completion: (() -> Void)? = nil) {
+        presentedViewController.dismiss(animated: animated, completion: completion)
+    }
+
+    // MARK: Action
+
+    @objc func actionDidCancel(gesture _: UITapGestureRecognizer) {
+        guard let presenterDelegate = presenterDelegate else {
+            dismiss(animated: true)
+            return
+        }
+
+        if presenterDelegate.presenterShouldHide(self) {
+            dismiss(animated: true)
+            presenterDelegate.presenterDidHide(self)
+        }
+    }
+
+    // MARK: Interactive dismissal
+
+    @objc func didPan(sender: Any?) {
+        guard let panGestureRecognizer = sender as? UIPanGestureRecognizer else { return }
+        guard let view = panGestureRecognizer.view else { return }
+
+        handlePan(from: panGestureRecognizer, on: view)
+    }
+
+    private func handlePan(from panGestureRecognizer: UIPanGestureRecognizer, on view: UIView) {
+        let translation = panGestureRecognizer.translation(in: view)
+        let velocity = panGestureRecognizer.velocity(in: view)
+
+        switch panGestureRecognizer.state {
+        case .began, .changed:
+            if sheetPresenterDelegate?.presenterCanDrag(self) == false {
+                return
+            }
+            if let interactiveDismissal = interactiveDismissal {
+                let progress = min(1.0, max(0.0, (translation.y - initialTranslation.y) / max(1.0, view.bounds.size.height)))
+
+                interactiveDismissal.update(progress)
+            } else {
+                if let presenterDelegate = presenterDelegate, !presenterDelegate.presenterShouldHide(self) {
+                    break
+                }
+
+                interactiveDismissal = UIPercentDrivenInteractiveTransition()
+                initialTranslation = translation
+                presentedViewController.dismiss(animated: true)
+            }
+        case .cancelled, .ended:
+            if let interactiveDismissal = interactiveDismissal {
+                let thresholdReached = interactiveDismissal.percentComplete >= configuration.dismissPercentThreshold
+                let shouldDismiss = (thresholdReached && velocity.y >= 0) ||
+                    (velocity.y >= configuration.dismissVelocityThreshold && translation.y >= configuration.dismissMinimumOffset)
+                stopPullToDismiss(finished: panGestureRecognizer.state != .cancelled && shouldDismiss)
+            }
+        default:
+            break
+        }
+    }
+
+    private func stopPullToDismiss(finished: Bool) {
+        guard let interactiveDismissal = interactiveDismissal else {
+            return
+        }
+
+        self.interactiveDismissal = nil
+
+        if finished {
+            interactiveDismissal.completionSpeed = configuration.dismissFinishSpeedFactor
+            interactiveDismissal.finish()
+
+            presenterDelegate?.presenterDidHide(self)
+        } else {
+            interactiveDismissal.completionSpeed = configuration.dismissCancelSpeedFactor
+            interactiveDismissal.cancel()
+        }
+    }
+}
+
+extension ModalPickerPresentationController: ModalPickerPresenterProtocol {
+    func hide(view _: any SoraUI.ModalViewProtocol, animated: Bool, completion: @escaping () -> Void) {
+        guard interactiveDismissal == nil else {
+            return
+        }
+
+        dismiss(animated: animated, completion: completion)
+    }
+
+    func hide(view _: ModalViewProtocol, animated: Bool) {
+        guard interactiveDismissal == nil else {
+            return
+        }
+
+        dismiss(animated: animated)
+    }
+}
+
+extension ModalPickerPresentationController: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(
+        _: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith _: UIGestureRecognizer
+    ) -> Bool {
+        true
+    }
+}
+
+protocol ModalPickerPresenterProtocol: ModalPresenterProtocol {
+    func hide(view: ModalViewProtocol, animated: Bool, completion: @escaping () -> Void)
+}

--- a/novawallet/Common/ViewController/ModalPicker/ModalPickerPresentationFactory.swift
+++ b/novawallet/Common/ViewController/ModalPicker/ModalPickerPresentationFactory.swift
@@ -1,0 +1,53 @@
+import UIKit
+import SoraUI
+
+// TODO: Remove after migration to UIKit-iOS
+public class ModalPickerPresentationFactory: NSObject {
+    let configuration: ModalSheetPresentationConfiguration
+
+    weak var presentation: ModalPickerPresentationController?
+
+    public init(configuration: ModalSheetPresentationConfiguration) {
+        self.configuration = configuration
+
+        super.init()
+    }
+}
+
+extension ModalPickerPresentationFactory: UIViewControllerTransitioningDelegate {
+    public func animationController(
+        forPresented _: UIViewController,
+        presenting _: UIViewController,
+        source _: UIViewController
+    ) -> UIViewControllerAnimatedTransitioning? {
+        ModalSheetPresentationAppearanceAnimator(animator: configuration.contentAppearanceAnimator)
+    }
+
+    public func animationController(forDismissed _: UIViewController)
+        -> UIViewControllerAnimatedTransitioning? {
+        ModalSheetPresentationDismissAnimator(
+            animator: configuration.contentDissmisalAnimator,
+            finalPositionOffset: configuration.style.headerStyle?.preferredHeight ?? 0.0
+        )
+    }
+
+    public func presentationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController?,
+        source _: UIViewController
+    ) -> UIPresentationController? {
+        let presentation = ModalPickerPresentationController(
+            presentedViewController: presented,
+            presenting: presenting,
+            configuration: configuration
+        )
+
+        self.presentation = presentation
+
+        return presentation
+    }
+
+    public func interactionControllerForDismissal(using _: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
+        presentation?.interactiveDismissal
+    }
+}

--- a/novawallet/Common/ViewController/ModalPicker/ModalPickerViewController.swift
+++ b/novawallet/Common/ViewController/ModalPicker/ModalPickerViewController.swift
@@ -188,8 +188,8 @@ class ModalPickerViewController<C: UITableViewCell & ModalPickerCellProtocol, T>
         guard let presenter = presenter as? ModalPickerPresenterProtocol else { return }
 
         if indexPath.section == 0, actionType.hasAction {
-            presenter.hide(view: self, animated: true) { [weak self] in
-                self?.delegate?.modalPickerDidSelectAction(context: self?.context)
+            presenter.hide(view: self, animated: true) {
+                self.delegate?.modalPickerDidSelectAction(context: self.context)
             }
         } else {
             let itemSectionIndex = actionType.hasAction ? indexPath.section - 1 : indexPath.section
@@ -206,16 +206,18 @@ class ModalPickerViewController<C: UITableViewCell & ModalPickerCellProtocol, T>
                 selectedIndex = indexPath.row
                 selectedSection = itemSectionIndex
 
-                presenter.hide(view: self, animated: true) { [weak self] in
-                    guard let self else { return }
-                    if sections.count > 1 {
-                        delegate?.modalPickerDidSelectModel(
-                            at: selectedIndex,
-                            section: selectedSection,
-                            context: context
+                presenter.hide(view: self, animated: true) {
+                    if self.sections.count > 1 {
+                        self.delegate?.modalPickerDidSelectModel(
+                            at: self.selectedIndex,
+                            section: self.selectedSection,
+                            context: self.context
                         )
                     } else {
-                        delegate?.modalPickerDidSelectModelAtIndex(selectedIndex, context: context)
+                        self.delegate?.modalPickerDidSelectModelAtIndex(
+                            self.selectedIndex,
+                            context: self.context
+                        )
                     }
                 }
             }

--- a/novawallet/Common/ViewController/ModalPicker/ModalPickerViewController.swift
+++ b/novawallet/Common/ViewController/ModalPicker/ModalPickerViewController.swift
@@ -184,9 +184,13 @@ class ModalPickerViewController<C: UITableViewCell & ModalPickerCellProtocol, T>
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
+        // TODO: Fix after migration to UIKit-iOS
+        guard let presenter = presenter as? ModalPickerPresenterProtocol else { return }
+
         if indexPath.section == 0, actionType.hasAction {
-            delegate?.modalPickerDidSelectAction(context: context)
-            presenter?.hide(view: self, animated: true)
+            presenter.hide(view: self, animated: true) { [weak self] in
+                self?.delegate?.modalPickerDidSelectAction(context: self?.context)
+            }
         } else {
             let itemSectionIndex = actionType.hasAction ? indexPath.section - 1 : indexPath.section
 
@@ -202,16 +206,17 @@ class ModalPickerViewController<C: UITableViewCell & ModalPickerCellProtocol, T>
                 selectedIndex = indexPath.row
                 selectedSection = itemSectionIndex
 
-                presenter?.hide(view: self, animated: true)
-
-                if sections.count > 1 {
-                    delegate?.modalPickerDidSelectModel(
-                        at: selectedIndex,
-                        section: selectedSection,
-                        context: context
-                    )
-                } else {
-                    delegate?.modalPickerDidSelectModelAtIndex(selectedIndex, context: context)
+                presenter.hide(view: self, animated: true) { [weak self] in
+                    guard let self else { return }
+                    if sections.count > 1 {
+                        delegate?.modalPickerDidSelectModel(
+                            at: selectedIndex,
+                            section: selectedSection,
+                            context: context
+                        )
+                    } else {
+                        delegate?.modalPickerDidSelectModelAtIndex(selectedIndex, context: context)
+                    }
                 }
             }
         }

--- a/novawallet/Modules/Staking/Parachain/ParaStkStakeSetup/ParaStkStakeSetupPresenter.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkStakeSetup/ParaStkStakeSetupPresenter.swift
@@ -502,9 +502,7 @@ extension ParaStkStakeSetupPresenter: ModalPickerViewControllerDelegate {
     }
 
     func modalPickerDidSelectAction(context _: AnyObject?) {
-        DispatchQueue.main.async {
-            self.wireframe.showCollatorSelection(from: self.view, delegate: self)
-        }
+        wireframe.showCollatorSelection(from: view, delegate: self)
     }
 }
 

--- a/novawallet/Modules/Staking/Parachain/ParaStkStakeSetup/ParaStkStakeSetupWireframe.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkStakeSetup/ParaStkStakeSetupWireframe.swift
@@ -40,7 +40,10 @@ final class ParaStkStakeSetupWireframe: ParaStkStakeSetupWireframeProtocol {
             return
         }
 
-        view?.controller.navigationController?.pushViewController(collatorsView.controller, animated: true)
+        view?.controller.navigationController?.pushViewController(
+            collatorsView.controller,
+            animated: true
+        )
     }
 
     func showDelegationSelection(


### PR DESCRIPTION
### SUMMARY
This PR introduces a short-time fix for `ModalPickerViewController` dismissal behavior by synchronizing dismiss and delegate calls via completion closure.

### SOLUTION

- Introduce `ModalPickerPresentationController` that is identical to `ModalPickerPresentationController` except of dismissing logic
- Introduce `ModalPickerPresentationFactory`