### PR TITLE
[CU-8697y3wrn] Fix adding evm based network from preconfigured

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1073,7 +1073,7 @@
 		2D15850F2D3AA5FC00E86DA8 /* UpdatedWalletBrowserStateCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D15850E2D3AA5FC00E86DA8 /* UpdatedWalletBrowserStateCleaner.swift */; };
 		2D1A5F552C358E280073773D /* CustomNetworkSetupFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1A5F542C358E280073773D /* CustomNetworkSetupFactory.swift */; };
 		2D1A5F572C35A8720073773D /* PartialCustomChainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1A5F562C35A8720073773D /* PartialCustomChainModel.swift */; };
-		2D1A5F5A2C35A8A30073773D /* ChainType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1A5F592C35A8A30073773D /* ChainType.swift */; };
+		2D1A5F5A2C35A8A30073773D /* CustomNetworkType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1A5F592C35A8A30073773D /* CustomNetworkType.swift */; };
 		2D1C5D0B2C241C2700E2DBDD /* NetworkNodeEditPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1C5D0A2C241C2700E2DBDD /* NetworkNodeEditPresenter.swift */; };
 		2D1C5D0E2C24214D00E2DBDD /* NetworkNodeBasePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1C5D0D2C24214D00E2DBDD /* NetworkNodeBasePresenter.swift */; };
 		2D1C5D102C242FF800E2DBDD /* NetworkNodeBaseInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1C5D0F2C242FF800E2DBDD /* NetworkNodeBaseInteractor.swift */; };
@@ -6518,7 +6518,7 @@
 		2D15850E2D3AA5FC00E86DA8 /* UpdatedWalletBrowserStateCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatedWalletBrowserStateCleaner.swift; sourceTree = "<group>"; };
 		2D1A5F542C358E280073773D /* CustomNetworkSetupFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNetworkSetupFactory.swift; sourceTree = "<group>"; };
 		2D1A5F562C35A8720073773D /* PartialCustomChainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartialCustomChainModel.swift; sourceTree = "<group>"; };
-		2D1A5F592C35A8A30073773D /* ChainType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainType.swift; sourceTree = "<group>"; };
+		2D1A5F592C35A8A30073773D /* CustomNetworkType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNetworkType.swift; sourceTree = "<group>"; };
 		2D1C5D0A2C241C2700E2DBDD /* NetworkNodeEditPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkNodeEditPresenter.swift; sourceTree = "<group>"; };
 		2D1C5D0D2C24214D00E2DBDD /* NetworkNodeBasePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkNodeBasePresenter.swift; sourceTree = "<group>"; };
 		2D1C5D0F2C242FF800E2DBDD /* NetworkNodeBaseInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkNodeBaseInteractor.swift; sourceTree = "<group>"; };
@@ -13308,7 +13308,7 @@
 			isa = PBXGroup;
 			children = (
 				2D1A5F562C35A8720073773D /* PartialCustomChainModel.swift */,
-				2D1A5F592C35A8A30073773D /* ChainType.swift */,
+				2D1A5F592C35A8A30073773D /* CustomNetworkType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -29023,7 +29023,7 @@
 				84BFE89C28C23A2500140F1F /* AutomationTime.swift in Sources */,
 				2D6287402C91ED5300060814 /* ReferendumVoteSetupPresenter.swift in Sources */,
 				846DA5592A2098BE006CD6C1 /* StakingResolvedAccountMapper.swift in Sources */,
-				2D1A5F5A2C35A8A30073773D /* ChainType.swift in Sources */,
+				2D1A5F5A2C35A8A30073773D /* CustomNetworkType.swift in Sources */,
 				D83B47B07C0D40A327AC44F7 /* CustomValidatorListViewFactory.swift in Sources */,
 				777DC2DA2B2363FA0060CB2C /* ProxyInfoTableViewCell.swift in Sources */,
 				8881043829EBC6BD000FA9BC /* EquilibriumTokenTransfer.swift in Sources */,

--- a/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
@@ -640,6 +640,10 @@ extension ChainNodeConnectable {
     var isEthereumBased: Bool {
         options?.contains(.ethereumBased) ?? false
     }
+
+    var isPureEvm: Bool {
+        isEthereumBased && !hasSubstrateRuntime
+    }
 }
 
 // MARK: ChainViewModelSource

--- a/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
@@ -360,7 +360,7 @@ extension ChainModel: Identifiable {
     var identifier: String { chainId }
 }
 
-enum LocalChainOptions: String, Codable {
+enum LocalChainOptions: String, Codable, Equatable {
     case ethereumBased
     case testnet
     case crowdloans

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/CustomNetworkDTO.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/CustomNetworkDTO.swift
@@ -11,7 +11,7 @@ protocol CustomNetworkSetupRequestConvertible {
 
 enum CustomNetwork {
     struct AddRequest: CustomNetworkSetupRequestConvertible {
-        let networkType: ChainType
+        let networkType: CustomNetworkType
         let url: String
         let name: String
         let currencySymbol: String
@@ -41,7 +41,7 @@ enum CustomNetwork {
     }
 
     struct SetupRequest {
-        let networkType: ChainType
+        let networkType: CustomNetworkType
         let url: String
         let name: String
         let iconUrl: URL?
@@ -54,7 +54,7 @@ enum CustomNetwork {
 
         init(
             from request: CustomNetworkSetupRequestConvertible,
-            networkType: ChainType,
+            networkType: CustomNetworkType,
             iconUrl: URL? = nil,
             replacingNode: ChainNodeModel? = nil,
             networkSetupType: CustomNetworkSetupOperationType
@@ -72,7 +72,7 @@ enum CustomNetwork {
         }
 
         init(
-            networkType: ChainType,
+            networkType: CustomNetworkType,
             url: String,
             name: String,
             iconUrl: URL?,

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/CustomNetworkProtocols.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/CustomNetworkProtocols.swift
@@ -1,7 +1,7 @@
 import SoraFoundation
 
 protocol CustomNetworkViewProtocol: ControllerBackedProtocol {
-    func didReceiveNetworkType(_ networkType: ChainType, show: Bool)
+    func didReceiveNetworkType(_ networkType: CustomNetworkType, show: Bool)
     func didReceiveTitle(text: String)
     func didReceiveUrl(viewModel: InputViewModelProtocol)
     func didReceiveName(viewModel: InputViewModelProtocol)

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/CustomNetworkSetupFactory.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/CustomNetworkSetupFactory.swift
@@ -178,7 +178,7 @@ private extension CustomNetworkSetupFactory {
                 .targetOperation
                 .extractNoCancellableResultData()
 
-            guard !partialChain.isEthereumBased else {
+            guard partialChain.hasSubstrateRuntime else {
                 return CompoundOperationWrapper.createWithResult(partialChain)
             }
 
@@ -216,7 +216,7 @@ private extension CustomNetworkSetupFactory {
                 .targetOperation
                 .extractNoCancellableResultData()
 
-            guard !partialChain.isEthereumBased else {
+            guard partialChain.hasSubstrateRuntime else {
                 return CompoundOperationWrapper.createWithResult(partialChain)
             }
 
@@ -266,9 +266,7 @@ private extension CustomNetworkSetupFactory {
         systemPropertiesOperationFactory: SystemPropertiesOperationFactoryProtocol,
         connection: ChainConnection
     ) -> CompoundOperationWrapper<PartialCustomChainModel> {
-        let isEvmChain = chain.isEthereumBased && chain.noSubstrateRuntime
-
-        return isEvmChain
+        chain.isPureEvm
             ? createEvmMainAssetSetupWrapper(for: chain)
             : createSubstrateMainAssetSetupWrapper(
                 for: chain,
@@ -277,7 +275,9 @@ private extension CustomNetworkSetupFactory {
             )
     }
 
-    func createEvmMainAssetSetupWrapper(for chain: PartialCustomChainModel) -> CompoundOperationWrapper<PartialCustomChainModel> {
+    func createEvmMainAssetSetupWrapper(
+        for chain: PartialCustomChainModel
+    ) -> CompoundOperationWrapper<PartialCustomChainModel> {
         let defaultEVMAssetPrecision: UInt16 = 18
 
         return .createWithResult(
@@ -305,7 +305,9 @@ private extension CustomNetworkSetupFactory {
         systemPropertiesOperationFactory: SystemPropertiesOperationFactoryProtocol,
         connection: ChainConnection
     ) -> CompoundOperationWrapper<PartialCustomChainModel> {
-        let propertiesOperation = systemPropertiesOperationFactory.createSystemPropertiesOperation(connection: connection)
+        let propertiesOperation = systemPropertiesOperationFactory.createSystemPropertiesOperation(
+            connection: connection
+        )
 
         let assetOperation = ClosureOperation<PartialCustomChainModel> {
             let properties = try propertiesOperation.extractNoCancellableResultData()
@@ -371,7 +373,7 @@ private extension CustomNetworkSetupFactory {
     ) -> CompoundOperationWrapper<PartialCustomChainModel> {
         let dependency: (targetOperation: BaseOperation<String>, dependencies: [Operation])
 
-        if chain.isEthereumBased {
+        if chain.isPureEvm {
             let wrapper = evmChainCorrespondingOperation(
                 connection: connection,
                 node: node,

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/CustomNetworkViewController.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/CustomNetworkViewController.swift
@@ -48,7 +48,7 @@ final class CustomNetworkViewController: UIViewController, ViewHolder {
 // MARK: CustomNetworkViewProtocol
 
 extension CustomNetworkViewController: CustomNetworkViewProtocol {
-    func didReceiveNetworkType(_ networkType: ChainType, show: Bool) {
+    func didReceiveNetworkType(_ networkType: CustomNetworkType, show: Bool) {
         show
             ? rootView.showNetworkTypeSwitch()
             : rootView.hideNetworkTypeSwitch()

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/Interactor/CustomNetworkAddInteractor.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/Interactor/CustomNetworkAddInteractor.swift
@@ -45,8 +45,8 @@ extension CustomNetworkAddInteractor: CustomNetworkAddInteractorInputProtocol {
     func addNetwork(with request: CustomNetwork.AddRequest) {
         setupFinishStrategy = setupFinishStrategyFactory.createAddNewStrategy(preConfiguredNetwork: networkToAdd)
 
-        let type: ChainType = if let networkToAdd {
-            networkToAdd.isEthereumBased ? .evm : .substrate
+        let type: CustomNetworkType = if let networkToAdd {
+            networkToAdd.isPureEvm ? .evm : .substrate
         } else {
             request.networkType
         }

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/Interactor/CustomNetworkBaseInteractorError.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/Interactor/CustomNetworkBaseInteractorError.swift
@@ -6,7 +6,7 @@ enum CustomNetworkBaseInteractorError: Error {
     case wrongCurrencySymbol(enteredSymbol: String, actualSymbol: String)
     case invalidPriceUrl
     case invalidChainId
-    case invalidNetworkType(selectedType: ChainType)
+    case invalidNetworkType(selectedType: CustomNetworkType)
     case connecting(innerError: NetworkNodeConnectingError)
     case common(innerError: CommonError)
 

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/Interactor/CustomNetworkSetupFinishStrategy.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/Interactor/CustomNetworkSetupFinishStrategy.swift
@@ -93,7 +93,7 @@ private extension CustomNetworkSetupFinishStrategy {
     ) -> Set<ChainNodeModel> {
         // we can have only a single node if it was setup by a user
         if let node = setUpNetwork.nodes.first, !preConfNetwork.nodes.contains(where: { $0.url == node.url }) {
-            [node].union(preConfNetwork.nodes)
+            Set([node]).union(preConfNetwork.nodes)
         } else {
             preConfNetwork.nodes
         }

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/Interactor/CustomNetworkSetupFinishStrategy.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/Interactor/CustomNetworkSetupFinishStrategy.swift
@@ -61,40 +61,70 @@ protocol CustomNetworkSetupFinishStrategy {
     )
 }
 
+private extension CustomNetworkSetupFinishStrategy {
+    func deriveExplorers(
+        from preConfNetwork: ChainModel,
+        setUpNetwork: ChainModel
+    ) -> [ChainModel.Explorer]? {
+        if let newExplorers = setUpNetwork.explorers, !newExplorers.isEmpty {
+            newExplorers
+        } else {
+            preConfNetwork.explorers
+        }
+    }
+
+    func deriveAssets(
+        from preConfNetwork: ChainModel,
+        setUpNetwork: ChainModel
+    ) -> Set<AssetModel> {
+        // we can have only a single asset if it was setup by a user
+        if
+            let asset = setUpNetwork.assets.first,
+            !preConfNetwork.assets.contains(where: { $0.assetId == asset.assetId }) {
+            [asset]
+        } else {
+            preConfNetwork.assets
+        }
+    }
+
+    func deriveNodes(
+        from preConfNetwork: ChainModel,
+        setUpNetwork: ChainModel
+    ) -> Set<ChainNodeModel> {
+        // we can have only a single node if it was setup by a user
+        if let node = setUpNetwork.nodes.first, !preConfNetwork.nodes.contains(where: { $0.url == node.url }) {
+            [node].union(preConfNetwork.nodes)
+        } else {
+            preConfNetwork.nodes
+        }
+    }
+
+    func deriveOptions(
+        from preConfNetwork: ChainModel,
+        setUpNetwork: ChainModel
+    ) -> [LocalChainOptions]? {
+        guard let preConfOptions = preConfNetwork.options else {
+            return setUpNetwork.options
+        }
+
+        let existingOptions = Set(preConfOptions)
+        let foundOptions = (setUpNetwork.options ?? []).filter { existingOptions.contains($0) }
+        return preConfOptions + foundOptions
+    }
+}
+
 extension CustomNetworkSetupFinishStrategy {
     func updatePreConfigured(
         network: ChainModel,
         using setUpNetwork: ChainModel
     ) -> ChainModel {
-        let explorers: [ChainModel.Explorer]? = {
-            if
-                let newExplorers = setUpNetwork.explorers,
-                !newExplorers.isEmpty {
-                newExplorers
-            } else {
-                network.explorers
-            }
-        }()
+        let explorers = deriveExplorers(from: network, setUpNetwork: setUpNetwork)
 
-        let assets: Set<AssetModel> = {
-            if
-                let asset = setUpNetwork.assets.first,
-                !network.assets.contains(where: { $0.assetId == asset.assetId }) {
-                [asset]
-            } else {
-                network.assets
-            }
-        }()
+        let assets = deriveAssets(from: network, setUpNetwork: setUpNetwork)
 
-        let nodes: Set<ChainNodeModel> = {
-            if
-                let node = setUpNetwork.nodes.first,
-                !network.nodes.contains(where: { $0.url == node.url }) {
-                setUpNetwork.nodes.union(network.nodes)
-            } else {
-                network.nodes
-            }
-        }()
+        let nodes = deriveNodes(from: network, setUpNetwork: setUpNetwork)
+
+        let options = deriveOptions(from: network, setUpNetwork: setUpNetwork)
 
         return ChainModel(
             chainId: network.chainId,
@@ -106,7 +136,7 @@ extension CustomNetworkSetupFinishStrategy {
             addressPrefix: network.addressPrefix,
             types: network.types,
             icon: network.icon,
-            options: network.options,
+            options: options,
             externalApis: network.externalApis,
             explorers: explorers,
             order: network.order,
@@ -171,10 +201,11 @@ struct CustomNetworkAddNewStrategy: CustomNetworkSetupFinishStrategy {
                 network
             }
 
-            let saveOperation = repository.saveOperation(
-                { [networkToSave] },
-                { [] }
-            )
+            let saveOperation = repository.saveOperation({
+                [networkToSave]
+            }, {
+                []
+            })
 
             execute(
                 operation: saveOperation,
@@ -244,10 +275,11 @@ struct CustomNetworkEditStrategy: CustomNetworkSetupFinishStrategy {
                 ? [networkToEdit.chainId]
                 : []
 
-            let saveOperation = repository.saveOperation(
-                { [readyNetwork] },
-                { deleteIds }
-            )
+            let saveOperation = repository.saveOperation({
+                [readyNetwork]
+            }, {
+                deleteIds
+            })
 
             execute(
                 operation: saveOperation,
@@ -285,10 +317,11 @@ struct CustomNetworkModifyStrategy: CustomNetworkSetupFinishStrategy {
             using: network
         )
 
-        let saveOperation = repository.saveOperation(
-            { [networkToSave] },
-            { [] }
-        )
+        let saveOperation = repository.saveOperation({
+            [networkToSave]
+        }, {
+            []
+        })
 
         execute(
             operation: saveOperation,

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/Model/CustomNetworkType.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/Model/CustomNetworkType.swift
@@ -1,4 +1,4 @@
-enum ChainType: Int {
+enum CustomNetworkType: Int {
     case substrate = 0
     case evm = 1
 }

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/Presenter/CustomNetworkAddPresenter.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/Presenter/CustomNetworkAddPresenter.swift
@@ -5,7 +5,7 @@ final class CustomNetworkAddPresenter: CustomNetworkBasePresenter {
     let interactor: CustomNetworkAddInteractorInputProtocol
 
     init(
-        chainType: ChainType,
+        chainType: CustomNetworkType,
         interactor: CustomNetworkAddInteractorInputProtocol,
         wireframe: CustomNetworkWireframeProtocol,
         localizationManager: LocalizationManagerProtocol

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/Presenter/CustomNetworkBasePresenter.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/Presenter/CustomNetworkBasePresenter.swift
@@ -13,11 +13,11 @@ class CustomNetworkBasePresenter {
     var partialBlockExplorerURL: String?
     var partialCoingeckoURL: String?
 
-    var chainType: ChainType
+    var chainType: CustomNetworkType
     var knownChain: ChainModel?
 
     init(
-        chainType: ChainType,
+        chainType: CustomNetworkType,
         interactor: CustomNetworkBaseInteractorInputProtocol,
         wireframe: CustomNetworkWireframeProtocol,
         localizationManager: LocalizationManagerProtocol
@@ -163,7 +163,7 @@ extension CustomNetworkBasePresenter: CustomNetworkPresenterProtocol {
         interactor.setup()
     }
 
-    func select(segment: ChainType?) {
+    func select(segment: CustomNetworkType?) {
         guard let segment else { return }
 
         chainType = segment

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/Presenter/CustomNetworkEditPresenter.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/Presenter/CustomNetworkEditPresenter.swift
@@ -5,7 +5,7 @@ final class CustomNetworkEditPresenter: CustomNetworkBasePresenter {
     let interactor: CustomNetworkEditInteractorInputProtocol
 
     init(
-        chainType: ChainType,
+        chainType: CustomNetworkType,
         interactor: CustomNetworkEditInteractorInputProtocol,
         wireframe: CustomNetworkWireframeProtocol,
         localizationManager: LocalizationManagerProtocol

--- a/novawallet/Modules/NetworkManagement/CustomNetwork/Presenter/CustomNetworkPresenterProtocols.swift
+++ b/novawallet/Modules/NetworkManagement/CustomNetwork/Presenter/CustomNetworkPresenterProtocols.swift
@@ -1,6 +1,6 @@
 protocol CustomNetworkPresenterProtocol: AnyObject {
     func setup()
-    func select(segment: ChainType?)
+    func select(segment: CustomNetworkType?)
     func handle(url: String)
     func handlePartial(url: String)
     func handlePartial(name: String)


### PR DESCRIPTION
## Purpose

Currently if a network is added from preconfigured list the options is has only used and derived ones are ignored preventing from cases when evm address support is derived from runtime. The PR introduces the logic that merges the options from preconfigured network and derived network.

Also PR fixes that logic that marks network as evm only it is ethereumBased and has no runtime in the preconfigured network model