### PR TITLE
Fix/banner close bugs

### DIFF
--- a/novawallet/Modules/Banners/BannersViewController.swift
+++ b/novawallet/Modules/Banners/BannersViewController.swift
@@ -129,13 +129,19 @@ private extension BannersViewController {
         dataSource.update(with: updatedModel.banners)
         setupPageControl()
 
-        let itemByActualOffset: Int = if
-            let lastItemIndex = dataSource.lastIndex,
-            let firstShowingItemIndex = dataSource.firstShowingItemIndex,
-            staticState.itemByActualOffset >= lastItemIndex {
-            firstShowingItemIndex
+        let currentItemIndexAfterClose = (staticState.itemByActualOffset - 1)
+
+        let itemByActualOffset: Int = if dataSource.multipleBanners {
+            if
+                let lastItemIndex = dataSource.lastIndex,
+                let firstShowingItemIndex = dataSource.firstShowingItemIndex,
+                currentItemIndexAfterClose >= lastItemIndex {
+                firstShowingItemIndex
+            } else {
+                currentItemIndexAfterClose == 0 ? 1 : currentItemIndexAfterClose
+            }
         } else {
-            staticState.itemByActualOffset
+            0
         }
 
         self.staticState = .init(itemByActualOffset: itemByActualOffset)

--- a/novawallet/Modules/Banners/Factory/BannersLocalizationFactory.swift
+++ b/novawallet/Modules/Banners/Factory/BannersLocalizationFactory.swift
@@ -137,7 +137,13 @@ extension BannersLocalizationFactory: BannersLocalizationFactoryProtocol {
 
 private extension BannersLocalizationFactory {
     enum Constants {
-        static let localizationPath: String = "localized"
+        static var localizationPath: String {
+            #if F_RELEASE
+                "localized"
+            #else
+                "localized_dev"
+            #endif
+        }
     }
 }
 


### PR DESCRIPTION
### SUMMARY

This PR contains 3 main changes:
- fixes case when we need to change page after closing banner
- extends custom page control with new animation of closing trailing banner
- adds usage for `localized_dev` path

### SCREEN RECORDINGS

https://github.com/user-attachments/assets/ccf5042b-cb7b-4417-a54b-0e0eef9f7706

