### PR TITLE
remove widget url params

### DIFF
--- a/novawallet/Modules/PayCard/Mercuryo/Hooks/MercuryoCardHookFactory.swift
+++ b/novawallet/Modules/PayCard/Mercuryo/Hooks/MercuryoCardHookFactory.swift
@@ -12,8 +12,6 @@ enum MercuryoCardApi {
     static let type = "sell"
     static let fiatCurrency = "EUR"
     static let fixFiatCurrency = "true"
-    static let fixPaymentMethod = "true"
-    static let paymentMethod = "fiat_card_open"
     static let showSpendCardDetails = "true"
     static let hideRefundAddress = "true"
     static let cardsEndpoint = "https://api.mercuryo.io/v1.6/cards"

--- a/novawallet/Modules/PayCard/Mercuryo/MercuryoCardResourceProvider.swift
+++ b/novawallet/Modules/PayCard/Mercuryo/MercuryoCardResourceProvider.swift
@@ -26,10 +26,6 @@ final class MercuryoCardResourceProvider {
             name: "fiat_currency",
             value: MercuryoCardApi.fiatCurrency
         )
-        let paymentMethodItem = URLQueryItem(
-            name: "payment_method",
-            value: MercuryoCardApi.paymentMethod
-        )
         let themeItem = URLQueryItem(
             name: "theme",
             value: MercuryoCardApi.theme
@@ -37,10 +33,6 @@ final class MercuryoCardResourceProvider {
         let showSpendCardDetails = URLQueryItem(
             name: "show_spend_card_details",
             value: MercuryoCardApi.showSpendCardDetails
-        )
-        let fixPaymentMethodItem = URLQueryItem(
-            name: "fix_payment_method",
-            value: MercuryoCardApi.fixPaymentMethod
         )
         let hideRefundAddressItem = URLQueryItem(
             name: "hide_refund_address",
@@ -58,8 +50,6 @@ final class MercuryoCardResourceProvider {
             showSpendCardDetails,
             currencyItem,
             fiatCurrencyItem,
-            fixPaymentMethodItem,
-            paymentMethodItem,
             hideRefundAddressItem,
             refundAddressItem
         ]


### PR DESCRIPTION
### SUMMARY

`payment_method` and `fix_payment_method` query params are removed from widget URL according to mercuryo team suggestions.