### PR TITLE
Fix charts lib crash

### DIFF
--- a/novawallet/Modules/AssetPriceChart/AssetPriceChartInteractor.swift
+++ b/novawallet/Modules/AssetPriceChart/AssetPriceChartInteractor.swift
@@ -27,7 +27,7 @@ final class AssetPriceChartInteractor: AnyProviderAutoCleaning {
         self.operationQueue = operationQueue
         self.currency = currency
     }
-    
+
     deinit {
         callStore.cancel()
         clear(streamableProvider: &priceProvider)

--- a/novawallet/Modules/AssetPriceChart/AssetPriceChartViewController.swift
+++ b/novawallet/Modules/AssetPriceChart/AssetPriceChartViewController.swift
@@ -121,6 +121,13 @@ private extension AssetPriceChartViewController {
             )
             rootView.chartView.rightAxis.labelTextColor = R.color.colorTextSecondary()!
             rootView.chartView.data = chartData
+            
+            /* Clear highlighted indexes to prevent renderer crashes.
+               The renderer attempts to highlight indexes from previous datasets,
+               which can cause out-of-range errors when switching from multiple
+               to single datasets.
+               Reference: https://github.com/ChartsOrg/Charts/issues/5154 */
+            rootView.chartView.highlightValues(nil)
             rootView.loadingState.remove(.chart)
         case .loading:
             rootView.chartView.rightAxis.labelTextColor = .clear


### PR DESCRIPTION
### SUMMARY

This PR adds cheap fix for library bug that crashes the app with out-of-bounds error.

### SOLUTION

Clear highlighted indexes to prevent renderer crashes. The renderer attempts to highlight indexes from previous datasets, which can cause out-of-range errors when switching from multiple to single datasets.
Reference: https://github.com/ChartsOrg/Charts/issues/5154