### PR TITLE
Add support for error parsing in ExtrinsicStatusService

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -851,6 +851,9 @@
 		0CEB6B532CA6E92700609DC2 /* VotingPowerSetClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB6B522CA6E92700609DC2 /* VotingPowerSetClosure.swift */; };
 		0CEB6B552CA70CB400609DC2 /* AssetBalance+OpenGov.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB6B542CA70CB400609DC2 /* AssetBalance+OpenGov.swift */; };
 		0CEBAD4E2D5A2BD9000EBA45 /* SwapsDifferenceModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEBAD4D2D5A2BD9000EBA45 /* SwapsDifferenceModelFactory.swift */; };
+		0CEBAD542D5F941E000EBA45 /* CallDispatchErrorDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEBAD532D5F941E000EBA45 /* CallDispatchErrorDecoder.swift */; };
+		0CEBAD562D61A275000EBA45 /* ExtrinsicStatusServiceInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEBAD552D61A275000EBA45 /* ExtrinsicStatusServiceInput.swift */; };
+		0CEBAD5B2D61A90D000EBA45 /* ExtrinsicStatusFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEBAD5A2D61A90D000EBA45 /* ExtrinsicStatusFetchTests.swift */; };
 		0CED3A082BD12DFD00B1E994 /* CloudBackupSecretsExporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED3A072BD12DFD00B1E994 /* CloudBackupSecretsExporting.swift */; };
 		0CED3A0A2BD1677B00B1E994 /* CloudBackupSecretsConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED3A092BD1677B00B1E994 /* CloudBackupSecretsConstants.swift */; };
 		0CED3A0C2BD1762D00B1E994 /* CloudBackupServiceFacadeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED3A0B2BD1762D00B1E994 /* CloudBackupServiceFacadeProtocol.swift */; };
@@ -6282,6 +6285,9 @@
 		0CEB6B522CA6E92700609DC2 /* VotingPowerSetClosure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VotingPowerSetClosure.swift; sourceTree = "<group>"; };
 		0CEB6B542CA70CB400609DC2 /* AssetBalance+OpenGov.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssetBalance+OpenGov.swift"; sourceTree = "<group>"; };
 		0CEBAD4D2D5A2BD9000EBA45 /* SwapsDifferenceModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapsDifferenceModelFactory.swift; sourceTree = "<group>"; };
+		0CEBAD532D5F941E000EBA45 /* CallDispatchErrorDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallDispatchErrorDecoder.swift; sourceTree = "<group>"; };
+		0CEBAD552D61A275000EBA45 /* ExtrinsicStatusServiceInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrinsicStatusServiceInput.swift; sourceTree = "<group>"; };
+		0CEBAD5A2D61A90D000EBA45 /* ExtrinsicStatusFetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrinsicStatusFetchTests.swift; sourceTree = "<group>"; };
 		0CED3A072BD12DFD00B1E994 /* CloudBackupSecretsExporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupSecretsExporting.swift; sourceTree = "<group>"; };
 		0CED3A092BD1677B00B1E994 /* CloudBackupSecretsConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupSecretsConstants.swift; sourceTree = "<group>"; };
 		0CED3A0B2BD1762D00B1E994 /* CloudBackupServiceFacadeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupServiceFacadeProtocol.swift; sourceTree = "<group>"; };
@@ -12174,6 +12180,7 @@
 				0CA8AD5F2CE08FEE00ED9746 /* SubstrateExtrinsicEvents.swift */,
 				0CA8AD602CE08FEE00ED9746 /* SubstrateExtrinsicStatus.swift */,
 				0CA7CEE12CE0BBE9004328F2 /* SubstrateEventsRepository.swift */,
+				0CEBAD552D61A275000EBA45 /* ExtrinsicStatusServiceInput.swift */,
 			);
 			path = ExtrinsicStatusService;
 			sourceTree = "<group>";
@@ -12719,6 +12726,14 @@
 				0CEB6B482CA561AC00609DC2 /* ParachainResolver.swift */,
 			);
 			path = AssetConverters;
+			sourceTree = "<group>";
+		};
+		0CEBAD572D61A8CF000EBA45 /* ExtrinsicStatusFetch */ = {
+			isa = PBXGroup;
+			children = (
+				0CEBAD5A2D61A90D000EBA45 /* ExtrinsicStatusFetchTests.swift */,
+			);
+			path = ExtrinsicStatusFetch;
 			sourceTree = "<group>";
 		};
 		0CF3A6C72CE9422400F93C49 /* View */ = {
@@ -16717,6 +16732,7 @@
 		8438E1D024BFAAD2001BDB13 /* novawalletIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				0CEBAD572D61A8CF000EBA45 /* ExtrinsicStatusFetch */,
 				0C2DA8AB2CC2B120001F79C8 /* AssetsExchange */,
 				0C8FDBA72CAE537800775D7F /* SwipeGov */,
 				0C71046E2C29B60D00487E64 /* MetadataShortener */,
@@ -16831,6 +16847,7 @@
 				8430D6C42800040A00FFB6AE /* EthereumExecuted.swift */,
 				84A3B8A12836DA2600DE2669 /* LastAccountIdKeyWrapper.swift */,
 				847A25BC28D7C0E7006AC9F5 /* TokenTransferedEvent.swift */,
+				0CEBAD532D5F941E000EBA45 /* CallDispatchErrorDecoder.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -25824,6 +25841,7 @@
 				0C2DA8AD2CC2B156001F79C8 /* AssetsExchangeTests.swift in Sources */,
 				8418167728253B120007684A /* ParachainStakingCollatorsTests.swift in Sources */,
 				0CA7198C2B78FEF9000B086E /* HydraQuoteTests.swift in Sources */,
+				0CEBAD5B2D61A90D000EBA45 /* ExtrinsicStatusFetchTests.swift in Sources */,
 				0C7104702C29B62800487E64 /* MetadataHashGenerationTests.swift in Sources */,
 				84F3B27E27F4206B00D64CF5 /* PhishingSitesSyncIntegrationTests.swift in Sources */,
 				846CA7842709C2BE0011124C /* ChainRegistry+Setup.swift in Sources */,
@@ -29621,6 +29639,7 @@
 				77A6F5D22A31DB8C004AFD1A /* JsonCanonicalizer.swift in Sources */,
 				777BD86029F9730F004969A2 /* ReferendumsFilterViewModel.swift in Sources */,
 				0C7104792C2AC0F300487E64 /* InMemoryCaching.swift in Sources */,
+				0CEBAD542D5F941E000EBA45 /* CallDispatchErrorDecoder.swift in Sources */,
 				B61457C5248F3B0E88A7990E /* ParaStkRebondPresenter.swift in Sources */,
 				84E8BA2829FFCA4000FD9F40 /* WalletConnectEthereumTransaction.swift in Sources */,
 				F6F73F4862779FE0B58A7931 /* ParaStkRebondInteractor.swift in Sources */,
@@ -30279,6 +30298,7 @@
 				3D798C32B3C960FC6216C8C9 /* StakingRewardFiltersViewController.swift in Sources */,
 				19055A725FD9C18753B74A52 /* StakingRewardFiltersViewLayout.swift in Sources */,
 				3983EDE80B9296F3A252BA03 /* StakingRewardFiltersViewFactory.swift in Sources */,
+				0CEBAD562D61A275000EBA45 /* ExtrinsicStatusServiceInput.swift in Sources */,
 				CF2F3A0F0999D6D054CD33D2 /* ReferendumSearchProtocols.swift in Sources */,
 				0CE629D62AA9B5E200E250BD /* BalanceViewModel.swift in Sources */,
 				0C2F86982A728EE900593C01 /* NPoolsRewardEngineFactory.swift in Sources */,

--- a/novawallet/Common/Services/AssetExchange/AssetHubExchange/AssetsHubExchangeProvider.swift
+++ b/novawallet/Common/Services/AssetExchange/AssetHubExchange/AssetsHubExchangeProvider.swift
@@ -79,7 +79,8 @@ final class AssetsHubExchangeProvider: AssetsExchangeBaseProvider {
                 statusService: ExtrinsicStatusService(
                     connection: connection,
                     runtimeProvider: runtimeService,
-                    eventsQueryFactory: BlockEventsQueryFactory(operationQueue: operationQueue, logger: logger)
+                    eventsQueryFactory: BlockEventsQueryFactory(operationQueue: operationQueue, logger: logger),
+                    logger: logger
                 ),
                 operationQueue: operationQueue
             )

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/AssetsHydraExchangeProvider.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/AssetsHydraExchangeProvider.swift
@@ -160,7 +160,11 @@ final class AssetsHydraExchangeProvider: AssetsExchangeBaseProvider {
             statusService: ExtrinsicStatusService(
                 connection: connection,
                 runtimeProvider: runtimeService,
-                eventsQueryFactory: BlockEventsQueryFactory(operationQueue: operationQueue, logger: logger)
+                eventsQueryFactory: BlockEventsQueryFactory(
+                    operationQueue: operationQueue,
+                    logger: logger
+                ),
+                logger: logger
             ),
             operationQueue: operationQueue
         )

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicStatusService/ExtrinsicStatusService.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicStatusService/ExtrinsicStatusService.swift
@@ -13,29 +13,86 @@ protocol ExtrinsicStatusServiceProtocol {
 enum ExtrinsicStatusServiceError: Error {
     case extrinsicNotFound(Data)
     case terminateEventNotFound(SubstrateExtrinsicEvents)
+    case errorDecodingFailed
 }
 
 final class ExtrinsicStatusService {
     let connection: JSONRPCEngine
     let runtimeProvider: RuntimeProviderProtocol
     let eventsQueryFactory: BlockEventsQueryFactoryProtocol
+    let logger: LoggerProtocol
 
     init(
         connection: JSONRPCEngine,
         runtimeProvider: RuntimeProviderProtocol,
-        eventsQueryFactory: BlockEventsQueryFactoryProtocol
+        eventsQueryFactory: BlockEventsQueryFactoryProtocol,
+        logger: LoggerProtocol
     ) {
         self.connection = connection
         self.runtimeProvider = runtimeProvider
         self.eventsQueryFactory = eventsQueryFactory
+        self.logger = logger
+    }
+}
+
+private extension ExtrinsicStatusService {
+    private func createSuccessStatus(
+        from events: SubstrateExtrinsicEvents,
+        input: ExtrinsicStatusServiceInput,
+        codingFactory: RuntimeCoderFactoryProtocol
+    ) -> SubstrateExtrinsicStatus {
+        let extString = input.extrinsicHash.toHex(includePrefix: true)
+
+        let events: [Event] = if let interstedEventsMatcher = input.matchingEvents {
+            events.eventRecords.filter {
+                interstedEventsMatcher.match(
+                    event: $0.event,
+                    using: codingFactory
+                )
+            }.map(\.event)
+        } else {
+            []
+        }
+
+        return .success(
+            .init(
+                extrinsicHash: extString,
+                blockHash: input.blockHash,
+                interestedEvents: events
+            )
+        )
+    }
+
+    private func createFailureStatus(
+        from events: SubstrateExtrinsicEvents,
+        input: ExtrinsicStatusServiceInput,
+        codingFactory: RuntimeCoderFactoryProtocol
+    ) throws -> SubstrateExtrinsicStatus {
+        let failMatcher = ExtrinsicFailureEventMatcher()
+
+        guard let failureEvent = events.eventRecords.first(
+            where: { failMatcher.match(event: $0.event, using: codingFactory) }
+        )?.event else {
+            throw ExtrinsicStatusServiceError.terminateEventNotFound(events)
+        }
+
+        let errorDecoderFactory = CallDispatchErrorDecoder(logger: logger)
+
+        guard
+            let dispatchError = errorDecoderFactory.decode(
+                errorParams: failureEvent.params,
+                using: codingFactory
+            ) else {
+            throw ExtrinsicStatusServiceError.errorDecodingFailed
+        }
+
+        let extString = input.extrinsicHash.toHex(includePrefix: true)
+        return .failure(.init(extrinsicHash: extString, blockHash: input.blockHash, error: dispatchError))
     }
 
     private func createMatchingWrapper(
         dependingOn queryOperation: BaseOperation<SubstrateBlockDetails>,
-        runtimeProvider: RuntimeProviderProtocol,
-        extrinsicHash: Data,
-        blockHash: BlockHash,
-        interstedEventsMatcher: ExtrinsicEventsMatching?
+        input: ExtrinsicStatusServiceInput
     ) -> CompoundOperationWrapper<SubstrateExtrinsicStatus> {
         let codingFactoryOperation = runtimeProvider.fetchCoderFactoryOperation()
 
@@ -44,52 +101,28 @@ final class ExtrinsicStatusService {
             let extrinsicEventsList = try queryOperation.extractNoCancellableResultData().extrinsicsWithEvents
 
             guard let extrinsicEvents = extrinsicEventsList
-                .first(where: { $0.extrinsicHash == extrinsicHash }) else {
-                throw ExtrinsicStatusServiceError.extrinsicNotFound(extrinsicHash)
+                .first(where: { $0.extrinsicHash == input.extrinsicHash }) else {
+                throw ExtrinsicStatusServiceError.extrinsicNotFound(input.extrinsicHash)
             }
 
             let successMatcher = ExtrinsicSuccessEventMatcher()
-
-            if extrinsicEvents.eventRecords.contains(
+            let isSuccess = extrinsicEvents.eventRecords.contains(
                 where: { successMatcher.match(event: $0.event, using: codingFactory) }
-            ) {
-                let extString = extrinsicHash.toHex(includePrefix: true)
+            )
 
-                let events: [Event] = if let interstedEventsMatcher {
-                    extrinsicEvents.eventRecords.filter {
-                        interstedEventsMatcher.match(
-                            event: $0.event,
-                            using: codingFactory
-                        )
-                    }.map(\.event)
-                } else {
-                    []
-                }
-
-                return .success(
-                    .init(
-                        extrinsicHash: extString,
-                        blockHash: blockHash,
-                        interestedEvents: events
-                    )
+            if isSuccess {
+                return self.createSuccessStatus(
+                    from: extrinsicEvents,
+                    input: input,
+                    codingFactory: codingFactory
+                )
+            } else {
+                return try self.createFailureStatus(
+                    from: extrinsicEvents,
+                    input: input,
+                    codingFactory: codingFactory
                 )
             }
-
-            let failMatcher = ExtrinsicFailureEventMatcher()
-
-            if let failureEvent = extrinsicEvents.eventRecords.first(
-                where: { failMatcher.match(event: $0.event, using: codingFactory) }
-            )?.event {
-                let dispatchError = try failureEvent.params.map(
-                    to: ExtrinsicFailedEventParams.self,
-                    with: codingFactory.createRuntimeJsonContext().toRawContext()
-                ).dispatchError
-
-                let extString = extrinsicHash.toHex(includePrefix: true)
-                return .failure(.init(extrinsicHash: extString, blockHash: blockHash, error: dispatchError))
-            }
-
-            throw ExtrinsicStatusServiceError.terminateEventNotFound(extrinsicEvents)
         }
 
         mappingOperation.addDependency(codingFactoryOperation)
@@ -117,12 +150,15 @@ extension ExtrinsicStatusService: ExtrinsicStatusServiceProtocol {
                 blockHash: blockHashData
             )
 
-            let statusWrapper = createMatchingWrapper(
-                dependingOn: eventsQueryWrapper.targetOperation,
-                runtimeProvider: runtimeProvider,
+            let input = ExtrinsicStatusServiceInput(
                 extrinsicHash: extHashData,
                 blockHash: blockHash,
-                interstedEventsMatcher: matchingEvents
+                matchingEvents: matchingEvents
+            )
+
+            let statusWrapper = createMatchingWrapper(
+                dependingOn: eventsQueryWrapper.targetOperation,
+                input: input
             )
 
             statusWrapper.addDependency(wrapper: eventsQueryWrapper)

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicStatusService/ExtrinsicStatusServiceInput.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicStatusService/ExtrinsicStatusServiceInput.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct ExtrinsicStatusServiceInput {
+    let extrinsicHash: Data
+    let blockHash: BlockHash
+    let matchingEvents: ExtrinsicEventsMatching?
+}

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicStatusService/SubstrateExtrinsicStatus.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicStatusService/SubstrateExtrinsicStatus.swift
@@ -10,7 +10,7 @@ enum SubstrateExtrinsicStatus {
     struct FailedExtrinsic {
         let extrinsicHash: ExtrinsicHash
         let blockHash: BlockHash
-        let error: DispatchExtrinsicError
+        let error: DispatchCallError
     }
 
     case success(SuccessExtrinsic)

--- a/novawallet/Common/Substrate/Types/CallDispatchErrorDecoder.swift
+++ b/novawallet/Common/Substrate/Types/CallDispatchErrorDecoder.swift
@@ -1,0 +1,124 @@
+import Foundation
+import SubstrateSdk
+
+protocol CallDispatchErrorDecoding {
+    func decode(
+        errorParams: JSON,
+        using codingFactory: RuntimeCoderFactoryProtocol
+    ) -> DispatchCallError?
+}
+
+enum CallDispatchErrorDecoderError: Error {
+    case unsupportedMetadata
+    case errorDescriptionNotFound
+}
+
+final class CallDispatchErrorDecoder {
+    let logger: LoggerProtocol
+
+    init(logger: LoggerProtocol) {
+        self.logger = logger
+    }
+}
+
+private extension CallDispatchErrorDecoder {
+    func decode(
+        moduleError: DispatchError.Module,
+        codingFactory: RuntimeCoderFactoryProtocol
+    ) throws -> DispatchCallError.ModuleDisplayError {
+        guard let pallets = (codingFactory.metadata as? PostV14RuntimeMetadataProtocol)?.postV14Pallets else {
+            throw CallDispatchErrorDecoderError.unsupportedMetadata
+        }
+
+        guard
+            let pallet = pallets.first(where: { $0.index == moduleError.index }),
+            let errorType = pallet.errors?.type else {
+            throw CallDispatchErrorDecoderError.errorDescriptionNotFound
+        }
+
+        let decoder = try codingFactory.createDecoder(from: moduleError.error)
+        let errorName: ErrorName = try decoder.read(of: String(errorType))
+
+        return DispatchCallError.ModuleDisplayError(moduleName: pallet.name, errorName: errorName.name)
+    }
+}
+
+private extension CallDispatchErrorDecoder {
+    struct ErrorName: Decodable {
+        let name: String
+
+        init(from decoder: any Decoder) throws {
+            var container = try decoder.unkeyedContainer()
+
+            name = try container.decode(String.self)
+        }
+    }
+
+    struct FailedEventParams: Decodable {
+        let dispatchError: DispatchError
+
+        init(from decoder: Decoder) throws {
+            var unkeyedContainer = try decoder.unkeyedContainer()
+
+            dispatchError = try unkeyedContainer.decode(DispatchError.self)
+        }
+    }
+
+    enum DispatchError: Decodable, Error {
+        struct Module: Decodable {
+            @StringCodable var index: UInt8
+            @BytesCodable var error: Data
+        }
+
+        case module(Module)
+        case other(String)
+
+        init(from decoder: Decoder) throws {
+            var unkeyedContainer = try decoder.unkeyedContainer()
+
+            let module = try unkeyedContainer.decode(String.self)
+
+            switch module {
+            case "Module":
+                let moduleError = try unkeyedContainer.decode(Module.self)
+                self = .module(moduleError)
+            default:
+                self = .other(module)
+            }
+        }
+    }
+}
+
+extension CallDispatchErrorDecoder: CallDispatchErrorDecoding {
+    func decode(
+        errorParams: JSON,
+        using codingFactory: RuntimeCoderFactoryProtocol
+    ) -> DispatchCallError? {
+        do {
+            let rawDispatchError = try errorParams.map(
+                to: FailedEventParams.self,
+                with: codingFactory.createRuntimeJsonContext().toRawContext()
+            )
+
+            switch rawDispatchError.dispatchError {
+            case let .module(module):
+                let displayError = try decode(moduleError: module, codingFactory: codingFactory)
+
+                let rawError = DispatchCallError.ModuleRawError(
+                    moduleIndex: module.index,
+                    error: module.error
+                )
+
+                let moduleError = DispatchCallError.ModuleError(raw: rawError, display: displayError)
+
+                return DispatchCallError.module(moduleError)
+            case let .other(message):
+                return .other(message)
+            }
+        } catch {
+            logger.error("Error: \(error)")
+
+            return nil
+        }
+    }
+}

--- a/novawallet/Common/Substrate/Types/EventRecord.swift
+++ b/novawallet/Common/Substrate/Types/EventRecord.swift
@@ -103,36 +103,22 @@ struct Event: Decodable {
     }
 }
 
-struct ExtrinsicFailedEventParams: Decodable {
-    let dispatchError: DispatchExtrinsicError
-
-    init(from decoder: Decoder) throws {
-        var unkeyedContainer = try decoder.unkeyedContainer()
-
-        dispatchError = try unkeyedContainer.decode(DispatchExtrinsicError.self)
+enum DispatchCallError: Error {
+    struct ModuleRawError {
+        let moduleIndex: UInt8
+        let error: Data
     }
-}
 
-enum DispatchExtrinsicError: Decodable, Error {
-    struct ModuleError: Decodable {
-        @StringCodable var index: UInt8
-        @BytesCodable var error: Data
+    struct ModuleDisplayError {
+        let moduleName: String
+        let errorName: String
+    }
+
+    struct ModuleError {
+        let raw: ModuleRawError
+        let display: ModuleDisplayError
     }
 
     case module(ModuleError)
     case other(String)
-
-    init(from decoder: Decoder) throws {
-        var unkeyedContainer = try decoder.unkeyedContainer()
-
-        let module = try unkeyedContainer.decode(String.self)
-
-        switch module {
-        case "Module":
-            let moduleError = try unkeyedContainer.decode(ModuleError.self)
-            self = .module(moduleError)
-        default:
-            self = .other(module)
-        }
-    }
 }

--- a/novawalletIntegrationTests/ExtrinsicStatusFetch/ExtrinsicStatusFetchTests.swift
+++ b/novawalletIntegrationTests/ExtrinsicStatusFetch/ExtrinsicStatusFetchTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import novawallet
+import SubstrateSdk
+
+final class CallDispatchErrorDecoderTests: XCTestCase {
+    func testHydraTradingLimitReachedError() throws {
+        do {
+            let status = try fetchStatus(
+                for: "0x5eda7def38fc7afad4812bdb3a8961e85421bbb4afe51943dc5f1ffbfdf52a23",
+                blockHash: "0xee7aba77eafe937cafbca64b245de1ff9bde876b58e83591e0331d4c135c1612",
+                matchingEvents: nil,
+                node: URL(string: "wss://hydration-rpc.n.dwellir.com")!,
+                chainId: KnowChainId.hydra
+            )
+            
+            Logger.shared.debug("Status: \(status)")
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+    
+    func testHydraXcmTokenTransferError() throws {
+        do {
+            let status = try fetchStatus(
+                for: "0xfdededd3f85f3f977c8cfa182237325c6d8929bae0a9180044e71677c8dad192",
+                blockHash: "0x1c368b3d9903d9b57dc9c741b8e6b84787abe6b02f3c3a51b6d24d5ec88fccb9",
+                matchingEvents: HydraSwapEventsMatcher(),
+                node: URL(string: "wss://hydration-rpc.n.dwellir.com")!,
+                chainId: KnowChainId.hydra
+            )
+            
+            Logger.shared.debug("Status: \(status)")
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+    
+    func testHydraSuccessSwap() throws {
+        do {
+            let status = try fetchStatus(
+                for: "0x42ce5185c39ee2127a8f84ff9e71b0c8528e2b703ca2a609fd8940db5c93cfb2",
+                blockHash: "0xb56343ae8a92a9fefed228e5e023ca034c83bbc4b43c74647bd063abcec599fb",
+                matchingEvents: HydraSwapEventsMatcher(),
+                node: URL(string: "wss://hydration-rpc.n.dwellir.com")!,
+                chainId: KnowChainId.hydra
+            )
+            
+            Logger.shared.debug("Status: \(status)")
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+    
+    private func fetchStatus(
+        for extrinsicHash: ExtrinsicHash,
+        blockHash: BlockHash,
+        matchingEvents: ExtrinsicEventsMatching?,
+        node: URL,
+        chainId: ChainModel.Id
+    ) throws -> SubstrateExtrinsicStatus {
+        let storageFacade = SubstrateStorageTestFacade()
+        let chainRegistry = ChainRegistryFacade.setupForIntegrationTest(with: storageFacade)
+        
+        let runtimeService = try chainRegistry.getRuntimeProviderOrError(for: chainId)
+        let connection = WebSocketEngine(urls: [node])!
+        connection.connect()
+        
+        let operationQueue = OperationQueue()
+        
+        let statusService = ExtrinsicStatusService(
+            connection: connection,
+            runtimeProvider: runtimeService,
+            eventsQueryFactory: BlockEventsQueryFactory(operationQueue: operationQueue),
+            logger: Logger.shared
+        )
+        
+        let wrapper = statusService.fetchExtrinsicStatusForHash(
+            extrinsicHash,
+            inBlock: blockHash,
+            matchingEvents: matchingEvents
+        )
+        
+        operationQueue.addOperations(wrapper.allOperations, waitUntilFinished: true)
+        
+        return try wrapper.targetOperation.extractNoCancellableResultData()
+    }
+}


### PR DESCRIPTION
## Purpose

Currently, the error returned from `ExtrinsicSubmissionMonitor` is in raw format and it is hard to understand why an extrinsic failed. The PR introduces automatic error parsing based on the runtime.