### PR TITLE
Use session collators to determine Mythos staking state

### DIFF
--- a/novawallet/Common/Services/Multistaking/Multistaking+Model.swift
+++ b/novawallet/Common/Services/Multistaking/Multistaking+Model.swift
@@ -98,11 +98,7 @@ extension Multistaking {
                 return nil
             }
 
-            if let userStake = mythosState.userStake, userStake.stake > 0 {
-                return mythosState.isStartedInCurrentSession ? .waiting : .active
-            } else {
-                return .bonded
-            }
+            return mythosState.hasActiveStaking ? .activeIndependent : .bonded
         }
 
         static func from(nominationPoolState: Multistaking.NominationPoolState) -> DashboardItemOnchainState? {


### PR DESCRIPTION
## Purpose

Current approach of determining waiting state lead to a situation where current session might change while indexer is still indexing and in result a user will see inactive state. Also, waiting state on the dashboard is not consistent with active state on the details.

New solution uses directly session collators to determine the active state on the dashboard instead of relaying on the indexer.