### PR TITLE
Fix/deeplink navigation

### DIFF
--- a/novawallet/Modules/AssetList/AssetListWireframe.swift
+++ b/novawallet/Modules/AssetList/AssetListWireframe.swift
@@ -67,7 +67,7 @@ final class AssetListWireframe: AssetListWireframeProtocol {
         }
 
         assetsSearchView.controller.modalTransitionStyle = .crossDissolve
-        assetsSearchView.controller.modalPresentationStyle = .fullScreen
+        assetsSearchView.controller.modalPresentationStyle = .overCurrentContext
 
         view?.controller.present(
             assetsSearchView.controller,
@@ -80,7 +80,7 @@ final class AssetListWireframe: AssetListWireframeProtocol {
         transferCompletion: @escaping TransferCompletionClosure,
         buyTokensClosure: @escaping BuyTokensClosure
     ) {
-        guard let assetsSearchView = AssetOperationViewFactory.createSendView(
+        guard let assetOperationView = AssetOperationViewFactory.createSendView(
             for: assetListModelObservable,
             transferCompletion: transferCompletion,
             buyTokensClosure: buyTokensClosure
@@ -89,7 +89,7 @@ final class AssetListWireframe: AssetListWireframeProtocol {
         }
 
         let navigationController = NovaNavigationController(
-            rootViewController: assetsSearchView.controller
+            rootViewController: assetOperationView.controller
         )
 
         view?.controller.presentWithCardLayout(
@@ -99,12 +99,12 @@ final class AssetListWireframe: AssetListWireframeProtocol {
     }
 
     func showRecieveTokens(from view: AssetListViewProtocol?) {
-        guard let assetsSearchView = AssetOperationViewFactory.createReceiveView(for: assetListModelObservable) else {
+        guard let assetOperationView = AssetOperationViewFactory.createReceiveView(for: assetListModelObservable) else {
             return
         }
 
         let navigationController = NovaNavigationController(
-            rootViewController: assetsSearchView.controller
+            rootViewController: assetOperationView.controller
         )
 
         view?.controller.presentWithCardLayout(
@@ -114,12 +114,12 @@ final class AssetListWireframe: AssetListWireframeProtocol {
     }
 
     func showBuyTokens(from view: AssetListViewProtocol?) {
-        guard let assetsSearchView = AssetOperationViewFactory.createBuyView(for: assetListModelObservable) else {
+        guard let assetOperationView = AssetOperationViewFactory.createBuyView(for: assetListModelObservable) else {
             return
         }
 
         let navigationController = NovaNavigationController(
-            rootViewController: assetsSearchView.controller
+            rootViewController: assetOperationView.controller
         )
 
         view?.controller.presentWithCardLayout(

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListProtocols.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListProtocols.swift
@@ -75,7 +75,7 @@ extension DAppBrowserSearchPresentable {
         navigationController.barSettings = NavigationBarSettings.defaultSettings.bySettingCloseButton(false)
 
         navigationController.modalTransitionStyle = .crossDissolve
-        navigationController.modalPresentationStyle = .fullScreen
+        navigationController.modalPresentationStyle = .overCurrentContext
         view?.controller.present(navigationController, animated: true, completion: nil)
     }
 }

--- a/novawallet/Modules/MainTabBar/MainTabBarWireframe.swift
+++ b/novawallet/Modules/MainTabBar/MainTabBarWireframe.swift
@@ -33,29 +33,33 @@ final class MainTabBarWireframe: MainTabBarWireframeProtocol {
         screen: UrlHandlingScreen,
         locale: Locale
     ) {
-        guard
-            let controller = view?.controller as? UITabBarController,
-            canPresentScreenWithoutBreakingFlow(on: controller) else {
-            return
-        }
-
-        switch screen {
-        case let .error(error):
-            if let errorContent = error.content(for: locale) {
-                let closeAction = R.string.localizable.commonOk(preferredLanguages: locale.rLanguages)
-                present(
-                    message: errorContent.message,
-                    title: errorContent.title,
-                    closeAction: closeAction,
-                    from: view
-                )
-            }
-        case .staking:
-            controller.selectedIndex = MainTabBarIndex.staking
-        case let .gov(rederendumIndex):
-            openGovernanceScreen(in: controller, rederendumIndex: rederendumIndex)
-        case let .dApp(model):
+        if case let .dApp(model) = screen {
             openBrowser(with: model)
+        } else {
+            guard
+                let controller = view?.controller as? UITabBarController,
+                canPresentScreenWithoutBreakingFlow(on: controller) else {
+                return
+            }
+
+            switch screen {
+            case let .error(error):
+                if let errorContent = error.content(for: locale) {
+                    let closeAction = R.string.localizable.commonOk(preferredLanguages: locale.rLanguages)
+                    present(
+                        message: errorContent.message,
+                        title: errorContent.title,
+                        closeAction: closeAction,
+                        from: view
+                    )
+                }
+            case .staking:
+                controller.selectedIndex = MainTabBarIndex.staking
+            case let .gov(rederendumIndex):
+                openGovernanceScreen(in: controller, rederendumIndex: rederendumIndex)
+            default:
+                break
+            }
         }
     }
 

--- a/novawallet/Modules/Notifications/Management/NotificationsManagementViewLayout.swift
+++ b/novawallet/Modules/Notifications/Management/NotificationsManagementViewLayout.swift
@@ -25,8 +25,16 @@ final class NotificationsManagementViewLayout: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        footerView.frame = CGRect(origin: .zero, size: CGSize(width: bounds.width, height: 106))
-        tableView.contentInset = .init(top: 16, left: 0, bottom: 8, right: 0)
+        footerView.bounds = CGRect(
+            origin: .zero,
+            size: CGSize(width: bounds.width, height: 106)
+        )
+        tableView.contentInset = .init(
+            top: 16,
+            left: 0,
+            bottom: 8,
+            right: 0
+        )
     }
 
     private func setupLayout() {

--- a/novawallet/Modules/NovaMainAppContainer/NovaMainAppContainerViewController.swift
+++ b/novawallet/Modules/NovaMainAppContainer/NovaMainAppContainerViewController.swift
@@ -91,7 +91,8 @@ private extension NovaMainAppContainerViewController {
             },
             animatableClosure: { [weak self] in
                 self?.tabBar?.view.layer.maskedCorners = []
-                self?.updateModalsLayoutIfNeeded()
+                self?.updateCardModalsLayoutIfNeeded()
+                self?.updateDefaultModalsLayoutIfNeeded()
             }
         )
     }
@@ -118,6 +119,7 @@ private extension NovaMainAppContainerViewController {
                     .layerMinXMaxYCorner,
                     .layerMaxXMaxYCorner
                 ]
+                self?.updateDefaultModalsLayoutIfNeeded()
             }
         )
     }
@@ -134,11 +136,37 @@ private extension NovaMainAppContainerViewController {
                 self?.topContainerBottomConstraint?.constant = -topContainerBottomOffset
 
                 return self?.rootView
+            },
+            animatableClosure: { [weak self] in
+                self?.updateDefaultModalsLayoutIfNeeded()
             }
         )
     }
 
-    func updateModalsLayoutIfNeeded() {
+    func updateDefaultModalsLayoutIfNeeded() {
+        guard let tabBar else { return }
+
+        var presentedViewController = tabBar.presentedController()
+
+        while presentedViewController != nil {
+            let presentationController = presentedViewController?.presentationController
+
+            guard !(presentationController is ModalCardPresentationController) else {
+                continue
+            }
+
+            presentationController?.presentedViewController.view.frame = CGRect(
+                x: tabBar.view.frame.origin.x,
+                y: tabBar.view.frame.origin.y,
+                width: tabBar.view.frame.width,
+                height: tabBar.view.frame.height
+            )
+
+            presentedViewController = presentedViewController?.presentedViewController
+        }
+    }
+
+    func updateCardModalsLayoutIfNeeded() {
         var presentedViewController = tabBar?.presentedController()
 
         while presentedViewController != nil {

--- a/novawallet/Modules/NovaMainAppContainer/NovaMainAppContainerViewController.swift
+++ b/novawallet/Modules/NovaMainAppContainer/NovaMainAppContainerViewController.swift
@@ -152,6 +152,7 @@ private extension NovaMainAppContainerViewController {
             let presentationController = presentedViewController?.presentationController
 
             guard !(presentationController is ModalCardPresentationController) else {
+                presentedViewController = presentedViewController?.presentedViewController
                 continue
             }
 

--- a/novawallet/Modules/Vote/Governance/Referendums/ReferendumsWireframe.swift
+++ b/novawallet/Modules/Vote/Governance/Referendums/ReferendumsWireframe.swift
@@ -127,7 +127,7 @@ final class ReferendumsWireframe: ReferendumsWireframeProtocol {
         }
 
         searchView.controller.modalTransitionStyle = .crossDissolve
-        searchView.controller.modalPresentationStyle = .fullScreen
+        searchView.controller.modalPresentationStyle = .overCurrentContext
 
         view?.controller.present(searchView.controller, animated: true, completion: nil)
     }


### PR DESCRIPTION
### SUMMARY

This PR adds navigation fixes for dApp opening via deeplink. 

### SOLUTION

- Always open `DAppBrowser` via deeplink, regardless of `MainTabBar` state
- Change `AssetsSearch`, `DAppSearch` and `ReferendumsSearch` presentation style
- Update default modals if needed on browser widget layout changes

### SCREEN RECORDINGS

https://github.com/user-attachments/assets/51ed7eb4-7caa-4d1f-970e-84a52c956410

