### PR TITLE
[CU-8697j1xuw] Fix address bar spoofing issue

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -392,6 +392,7 @@
 		0C6D66AB2A8C0B6700AAB988 /* BaseSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6D66AA2A8C0B6700AAB988 /* BaseSigner.swift */; };
 		0C6F0C9E2A69723B007170C6 /* StartStakingStateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6F0C9C2A69723B007170C6 /* StartStakingStateProtocol.swift */; };
 		0C6FE8082D4D206100E5B651 /* DAppNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6FE8072D4D206100E5B651 /* DAppNavigation.swift */; };
+		0C6FE80A2D507AB100E5B651 /* URLOriginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6FE8092D507AB100E5B651 /* URLOriginTests.swift */; };
 		0C7071292C1F600F0080DDCD /* OnLauchAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7071282C1F600F0080DDCD /* OnLauchAction.swift */; };
 		0C70712B2C1F60F50080DDCD /* OnLaunchActionsQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C70712A2C1F60F50080DDCD /* OnLaunchActionsQueue.swift */; };
 		0C7104692C2966C000487E64 /* LedgerConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7104682C2966C000487E64 /* LedgerConversionTests.swift */; };
@@ -5786,6 +5787,7 @@
 		0C6D66AA2A8C0B6700AAB988 /* BaseSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseSigner.swift; sourceTree = "<group>"; };
 		0C6F0C9C2A69723B007170C6 /* StartStakingStateProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartStakingStateProtocol.swift; sourceTree = "<group>"; };
 		0C6FE8072D4D206100E5B651 /* DAppNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppNavigation.swift; sourceTree = "<group>"; };
+		0C6FE8092D507AB100E5B651 /* URLOriginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLOriginTests.swift; sourceTree = "<group>"; };
 		0C7071282C1F600F0080DDCD /* OnLauchAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnLauchAction.swift; sourceTree = "<group>"; };
 		0C70712A2C1F60F50080DDCD /* OnLaunchActionsQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnLaunchActionsQueue.swift; sourceTree = "<group>"; };
 		0C7104682C2966C000487E64 /* LedgerConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LedgerConversionTests.swift; sourceTree = "<group>"; };
@@ -22224,6 +22226,7 @@
 				2D8463652C488416007E2986 /* ChainFilterStrategyTests.swift */,
 				842B2FCC2947239B002829B6 /* CoinGeckoUrlParserTests.swift */,
 				840D627029CB3FD900D5E894 /* URLBuilderTests.swift */,
+				0C6FE8092D507AB100E5B651 /* URLOriginTests.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -30818,6 +30821,7 @@
 				84B7C73B289BFA79001A3566 /* StakingUnbondConfirmTests.swift in Sources */,
 				842A738E27DEF592006EE1EA /* AssetTransactionGenerator.swift in Sources */,
 				84CE69ED25667A5600559427 /* ByteLengthEncodingTests.swift in Sources */,
+				0C6FE80A2D507AB100E5B651 /* URLOriginTests.swift in Sources */,
 				843461FA290E55D100379936 /* GovernanceUnlocksTestBuilding.swift in Sources */,
 				84B7C73D289BFA79001A3566 /* StakingPayoutsConfirmTests.swift in Sources */,
 				84B7C72E289BFA79001A3566 /* CustomValidatorListTestDataGenerator.swift in Sources */,

--- a/novawallet/Common/Extension/Foundation/URL+Helpers.swift
+++ b/novawallet/Common/Extension/Foundation/URL+Helpers.swift
@@ -16,4 +16,8 @@ extension URL {
 
         return host.caseInsensitiveCompare(otherHost) == .orderedSame
     }
+
+    static func hasSameOrigin(_ lhs: URL, _ rhs: URL) -> Bool {
+        lhs.scheme == rhs.scheme && lhs.host == rhs.host && lhs.port == rhs.port
+    }
 }

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserPresenter.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserPresenter.swift
@@ -115,9 +115,10 @@ extension DAppBrowserPresenter: DAppBrowserPresenterProtocol {
 
     func process(
         message: Any,
-        host: String,
         transport name: String
     ) {
+        let host = browserPage?.url.host ?? ""
+
         interactor.process(
             message: message,
             host: host,

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserProtocols.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserProtocols.swift
@@ -27,11 +27,7 @@ protocol DAppBrowserPresenterProtocol: AnyObject {
 
     func process(page: DAppBrowserPage)
 
-    func process(
-        message: Any,
-        host: String,
-        transport name: String
-    )
+    func process(message: Any, transport name: String)
 
     func process(stateRender: DAppBrowserTabRenderProtocol)
 

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserViewController.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserViewController.swift
@@ -586,6 +586,10 @@ extension DAppBrowserViewController: WKUIDelegate, WKNavigationDelegate {
         didChangeUrl(url)
     }
 
+    func webView(_: WKWebView, didFinish _: WKNavigation!) {
+        presenter.didLoadPage()
+    }
+
     func webView(
         _ webView: WKWebView,
         createWebViewWith _: WKWebViewConfiguration,

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserViewController.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserViewController.swift
@@ -144,11 +144,19 @@ private extension DAppBrowserViewController {
 
     func configureObservers() {
         urlObservation = rootView.webView?.observe(\.url, options: [.initial, .new]) { [weak self] _, change in
-            guard let newValue = change.newValue, let url = newValue else {
+            // allow to change url here only for the same origin to prevent spoofing
+            // https://github.com/mozilla-mobile/firefox-ios/wiki/WKWebView-navigation-and-security-considerations
+            guard
+                let oldValue = change.oldValue,
+                let newValue = change.newValue,
+                let oldUrl = oldValue,
+                let newUrl = newValue,
+                URL.hasSameOrigin(oldUrl, newUrl) else {
+                // didCommit delegate should catch origin change
                 return
             }
 
-            self?.didChangeUrl(url)
+            self?.didChangeUrl(newUrl)
         }
 
         goBackObservation = rootView.webView?.observe(
@@ -171,17 +179,6 @@ private extension DAppBrowserViewController {
             }
 
             self?.didChangeGoForward(newValue)
-        }
-
-        titleObservation = rootView.webView?.observe(
-            \.title,
-            options: [.initial, .new]
-        ) { [weak self] _, change in
-            guard let newValue = change.newValue, let title = newValue else {
-                return
-            }
-
-            self?.didChangeTitle(title)
         }
     }
 
@@ -215,15 +212,6 @@ private extension DAppBrowserViewController {
         rootView.settingsBarButton.action = #selector(actionSettings)
 
         rootView.urlBar.addTarget(self, action: #selector(actionSearch), for: .touchUpInside)
-    }
-
-    func didChangeTitle(_ title: String) {
-        guard let url = rootView.webView?.url else {
-            return
-        }
-
-        let page = DAppBrowserPage(url: url, title: title)
-        presenter.process(page: page)
     }
 
     func didChangeUrl(_ newUrl: URL) {
@@ -448,9 +436,7 @@ private extension DAppBrowserViewController {
 
 extension DAppBrowserViewController: DAppBrowserScriptHandlerDelegate {
     func browserScriptHandler(_: DAppBrowserScriptHandler, didReceive message: WKScriptMessage) {
-        let host = rootView.webView?.url?.host ?? ""
-
-        presenter.process(message: message.body, host: host, transport: message.name)
+        presenter.process(message: message.body, transport: message.name)
     }
 }
 
@@ -592,11 +578,12 @@ extension DAppBrowserViewController: WKUIDelegate, WKNavigationDelegate {
         }
     }
 
-    func webView(
-        _: WKWebView,
-        didFinish _: WKNavigation!
-    ) {
-        presenter.didLoadPage()
+    func webView(_ webView: WKWebView, didCommit _: WKNavigation) {
+        guard let url = webView.url else {
+            return
+        }
+
+        didChangeUrl(url)
     }
 
     func webView(

--- a/novawalletTests/Common/Helpers/URLOriginTests.swift
+++ b/novawalletTests/Common/Helpers/URLOriginTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import novawallet
+
+final class URLOriginTests: XCTestCase {
+
+    func testOriginsComparison() {
+        performTest(str1: "https://host:20/path", str2: "https://host:20/path", sameOrigin: true)
+        performTest(str1: "https://host:20/path", str2: "https://host:20/path?q=5", sameOrigin: true)
+        performTest(str1: "https://host:20/path", str2: "https://host:20/path/p2?q=5", sameOrigin: true)
+        performTest(str1: "https://host:20/path", str2: "https://host:10/path", sameOrigin: false)
+        performTest(str1: "https://host:20/path", str2: "http://host:20/path", sameOrigin: false)
+        performTest(str1: "https://host:20/path", str2: "https://hst:20/path", sameOrigin: false)
+    }
+    
+    private func performTest(str1: String, str2: String, sameOrigin: Bool) {
+        let url1 = URL(string: str1)!
+        let url2 = URL(string: str2)!
+        
+        if sameOrigin {
+            XCTAssertTrue(URL.hasSameOrigin(url1, url2))
+        } else {
+            XCTAssertFalse(URL.hasSameOrigin(url1, url2))
+        }
+    }
+}

--- a/novawalletTests/Mocks/ModuleMocks.swift
+++ b/novawalletTests/Mocks/ModuleMocks.swift
@@ -4880,16 +4880,16 @@ import Operation_iOS
     
     
     
-     func process(message: Any, host: String, transport name: String)  {
+     func process(message: Any, transport name: String)  {
         
-    return cuckoo_manager.call("process(message: Any, host: String, transport: String)",
-            parameters: (message, host, name),
-            escapingParameters: (message, host, name),
+    return cuckoo_manager.call("process(message: Any, transport: String)",
+            parameters: (message, name),
+            escapingParameters: (message, name),
             superclassCall:
                 
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
-            defaultCall: __defaultImplStub!.process(message: message, host: host, transport: name))
+            defaultCall: __defaultImplStub!.process(message: message, transport: name))
         
     }
     
@@ -5022,9 +5022,9 @@ import Operation_iOS
 	        return .init(stub: cuckoo_manager.createStub(for: MockDAppBrowserPresenterProtocol.self, method: "process(page: DAppBrowserPage)", parameterMatchers: matchers))
 	    }
 	    
-	    func process<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(message: M1, host: M2, transport name: M3) -> Cuckoo.ProtocolStubNoReturnFunction<(Any, String, String)> where M1.MatchedType == Any, M2.MatchedType == String, M3.MatchedType == String {
-	        let matchers: [Cuckoo.ParameterMatcher<(Any, String, String)>] = [wrap(matchable: message) { $0.0 }, wrap(matchable: host) { $0.1 }, wrap(matchable: name) { $0.2 }]
-	        return .init(stub: cuckoo_manager.createStub(for: MockDAppBrowserPresenterProtocol.self, method: "process(message: Any, host: String, transport: String)", parameterMatchers: matchers))
+	    func process<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(message: M1, transport name: M2) -> Cuckoo.ProtocolStubNoReturnFunction<(Any, String)> where M1.MatchedType == Any, M2.MatchedType == String {
+	        let matchers: [Cuckoo.ParameterMatcher<(Any, String)>] = [wrap(matchable: message) { $0.0 }, wrap(matchable: name) { $0.1 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockDAppBrowserPresenterProtocol.self, method: "process(message: Any, transport: String)", parameterMatchers: matchers))
 	    }
 	    
 	    func process<M1: Cuckoo.Matchable>(stateRender: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(DAppBrowserTabRenderProtocol)> where M1.MatchedType == DAppBrowserTabRenderProtocol {
@@ -5097,9 +5097,9 @@ import Operation_iOS
 	    }
 	    
 	    @discardableResult
-	    func process<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(message: M1, host: M2, transport name: M3) -> Cuckoo.__DoNotUse<(Any, String, String), Void> where M1.MatchedType == Any, M2.MatchedType == String, M3.MatchedType == String {
-	        let matchers: [Cuckoo.ParameterMatcher<(Any, String, String)>] = [wrap(matchable: message) { $0.0 }, wrap(matchable: host) { $0.1 }, wrap(matchable: name) { $0.2 }]
-	        return cuckoo_manager.verify("process(message: Any, host: String, transport: String)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    func process<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(message: M1, transport name: M2) -> Cuckoo.__DoNotUse<(Any, String), Void> where M1.MatchedType == Any, M2.MatchedType == String {
+	        let matchers: [Cuckoo.ParameterMatcher<(Any, String)>] = [wrap(matchable: message) { $0.0 }, wrap(matchable: name) { $0.1 }]
+	        return cuckoo_manager.verify("process(message: Any, transport: String)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
 	    }
 	    
 	    @discardableResult
@@ -5173,7 +5173,7 @@ import Operation_iOS
     
     
     
-     func process(message: Any, host: String, transport name: String)   {
+     func process(message: Any, transport name: String)   {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
@@ -6485,21 +6485,6 @@ import SubstrateSdk
         
     }
     
-    
-    
-     func didReceiveDApp(with id: String)  {
-        
-    return cuckoo_manager.call("didReceiveDApp(with: String)",
-            parameters: (id),
-            escapingParameters: (id),
-            superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
-            defaultCall: __defaultImplStub!.didReceiveDApp(with: id))
-        
-    }
-    
 
 	 struct __StubbingProxy_DAppListViewProtocol: Cuckoo.StubbingProxy {
 	    private let cuckoo_manager: Cuckoo.MockManager
@@ -6527,11 +6512,6 @@ import SubstrateSdk
 	    func didReceive<M1: Cuckoo.Matchable>(_ sections: M1) -> Cuckoo.ProtocolStubNoReturnFunction<([DAppListSectionViewModel])> where M1.MatchedType == [DAppListSectionViewModel] {
 	        let matchers: [Cuckoo.ParameterMatcher<([DAppListSectionViewModel])>] = [wrap(matchable: sections) { $0 }]
 	        return .init(stub: cuckoo_manager.createStub(for: MockDAppListViewProtocol.self, method: "didReceive(_: [DAppListSectionViewModel])", parameterMatchers: matchers))
-	    }
-	    
-	    func didReceiveDApp<M1: Cuckoo.Matchable>(with id: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(String)> where M1.MatchedType == String {
-	        let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: id) { $0 }]
-	        return .init(stub: cuckoo_manager.createStub(for: MockDAppListViewProtocol.self, method: "didReceiveDApp(with: String)", parameterMatchers: matchers))
 	    }
 	    
 	}
@@ -6570,12 +6550,6 @@ import SubstrateSdk
 	    func didReceive<M1: Cuckoo.Matchable>(_ sections: M1) -> Cuckoo.__DoNotUse<([DAppListSectionViewModel]), Void> where M1.MatchedType == [DAppListSectionViewModel] {
 	        let matchers: [Cuckoo.ParameterMatcher<([DAppListSectionViewModel])>] = [wrap(matchable: sections) { $0 }]
 	        return cuckoo_manager.verify("didReceive(_: [DAppListSectionViewModel])", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
-	    }
-	    
-	    @discardableResult
-	    func didReceiveDApp<M1: Cuckoo.Matchable>(with id: M1) -> Cuckoo.__DoNotUse<(String), Void> where M1.MatchedType == String {
-	        let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: id) { $0 }]
-	        return cuckoo_manager.verify("didReceiveDApp(with: String)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
 	    }
 	    
 	}
@@ -6617,9 +6591,96 @@ import SubstrateSdk
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
+}
+
+
+
+ class MockDAppOpenViewProtocol: DAppOpenViewProtocol, Cuckoo.ProtocolMock {
+    
+     typealias MocksType = DAppOpenViewProtocol
+    
+     typealias Stubbing = __StubbingProxy_DAppOpenViewProtocol
+     typealias Verification = __VerificationProxy_DAppOpenViewProtocol
+
+     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
+
+    
+    private var __defaultImplStub: DAppOpenViewProtocol?
+
+     func enableDefaultImplementation(_ stub: DAppOpenViewProtocol) {
+        __defaultImplStub = stub
+        cuckoo_manager.enableDefaultStubImplementation()
+    }
+    
+
+    
+
+    
+
     
     
-     func didReceiveDApp(with id: String)   {
+    
+     func didReceiveDAppNavigation(model: DAppNavigation)  {
+        
+    return cuckoo_manager.call("didReceiveDAppNavigation(model: DAppNavigation)",
+            parameters: (model),
+            escapingParameters: (model),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.didReceiveDAppNavigation(model: model))
+        
+    }
+    
+
+	 struct __StubbingProxy_DAppOpenViewProtocol: Cuckoo.StubbingProxy {
+	    private let cuckoo_manager: Cuckoo.MockManager
+	
+	     init(manager: Cuckoo.MockManager) {
+	        self.cuckoo_manager = manager
+	    }
+	    
+	    
+	    func didReceiveDAppNavigation<M1: Cuckoo.Matchable>(model: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(DAppNavigation)> where M1.MatchedType == DAppNavigation {
+	        let matchers: [Cuckoo.ParameterMatcher<(DAppNavigation)>] = [wrap(matchable: model) { $0 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockDAppOpenViewProtocol.self, method: "didReceiveDAppNavigation(model: DAppNavigation)", parameterMatchers: matchers))
+	    }
+	    
+	}
+
+	 struct __VerificationProxy_DAppOpenViewProtocol: Cuckoo.VerificationProxy {
+	    private let cuckoo_manager: Cuckoo.MockManager
+	    private let callMatcher: Cuckoo.CallMatcher
+	    private let sourceLocation: Cuckoo.SourceLocation
+	
+	     init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+	        self.cuckoo_manager = manager
+	        self.callMatcher = callMatcher
+	        self.sourceLocation = sourceLocation
+	    }
+	
+	    
+	
+	    
+	    @discardableResult
+	    func didReceiveDAppNavigation<M1: Cuckoo.Matchable>(model: M1) -> Cuckoo.__DoNotUse<(DAppNavigation), Void> where M1.MatchedType == DAppNavigation {
+	        let matchers: [Cuckoo.ParameterMatcher<(DAppNavigation)>] = [wrap(matchable: model) { $0 }]
+	        return cuckoo_manager.verify("didReceiveDAppNavigation(model: DAppNavigation)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	}
+}
+
+ class DAppOpenViewProtocolStub: DAppOpenViewProtocol {
+    
+
+    
+
+    
+    
+    
+     func didReceiveDAppNavigation(model: DAppNavigation)   {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
@@ -6770,6 +6831,21 @@ import SubstrateSdk
         
     }
     
+    
+    
+     func provideNavigation(for model: DAppNavigation)  {
+        
+    return cuckoo_manager.call("provideNavigation(for: DAppNavigation)",
+            parameters: (model),
+            escapingParameters: (model),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.provideNavigation(for: model))
+        
+    }
+    
 
 	 struct __StubbingProxy_DAppListPresenterProtocol: Cuckoo.StubbingProxy {
 	    private let cuckoo_manager: Cuckoo.MockManager
@@ -6817,6 +6893,11 @@ import SubstrateSdk
 	    func selectDApp<M1: Cuckoo.Matchable>(with id: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(String)> where M1.MatchedType == String {
 	        let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: id) { $0 }]
 	        return .init(stub: cuckoo_manager.createStub(for: MockDAppListPresenterProtocol.self, method: "selectDApp(with: String)", parameterMatchers: matchers))
+	    }
+	    
+	    func provideNavigation<M1: Cuckoo.Matchable>(for model: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(DAppNavigation)> where M1.MatchedType == DAppNavigation {
+	        let matchers: [Cuckoo.ParameterMatcher<(DAppNavigation)>] = [wrap(matchable: model) { $0 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockDAppListPresenterProtocol.self, method: "provideNavigation(for: DAppNavigation)", parameterMatchers: matchers))
 	    }
 	    
 	}
@@ -6883,6 +6964,12 @@ import SubstrateSdk
 	        return cuckoo_manager.verify("selectDApp(with: String)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
 	    }
 	    
+	    @discardableResult
+	    func provideNavigation<M1: Cuckoo.Matchable>(for model: M1) -> Cuckoo.__DoNotUse<(DAppNavigation), Void> where M1.MatchedType == DAppNavigation {
+	        let matchers: [Cuckoo.ParameterMatcher<(DAppNavigation)>] = [wrap(matchable: model) { $0 }]
+	        return cuckoo_manager.verify("provideNavigation(for: DAppNavigation)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
 	}
 }
 
@@ -6937,6 +7024,12 @@ import SubstrateSdk
     
     
      func selectDApp(with id: String)   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+    
+    
+    
+     func provideNavigation(for model: DAppNavigation)   {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     


### PR DESCRIPTION
## Purpose

This PR moves current URL update logic for the DApp browser to the `webView:didCommit:` from the observer to fix url/title spoofing problem. However we still allow to update url from the observer when previous and current origins are the same - some dapps may use js scripts to navigate between pages that prevent delegate call.