### PR TITLE
History draggable layout change on balance widget operations

### DIFF
--- a/novawallet/Modules/AssetDetails/AssetDetailsViewController.swift
+++ b/novawallet/Modules/AssetDetails/AssetDetailsViewController.swift
@@ -34,14 +34,20 @@ final class AssetDetailsViewController: UIViewController, ViewHolder {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setupChartView()
-        addHandlers()
+        setupView()
         applyLocalization()
         presenter.setup()
     }
 }
 
 private extension AssetDetailsViewController {
+    func setupView() {
+        setupChartView()
+        addHandlers()
+
+        rootView.delegate = self
+    }
+
     func setupChartView() {
         let insets = UIEdgeInsets(
             inset: AssetDetailsViewLayout.Constants.chartWidgetInset
@@ -114,6 +120,14 @@ extension AssetDetailsViewController: AssetDetailsViewProtocol {
         rootView.receiveButton.isEnabled = availableOperations.contains(.receive)
         rootView.swapButton.isEnabled = availableOperations.contains(.swap)
         rootView.buyButton.isEnabled = availableOperations.contains(.buy)
+    }
+}
+
+extension AssetDetailsViewController: AssetDetailsViewLayoutDelegate {
+    func didUpdateHeight(_ height: CGFloat) {
+        observable.observers.forEach {
+            $0.observer?.didChangePreferredContentHeight(to: height)
+        }
     }
 }
 

--- a/novawallet/Modules/AssetDetails/Container/ContainerProtocols.swift
+++ b/novawallet/Modules/AssetDetails/Container/ContainerProtocols.swift
@@ -19,7 +19,6 @@ protocol ReloadableDelegate: AnyObject {
 }
 
 @objc protocol ContainableObserver {
-    func willChangePreferredContentHeight()
     func didChangePreferredContentHeight(to newContentHeight: CGFloat)
 }
 

--- a/novawallet/Modules/AssetDetails/Container/ContainerViewController.swift
+++ b/novawallet/Modules/AssetDetails/Container/ContainerViewController.swift
@@ -225,12 +225,12 @@ class ContainerViewController: UIViewController, AdaptiveDesignable {
             let preferredContentInsets = createPreferredContentInsets(for: preferredContentHeight)
 
             let compactOriginY = containerSize.height - preferredContentInsets.bottom
-            let compactHeight = preferredContentInsets.bottom
+
             return CGRect(
                 x: 0.0,
                 y: compactOriginY,
                 width: containerSize.width,
-                height: compactHeight
+                height: containerSize.height
             )
         case .full:
             return CGRect(origin: .zero, size: containerSize)

--- a/novawallet/Modules/AssetDetails/View/AssetDetailsViewLayout.swift
+++ b/novawallet/Modules/AssetDetails/View/AssetDetailsViewLayout.swift
@@ -2,7 +2,13 @@ import UIKit
 import SoraUI
 import SnapKit
 
+protocol AssetDetailsViewLayoutDelegate: AnyObject {
+    func didUpdateHeight(_ height: CGFloat)
+}
+
 final class AssetDetailsViewLayout: UIView {
+    weak var delegate: AssetDetailsViewLayoutDelegate?
+
     private let balanceExpandingAnimator: BlockViewAnimatorProtocol = BlockViewAnimator(
         duration: 0.2,
         options: [.curveEaseInOut]
@@ -49,6 +55,8 @@ final class AssetDetailsViewLayout: UIView {
     let receiveButton: RoundedButton = createOperationButton(icon: R.image.iconReceive())
     let buyButton: RoundedButton = createOperationButton(icon: R.image.iconBuy())
     let swapButton = createOperationButton(icon: R.image.iconActionChange())
+
+    private var currentBalanceHeight = AssetDetailsBalanceWidget.Constants.collapsedStateHeight
 
     private lazy var buttonsRow = PayButtonsRow(
         frame: .zero,
@@ -211,7 +219,7 @@ final class AssetDetailsViewLayout: UIView {
 
     var prefferedHeight: CGFloat {
         let balanceSectionHeight = Constants.containerViewTopOffset
-            + AssetDetailsBalanceWidget.Constants.expandedStateHeight
+            + currentBalanceHeight
         let buttonsRowHeight = buttonsRow.preferredHeight ?? 0
 
         return priceLabel.font.lineHeight
@@ -225,6 +233,8 @@ final class AssetDetailsViewLayout: UIView {
 
 extension AssetDetailsViewLayout: AssetDetailsBalanceWidgetDelegate {
     func didChangeState(to state: AssetDetailsBalanceWidget.State) {
+        currentBalanceHeight = state.height
+
         balanceWidget.snp.updateConstraints { make in
             make.height.equalTo(state.height)
         }
@@ -233,6 +243,8 @@ extension AssetDetailsViewLayout: AssetDetailsBalanceWidgetDelegate {
             block: { [weak self] in self?.containerView.layoutIfNeeded() },
             completionBlock: nil
         )
+
+        delegate?.didUpdateHeight(prefferedHeight)
     }
 }
 


### PR DESCRIPTION
### SUMMARY

This PR adds animated layout changes for the draggable history sheet when balance widget is expanding or collapsing. 
Additionally, to prevent early frame minimization that would be visible to users, we no longer use `compactHeight`. The difference between using `containerSize` vs. `compactHeight` is demonstrated in the screen recordings.

### SCREEN RECORDINGS
Using `compactHeight`
https://github.com/user-attachments/assets/8255f508-c24f-4d62-af31-b5f5e3a94ab7

Using `containerSize`
https://github.com/user-attachments/assets/006f7a7b-7fc0-4afe-a13a-6226fee60d47