### PR TITLE
Add support of the block hash in the state call

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -851,6 +851,8 @@
 		0CEB6B532CA6E92700609DC2 /* VotingPowerSetClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB6B522CA6E92700609DC2 /* VotingPowerSetClosure.swift */; };
 		0CEB6B552CA70CB400609DC2 /* AssetBalance+OpenGov.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB6B542CA70CB400609DC2 /* AssetBalance+OpenGov.swift */; };
 		0CEBAD4E2D5A2BD9000EBA45 /* SwapsDifferenceModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEBAD4D2D5A2BD9000EBA45 /* SwapsDifferenceModelFactory.swift */; };
+		0CEBAD612D61BDA9000EBA45 /* StateCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEBAD602D61BDA9000EBA45 /* StateCallTests.swift */; };
+		0CEBAD632D61BF2A000EBA45 /* PolkadotInflationPredictionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEBAD622D61BF2A000EBA45 /* PolkadotInflationPredictionFactory.swift */; };
 		0CED3A082BD12DFD00B1E994 /* CloudBackupSecretsExporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED3A072BD12DFD00B1E994 /* CloudBackupSecretsExporting.swift */; };
 		0CED3A0A2BD1677B00B1E994 /* CloudBackupSecretsConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED3A092BD1677B00B1E994 /* CloudBackupSecretsConstants.swift */; };
 		0CED3A0C2BD1762D00B1E994 /* CloudBackupServiceFacadeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED3A0B2BD1762D00B1E994 /* CloudBackupServiceFacadeProtocol.swift */; };
@@ -6282,6 +6284,8 @@
 		0CEB6B522CA6E92700609DC2 /* VotingPowerSetClosure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VotingPowerSetClosure.swift; sourceTree = "<group>"; };
 		0CEB6B542CA70CB400609DC2 /* AssetBalance+OpenGov.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssetBalance+OpenGov.swift"; sourceTree = "<group>"; };
 		0CEBAD4D2D5A2BD9000EBA45 /* SwapsDifferenceModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapsDifferenceModelFactory.swift; sourceTree = "<group>"; };
+		0CEBAD602D61BDA9000EBA45 /* StateCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateCallTests.swift; sourceTree = "<group>"; };
+		0CEBAD622D61BF2A000EBA45 /* PolkadotInflationPredictionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolkadotInflationPredictionFactory.swift; sourceTree = "<group>"; };
 		0CED3A072BD12DFD00B1E994 /* CloudBackupSecretsExporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupSecretsExporting.swift; sourceTree = "<group>"; };
 		0CED3A092BD1677B00B1E994 /* CloudBackupSecretsConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupSecretsConstants.swift; sourceTree = "<group>"; };
 		0CED3A0B2BD1762D00B1E994 /* CloudBackupServiceFacadeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupServiceFacadeProtocol.swift; sourceTree = "<group>"; };
@@ -12721,6 +12725,14 @@
 			path = AssetConverters;
 			sourceTree = "<group>";
 		};
+		0CEBAD5F2D61BD88000EBA45 /* StateCall */ = {
+			isa = PBXGroup;
+			children = (
+				0CEBAD602D61BDA9000EBA45 /* StateCallTests.swift */,
+			);
+			path = StateCall;
+			sourceTree = "<group>";
+		};
 		0CF3A6C72CE9422400F93C49 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -16717,6 +16729,7 @@
 		8438E1D024BFAAD2001BDB13 /* novawalletIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				0CEBAD5F2D61BD88000EBA45 /* StateCall */,
 				0C2DA8AB2CC2B120001F79C8 /* AssetsExchange */,
 				0C8FDBA72CAE537800775D7F /* SwipeGov */,
 				0C71046E2C29B60D00487E64 /* MetadataShortener */,
@@ -22424,6 +22437,7 @@
 				0C846B8A2BE52FBD000EBFC2 /* VaraRewardParamsService.swift */,
 				0CF4ADFE2CECACF9009C51FA /* PolkadotRewardParamsService.swift */,
 				0CF4AE0A2CECDCF1009C51FA /* PolkadotRewardEngine.swift */,
+				0CEBAD622D61BF2A000EBA45 /* PolkadotInflationPredictionFactory.swift */,
 			);
 			path = RelayChain;
 			sourceTree = "<group>";
@@ -25830,6 +25844,7 @@
 				84264EE1285B6C6700BF6D4A /* XcmTransfersSyncTests.swift in Sources */,
 				84BFE8A228C2420A00140F1F /* AutocompounDelegateStakeTests.swift in Sources */,
 				F49F49A326A5C45600A25931 /* BabeEraOperationFactoryTests.swift in Sources */,
+				0CEBAD612D61BDA9000EBA45 /* StateCallTests.swift in Sources */,
 				77DC54842B1FE2F500C7E45A /* ProxySyncIntegrationTests.swift in Sources */,
 				0C2DA8AF2CC2F928001F79C8 /* AssetsExchangeGraphDescription.swift in Sources */,
 				84532D5F28E4210E00EF4ADC /* ConvictionVotesFetchTests.swift in Sources */,
@@ -30142,6 +30157,7 @@
 				2D81FAEB2CC65CF800BA0E46 /* TokensManageSearchView.swift in Sources */,
 				347BBBBCC84CA155006FDCDB /* GovernanceSelectTracksViewLayout.swift in Sources */,
 				0C59E8CD2AA5D673001E11F3 /* PooledBalanceUpdatingService.swift in Sources */,
+				0CEBAD632D61BF2A000EBA45 /* PolkadotInflationPredictionFactory.swift in Sources */,
 				0C2DA8A42CC223D9001F79C8 /* AssetsHydraExchangeEdge.swift in Sources */,
 				0C71049C2C2C422500487E64 /* BaseLedgerWalletConfirmInteractor.swift in Sources */,
 				60B66AA63089FC2A3A701CF2 /* GovernanceSelectTracksViewFactory.swift in Sources */,

--- a/novawallet/Common/Extension/SubstrateSdk/RuntimeMetadata+Internal.swift
+++ b/novawallet/Common/Extension/SubstrateSdk/RuntimeMetadata+Internal.swift
@@ -1,6 +1,10 @@
 import Foundation
 import SubstrateSdk
 
+enum RuntimeMetadataInternalError: Error {
+    case runtimeApiNotFound(moduleName: String, methodName: String)
+}
+
 extension RuntimeMetadataProtocol {
     func getStorageMetadata(for codingPath: StorageCodingPath) -> StorageEntryMetadata? {
         getStorageMetadata(in: codingPath.moduleName, storageName: codingPath.itemName)
@@ -32,5 +36,19 @@ extension RuntimeMetadataProtocol {
 
     func eventMatches(_ event: Event, path: EventCodingPath) -> Bool {
         eventMatches(event, oneOf: [path])
+    }
+
+    func getRuntimeApiMethodOrError(
+        for moduleName: String,
+        methodName: String
+    ) throws -> RuntimeApiQueryResult {
+        guard let result = getRuntimeApiMethod(for: moduleName, methodName: methodName) else {
+            throw RuntimeMetadataInternalError.runtimeApiNotFound(
+                moduleName: moduleName,
+                methodName: methodName
+            )
+        }
+
+        return result
     }
 }

--- a/novawallet/Common/Network/JSONRPC/RemoteStateCallRequest.swift
+++ b/novawallet/Common/Network/JSONRPC/RemoteStateCallRequest.swift
@@ -9,7 +9,18 @@ enum StateCallRpc {
 
     struct Request: Encodable {
         let builtInFunction: String
+        let blockHash: BlockHash?
         let paramsClosure: (inout UnkeyedEncodingContainer) throws -> Void
+
+        init(
+            builtInFunction: String,
+            blockHash: BlockHash? = nil,
+            paramsClosure: @escaping (inout UnkeyedEncodingContainer) throws -> Void
+        ) {
+            self.builtInFunction = builtInFunction
+            self.paramsClosure = paramsClosure
+            self.blockHash = blockHash
+        }
 
         func encode(to encoder: Encoder) throws {
             var container = encoder.unkeyedContainer()
@@ -17,6 +28,10 @@ enum StateCallRpc {
             try container.encode(builtInFunction)
 
             try paramsClosure(&container)
+
+            if let blockHash {
+                try container.encode(blockHash.withHexPrefix())
+            }
         }
     }
 }

--- a/novawallet/Common/Services/ChainRegistry/RuntimeProviderPool/RuntimeFetchOperationFactory.swift
+++ b/novawallet/Common/Services/ChainRegistry/RuntimeProviderPool/RuntimeFetchOperationFactory.swift
@@ -38,7 +38,8 @@ final class RuntimeFetchOperationFactory {
             for: Self.availableVersionsCall,
             paramsClosure: nil,
             connection: connection,
-            decoder: StateCallResultFromScaleTypeDecoder()
+            decoder: StateCallResultFromScaleTypeDecoder(),
+            at: nil
         )
 
         let metadataRequestWrapper: CompoundOperationWrapper<Data> = requestFactory.createStaticCodingWrapper(
@@ -52,7 +53,8 @@ final class RuntimeFetchOperationFactory {
                 return try maxVersion.scaleEncoded()
             },
             connection: connection,
-            decoder: StateCallRawDataDecoder()
+            decoder: StateCallRawDataDecoder(),
+            at: nil
         )
 
         metadataRequestWrapper.addDependency(wrapper: versionRequestWrapper)

--- a/novawallet/Modules/Staking/Services/RewardCalculatorService/RelayChain/PolkadotInflationPredictionFactory.swift
+++ b/novawallet/Modules/Staking/Services/RewardCalculatorService/RelayChain/PolkadotInflationPredictionFactory.swift
@@ -1,0 +1,84 @@
+import Foundation
+import SubstrateSdk
+import Operation_iOS
+
+protocol PolkadotInflationPredictionFactoryProtocol {
+    func createPredictionWrapper(
+        for connection: JSONRPCEngine,
+        runtimeProvider: RuntimeCodingServiceProtocol,
+        at block: BlockHash?
+    ) -> CompoundOperationWrapper<RuntimeApiInflationPrediction>
+}
+
+extension PolkadotInflationPredictionFactoryProtocol {
+    func createPredictionWrapper(
+        for connection: JSONRPCEngine,
+        runtimeProvider: RuntimeCodingServiceProtocol
+    ) -> CompoundOperationWrapper<RuntimeApiInflationPrediction> {
+        createPredictionWrapper(
+            for: connection,
+            runtimeProvider: runtimeProvider,
+            at: nil
+        )
+    }
+}
+
+final class PolkadotInflationPredictionFactory {
+    let operationQueue: OperationQueue
+    let stateCallFactory: StateCallRequestFactoryProtocol
+
+    init(stateCallFactory: StateCallRequestFactoryProtocol, operationQueue: OperationQueue) {
+        self.stateCallFactory = stateCallFactory
+        self.operationQueue = operationQueue
+    }
+}
+
+private extension PolkadotInflationPredictionFactory {
+    func createPredictionWrapper(
+        for connection: JSONRPCEngine,
+        runtimeProvider: RuntimeCodingServiceProtocol,
+        stateCallFactory: StateCallRequestFactoryProtocol,
+        at block: BlockHash?
+    ) -> CompoundOperationWrapper<RuntimeApiInflationPrediction> {
+        let codingFactoryOperation = runtimeProvider.fetchCoderFactoryOperation()
+
+        let fetchWrapper = OperationCombiningService<RuntimeApiInflationPrediction>.compoundNonOptionalWrapper(
+            operationQueue: operationQueue
+        ) {
+            let codingFactory = try codingFactoryOperation.extractNoCancellableResultData()
+
+            let runtimeApi = try codingFactory.metadata.getRuntimeApiMethodOrError(
+                for: "Inflation",
+                methodName: "experimental_inflation_prediction_info"
+            )
+
+            return stateCallFactory.createWrapper(
+                for: runtimeApi.callName,
+                paramsClosure: nil,
+                codingFactoryClosure: { codingFactory },
+                connection: connection,
+                queryType: String(runtimeApi.method.output),
+                at: block
+            )
+        }
+
+        fetchWrapper.addDependency(operations: [codingFactoryOperation])
+
+        return fetchWrapper.insertingHead(operations: [codingFactoryOperation])
+    }
+}
+
+extension PolkadotInflationPredictionFactory: PolkadotInflationPredictionFactoryProtocol {
+    func createPredictionWrapper(
+        for connection: JSONRPCEngine,
+        runtimeProvider: RuntimeCodingServiceProtocol,
+        at block: BlockHash?
+    ) -> CompoundOperationWrapper<RuntimeApiInflationPrediction> {
+        createPredictionWrapper(
+            for: connection,
+            runtimeProvider: runtimeProvider,
+            stateCallFactory: stateCallFactory,
+            at: block
+        )
+    }
+}

--- a/novawalletIntegrationTests/StateCall/StateCallTests.swift
+++ b/novawalletIntegrationTests/StateCall/StateCallTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import novawallet
+import SubstrateSdk
+
+final class StateCallTests: XCTestCase {
+
+    func testStateCall() {
+        do {
+            let inflation = try fetchStakingInflation(
+                for: KnowChainId.polkadot,
+                node: URL(string: "wss://polkadot-rpc.dwellir.com")!,
+                at: nil
+            )
+            
+            Logger.shared.debug("Inflation: \(inflation)")
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+    
+    func testStateCallAtBlock() {
+        do {
+            let inflation = try fetchStakingInflation(
+                for: KnowChainId.polkadot,
+                node: URL(string: "wss://polkadot-rpc.dwellir.com")!,
+                at: "0x9fe303d65c87f2a5673d4c413dbcb8aa447f2ec15130ab5cd87e7f04141e8ca0"
+            )
+            
+            Logger.shared.debug("Inflation: \(inflation)")
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+    
+    private func fetchStakingInflation(
+        for chainId: ChainModel.Id,
+        node: URL,
+        at block: BlockHash?
+    ) throws -> RuntimeApiInflationPrediction {
+        let storageFacade = SubstrateStorageTestFacade()
+        let chainRegistry = ChainRegistryFacade.setupForIntegrationTest(with: storageFacade)
+        
+        let runtimeProvider = try chainRegistry.getRuntimeProviderOrError(for: chainId)
+        let connection = WebSocketEngine(urls: [node])!
+        connection.connect()
+        
+        let stateCallFactory = StateCallRequestFactory()
+        let operationQueue = OperationQueue()
+        
+        let fetchFactory = PolkadotInflationPredictionFactory(
+            stateCallFactory: stateCallFactory,
+            operationQueue: operationQueue
+        )
+        
+        let wrapper = fetchFactory.createPredictionWrapper(
+            for: connection,
+            runtimeProvider: runtimeProvider,
+            at: block
+        )
+        
+        operationQueue.addOperations(wrapper.allOperations, waitUntilFinished: true)
+        
+        return try wrapper.targetOperation.extractNoCancellableResultData()
+    }
+}


### PR DESCRIPTION
## Purpose

Currently, state call request is always executed on the last known by the node block. However, there are certain case where one wants to execute query requests on the certain block. For example, such block hash might be received on the state subscription update. The PR introduces an option to provide block hash to the `StateCallRequestFactory`.