### PR TITLE
Fix Mercuryo Widget params

### DIFF
--- a/novawallet/Modules/PayCard/Mercuryo/Hooks/MercuryoCardHookFactory.swift
+++ b/novawallet/Modules/PayCard/Mercuryo/Hooks/MercuryoCardHookFactory.swift
@@ -10,8 +10,6 @@ enum MercuryoCardApi {
     static let widgetId = "4ce98182-ed76-4933-ba1b-b85e4a51d75a" // TODO: Change for production
     static let theme = "nova"
     static let type = "sell"
-    static let fiatCurrency = "EUR"
-    static let fixCurrency = "true"
     static let fixFiatCurrency = "true"
     static let showSpendCardDetails = "true"
     static let hideRefundAddress = "true"

--- a/novawallet/Modules/PayCard/Mercuryo/MercuryoCardResourceProvider.swift
+++ b/novawallet/Modules/PayCard/Mercuryo/MercuryoCardResourceProvider.swift
@@ -19,16 +19,8 @@ final class MercuryoCardResourceProvider {
             value: MercuryoCardApi.type
         )
         let currencyItem = URLQueryItem(
-            name: "currency",
+            name: "currencies",
             value: "\(chainAsset.asset.symbol)"
-        )
-        let fiatCurrencyItem = URLQueryItem(
-            name: "fiat_currency",
-            value: MercuryoCardApi.fiatCurrency
-        )
-        let fixCurrencyItem = URLQueryItem(
-            name: "fix_currency",
-            value: MercuryoCardApi.fixCurrency
         )
         let themeItem = URLQueryItem(
             name: "theme",
@@ -53,8 +45,6 @@ final class MercuryoCardResourceProvider {
             typeItem,
             showSpendCardDetails,
             currencyItem,
-            fiatCurrencyItem,
-            fixCurrencyItem,
             hideRefundAddressItem,
             refundAddressItem
         ]


### PR DESCRIPTION
### SUMMARY
removed `fix_currency` and `fiat_currency` param according to mercuryo team suggestions.
changed `currency` param to `currencies`.