### PR TITLE
Fix modal presentation without root container

### DIFF
--- a/novawallet/Common/ViewController/ModalCard/UIViewController+PresentCardLayout.swift
+++ b/novawallet/Common/ViewController/ModalCard/UIViewController+PresentCardLayout.swift
@@ -7,9 +7,10 @@ extension UIViewController {
         animated: Bool,
         completion: (() -> Void)? = nil
     ) {
-        let contextRootViewController = viewController.tabBarController ?? UIApplication.shared.rootContainer
-
-        guard let contextRootViewController else { return }
+        let contextRootViewController = viewController.tabBarController
+            ?? UIApplication.shared.rootContainer
+            ?? viewController.navigationController
+            ?? viewController
 
         let appearanceAnimator = BlockViewAnimator(
             duration: 0.25,


### PR DESCRIPTION
### SUMMARY
The problem is current implementation of `ModalCardPresentation` can't be used by `presentWithCardLayout` if there is no root container such UITabBarController or NovaMainAppContainerViewController. This PR fixes the problem.

### SOLUTION
We now use current view controller that wants to present view `presentWithCardLayout` if there is no higher level containers. 