### PR TITLE
Fix price chart and asset details bugs

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1506,6 +1506,8 @@
 		2DBB288F2CD42E8D00DFA0AD /* IconType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB288E2CD42E8D00DFA0AD /* IconType.swift */; };
 		2DBB28912CD42ED800DFA0AD /* ChainLogoImageInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB28902CD42ED800DFA0AD /* ChainLogoImageInfo.swift */; };
 		2DBB28932CD432FB00DFA0AD /* CopyAddressPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB28922CD432FB00DFA0AD /* CopyAddressPresentable.swift */; };
+		2DBEE9912D7A1C9C000B735B /* AssetDetailsBalanceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBEE9902D7A1C9C000B735B /* AssetDetailsBalanceModel.swift */; };
+		2DBEE9932D7A29CB000B735B /* StackTitleValueIconView+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBEE9922D7A29CB000B735B /* StackTitleValueIconView+Style.swift */; };
 		2DC075E32BF24AB400868563 /* CheckBoxIconDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC075E22BF24AB400868563 /* CheckBoxIconDetailsView.swift */; };
 		2DC075E92BF4B97900868563 /* BackupAttentionTableTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC075E82BF4B97900868563 /* BackupAttentionTableTitleView.swift */; };
 		2DC304EC2D2BF27A0020B0E6 /* ModalCardPresentationControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC304EB2D2BF27A0020B0E6 /* ModalCardPresentationControllerDelegate.swift */; };
@@ -1550,6 +1552,7 @@
 		2DEDF68D2C36FDCB007D5F4A /* LightChainModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEDF68C2C36FDCB007D5F4A /* LightChainModel.swift */; };
 		2DF6F5F62C5CE7D4000D9CDD /* ReferendmVotesViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF6F5F52C5CE7D4000D9CDD /* ReferendmVotesViewModelFactory.swift */; };
 		2DF6F5F82C5D7DEE000D9CDD /* Decimal+Rounding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF6F5F72C5D7DEE000D9CDD /* Decimal+Rounding.swift */; };
+		2DF95D252D77AF8B001D8785 /* Array+Distribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF95D242D77AF8B001D8785 /* Array+Distribute.swift */; };
 		2DF95D282D785A41001D8785 /* CoreHapticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF95D272D785A41001D8785 /* CoreHapticEngine.swift */; };
 		2DF95D2A2D785AF1001D8785 /* HapticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF95D292D785AF1001D8785 /* HapticEngine.swift */; };
 		2DF95D2D2D785DA2001D8785 /* HapticPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF95D2C2D785DA2001D8785 /* HapticPlayer.swift */; };
@@ -1558,7 +1561,6 @@
 		2DF95D342D786097001D8785 /* CustomHapticPatternConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF95D332D786097001D8785 /* CustomHapticPatternConfig.swift */; };
 		2DF95D372D786156001D8785 /* SequentialHapticPlayerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF95D362D786156001D8785 /* SequentialHapticPlayerConfig.swift */; };
 		2DF95D3B2D786631001D8785 /* HapticPlayerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF95D3A2D786631001D8785 /* HapticPlayerFactory.swift */; };
-		2DF95D252D77AF8B001D8785 /* Array+Distribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF95D242D77AF8B001D8785 /* Array+Distribute.swift */; };
 		2EC610DC06643A00876BED6E /* AssetListWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B249C5D43CB86CF62C165F8 /* AssetListWireframe.swift */; };
 		2EDE38E0F2E3494D16717A74 /* WalletConnectInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDDB8BE848C65B65FE4086D /* WalletConnectInteractor.swift */; };
 		2F133E695C10ACC0D2FB44FE /* DAppSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C0B1C175A2470AAA50DAC5 /* DAppSettingsViewController.swift */; };
@@ -7200,6 +7202,8 @@
 		2DBB288E2CD42E8D00DFA0AD /* IconType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconType.swift; sourceTree = "<group>"; };
 		2DBB28902CD42ED800DFA0AD /* ChainLogoImageInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainLogoImageInfo.swift; sourceTree = "<group>"; };
 		2DBB28922CD432FB00DFA0AD /* CopyAddressPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyAddressPresentable.swift; sourceTree = "<group>"; };
+		2DBEE9902D7A1C9C000B735B /* AssetDetailsBalanceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetDetailsBalanceModel.swift; sourceTree = "<group>"; };
+		2DBEE9922D7A29CB000B735B /* StackTitleValueIconView+Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StackTitleValueIconView+Style.swift"; sourceTree = "<group>"; };
 		2DC075E22BF24AB400868563 /* CheckBoxIconDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckBoxIconDetailsView.swift; sourceTree = "<group>"; };
 		2DC075E82BF4B97900868563 /* BackupAttentionTableTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupAttentionTableTitleView.swift; sourceTree = "<group>"; };
 		2DC304EB2D2BF27A0020B0E6 /* ModalCardPresentationControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalCardPresentationControllerDelegate.swift; sourceTree = "<group>"; };
@@ -7247,6 +7251,7 @@
 		2DEED7526468089FE8A8989C /* SwapConfirmInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwapConfirmInteractor.swift; sourceTree = "<group>"; };
 		2DF6F5F52C5CE7D4000D9CDD /* ReferendmVotesViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferendmVotesViewModelFactory.swift; sourceTree = "<group>"; };
 		2DF6F5F72C5D7DEE000D9CDD /* Decimal+Rounding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Rounding.swift"; sourceTree = "<group>"; };
+		2DF95D242D77AF8B001D8785 /* Array+Distribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Distribute.swift"; sourceTree = "<group>"; };
 		2DF95D272D785A41001D8785 /* CoreHapticEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreHapticEngine.swift; sourceTree = "<group>"; };
 		2DF95D292D785AF1001D8785 /* HapticEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticEngine.swift; sourceTree = "<group>"; };
 		2DF95D2C2D785DA2001D8785 /* HapticPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticPlayer.swift; sourceTree = "<group>"; };
@@ -7255,7 +7260,6 @@
 		2DF95D332D786097001D8785 /* CustomHapticPatternConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHapticPatternConfig.swift; sourceTree = "<group>"; };
 		2DF95D362D786156001D8785 /* SequentialHapticPlayerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequentialHapticPlayerConfig.swift; sourceTree = "<group>"; };
 		2DF95D3A2D786631001D8785 /* HapticPlayerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticPlayerFactory.swift; sourceTree = "<group>"; };
-		2DF95D242D77AF8B001D8785 /* Array+Distribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Distribute.swift"; sourceTree = "<group>"; };
 		2E0DC18CB648BFACAD038C02 /* Pods-novawalletAll-novawalletIntegrationTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-novawalletAll-novawalletIntegrationTests.staging.xcconfig"; path = "Target Support Files/Pods-novawalletAll-novawalletIntegrationTests/Pods-novawalletAll-novawalletIntegrationTests.staging.xcconfig"; sourceTree = "<group>"; };
 		2E4B0600AFFB96A75CF98755 /* StakingRedeemProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingRedeemProtocols.swift; sourceTree = "<group>"; };
 		2E800814C025B38C87CC282D /* TokensAddSelectNetworkViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokensAddSelectNetworkViewFactory.swift; sourceTree = "<group>"; };
@@ -24290,6 +24294,7 @@
 			isa = PBXGroup;
 			children = (
 				88D02FE72942EB1A00E26390 /* AssetDetailsModel.swift */,
+				2DBEE9902D7A1C9C000B735B /* AssetDetailsBalanceModel.swift */,
 				88D02FED2942F00D00E26390 /* AssetDetailsOperation.swift */,
 				88D02FF129431FC900E26390 /* AssetDetailsLocksViewModel.swift */,
 				846AF8452525C93A00868F37 /* BalanceContext.swift */,
@@ -24335,6 +24340,7 @@
 			isa = PBXGroup;
 			children = (
 				8487010D2907DF2F00F2C0C3 /* MultiValueView+Style.swift */,
+				2DBEE9922D7A29CB000B735B /* StackTitleValueIconView+Style.swift */,
 				889D889628F022AA00C4320F /* UILabel+Style.swift */,
 				88DC3E20292CAA0100DBCE4D /* RoundedView+Style.swift */,
 				88DC3E24292CAA9300DBCE4D /* IconDetailsView+Style.swift */,
@@ -28465,6 +28471,7 @@
 				84D8F16F24D8451F00AF43E9 /* CryptoType+ViewModel.swift in Sources */,
 				AEBE16E6262EA7C100DF257C /* StakingErrors.swift in Sources */,
 				848CC93B28D9F6A5009EB4B0 /* OnChainScheduler.swift in Sources */,
+				2DBEE9912D7A1C9C000B735B /* AssetDetailsBalanceModel.swift in Sources */,
 				0CA7197D2B7737D5000B086E /* HydraQuoteFactory.swift in Sources */,
 				84953F662934C7D90033F47D /* EtherscanERC20HistoryResponse.swift in Sources */,
 				AEAC68F526E9F93B00346599 /* CoingeckoDefinitions.swift in Sources */,
@@ -29089,6 +29096,7 @@
 				0CAC02FB2B4BC10800DDEC3A /* ProxySignValidationError.swift in Sources */,
 				84FF267C28494B13003EC78D /* ParaStkStakeSetupPresenter+StartStaking.swift in Sources */,
 				2D8FF9D32C9BD67500089F53 /* SwipeGovAlertPresentable.swift in Sources */,
+				2DBEE9932D7A29CB000B735B /* StackTitleValueIconView+Style.swift in Sources */,
 				0C13DFCF2AF8ADB300E5F355 /* BigUInt+Operation.swift in Sources */,
 				88D02FEA2942ED4F00E26390 /* RoundedButton+Style.swift in Sources */,
 				842BDB2A278C4F3C00AB4B5A /* DAppBrowserAuthorizingState.swift in Sources */,

--- a/novawallet/Common/Extension/UIKit/Style/StackTitleValueIconView+Style.swift
+++ b/novawallet/Common/Extension/UIKit/Style/StackTitleValueIconView+Style.swift
@@ -1,0 +1,18 @@
+import UIKit
+import SoraUI
+
+extension StackTitleValueIconView {
+    struct Style {
+        let title: UILabel.Style
+        let value: UILabel.Style
+        let icon: UIImage?
+        let iconBorderStyle: RoundedView.Style
+    }
+
+    func apply(style: Style) {
+        rowContentView.fView.fView.apply(style: style.title)
+        rowContentView.sView.apply(style: style.value)
+        rowContentView.fView.sView.image = style.icon
+        rowContentView.fView.sView.borderView.apply(style: style.iconBorderStyle)
+    }
+}

--- a/novawallet/Modules/AssetDetails/AssetDetailsPresenter.swift
+++ b/novawallet/Modules/AssetDetails/AssetDetailsPresenter.swift
@@ -40,10 +40,6 @@ final class AssetDetailsPresenter: PurchaseFlowManaging, AssetPriceChartInputOwn
         localizationManager = localizableManager
     }
 
-    private func hasLocks(for balance: AssetBalance, externalBalances: [ExternalAssetBalance]) -> Bool {
-        balance.locked > 0 || !externalBalances.isEmpty
-    }
-
     private func calculateTotalExternalBalances(for externalBalances: [ExternalAssetBalance]) -> BigUInt {
         externalBalances.reduce(0) { $0 + $1.amount }
     }
@@ -58,7 +54,6 @@ final class AssetDetailsPresenter: PurchaseFlowManaging, AssetPriceChartInputOwn
         }
 
         let assetDetailsModel = viewModelFactory.createAssetDetailsModel(
-            balance: balance,
             priceData: priceData,
             chainAsset: chainAsset,
             locale: selectedLocale

--- a/novawallet/Modules/AssetDetails/AssetDetailsPresenter.swift
+++ b/novawallet/Modules/AssetDetails/AssetDetailsPresenter.swift
@@ -67,33 +67,19 @@ final class AssetDetailsPresenter: PurchaseFlowManaging, AssetPriceChartInputOwn
 
         let totalExternalBalances = calculateTotalExternalBalances(for: externalAssetBalances)
 
-        let totalBalance = viewModelFactory.createBalanceViewModel(
-            value: balance.totalInPlank + totalExternalBalances,
-            assetDisplayInfo: chainAsset.assetDisplayInfo,
-            priceData: priceData,
-            locale: selectedLocale
+        let balanceModel = viewModelFactory.createBalanceViewModel(
+            params: .init(
+                total: balance.totalInPlank + totalExternalBalances,
+                locked: balance.locked + totalExternalBalances,
+                transferrable: balance.transferable,
+                externalBalances: externalAssetBalances,
+                assetDisplayInfo: chainAsset.assetDisplayInfo,
+                priceData: priceData,
+                locale: selectedLocale
+            )
         )
 
-        let transferableBalance = viewModelFactory.createBalanceViewModel(
-            value: balance.transferable,
-            assetDisplayInfo: chainAsset.assetDisplayInfo,
-            priceData: priceData,
-            locale: selectedLocale
-        )
-
-        let lockedBalance = viewModelFactory.createBalanceViewModel(
-            value: balance.locked + totalExternalBalances,
-            assetDisplayInfo: chainAsset.assetDisplayInfo,
-            priceData: priceData,
-            locale: selectedLocale
-        )
-
-        view.didReceive(totalBalance: totalBalance)
-        view.didReceive(transferableBalance: transferableBalance)
-
-        let isSelectable = hasLocks(for: balance, externalBalances: externalAssetBalances)
-        view.didReceive(lockedBalance: lockedBalance, isSelectable: isSelectable)
-
+        view.didReceive(balance: balanceModel)
         view.didReceive(availableOperations: availableOperations)
     }
 

--- a/novawallet/Modules/AssetDetails/AssetDetailsProtocols.swift
+++ b/novawallet/Modules/AssetDetails/AssetDetailsProtocols.swift
@@ -2,9 +2,7 @@ import Operation_iOS
 
 protocol AssetDetailsViewProtocol: AnyObject, ControllerBackedProtocol, Containable {
     func didReceive(assetModel: AssetDetailsModel)
-    func didReceive(totalBalance: BalanceViewModelProtocol)
-    func didReceive(transferableBalance: BalanceViewModelProtocol)
-    func didReceive(lockedBalance: BalanceViewModelProtocol, isSelectable: Bool)
+    func didReceive(balance: AssetDetailsBalanceModel)
     func didReceive(availableOperations: AssetDetailsOperation)
 }
 

--- a/novawallet/Modules/AssetDetails/AssetDetailsViewController.swift
+++ b/novawallet/Modules/AssetDetails/AssetDetailsViewController.swift
@@ -101,25 +101,15 @@ extension AssetDetailsViewController: AssetDetailsViewProtocol {
         rootView.set(assetDetailsModel: assetModel)
     }
 
-    func didReceive(totalBalance: BalanceViewModelProtocol) {
-        rootView.balanceWidget.totalTokensBalanceLabel.text = totalBalance.amount
-        rootView.balanceWidget.totalValueBalanceLabel.text = totalBalance.price
-    }
-
-    func didReceive(transferableBalance: BalanceViewModelProtocol) {
-        rootView.balanceWidget.transferrableCell.bind(viewModel: transferableBalance)
-    }
-
-    func didReceive(lockedBalance: BalanceViewModelProtocol, isSelectable: Bool) {
-        rootView.balanceWidget.lockCell.bind(viewModel: lockedBalance)
-        rootView.balanceWidget.lockCell.canSelect = isSelectable
-    }
-
     func didReceive(availableOperations: AssetDetailsOperation) {
         rootView.sendButton.isEnabled = availableOperations.contains(.send)
         rootView.receiveButton.isEnabled = availableOperations.contains(.receive)
         rootView.swapButton.isEnabled = availableOperations.contains(.swap)
         rootView.buyButton.isEnabled = availableOperations.contains(.buy)
+    }
+
+    func didReceive(balance: AssetDetailsBalanceModel) {
+        rootView.balanceWidget.bind(with: balance)
     }
 }
 

--- a/novawallet/Modules/AssetDetails/Model/AssetDetailsBalanceModel.swift
+++ b/novawallet/Modules/AssetDetails/Model/AssetDetailsBalanceModel.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct AssetDetailsBalanceModel {
+    let total: AssetDetailsInteractiveBalanceModel
+    let locked: AssetDetailsInteractiveBalanceModel
+    let transferrable: BalanceViewModelProtocol
+}
+
+struct AssetDetailsInteractiveBalanceModel {
+    let balance: BalanceViewModelProtocol
+    let interactive: Bool
+}

--- a/novawallet/Modules/AssetDetails/View/AssetDetailsBalanceWidget.swift
+++ b/novawallet/Modules/AssetDetails/View/AssetDetailsBalanceWidget.swift
@@ -40,10 +40,9 @@ class AssetDetailsBalanceWidget: UIView {
     }
 
     let totalCell: StackTitleValueIconView = .create { view in
-        view.rowContentView.fView.sView.image = R.image.iconSmallArrowDown()?
-            .tinted(with: R.color.colorIconChip()!)?
-            .withAlignmentRectInsets(.init(inset: -4))
-        view.rowContentView.fView.sView.borderView.apply(style: .chips)
+        view.apply(style: .balanceWidgetStaticPart)
+        view.canSelect = false
+
         view.rowContentView.fView.sView.borderView.cornerRadius = Constants.arrowImageViewSize.width / 2
 
         view.frame = CGRect(
@@ -62,14 +61,6 @@ class AssetDetailsBalanceWidget: UIView {
         $0.canSelect = false
     }
 
-    var totalTokensBalanceLabel: UILabel {
-        totalCell.rowContentView.fView.fView
-    }
-
-    var totalValueBalanceLabel: UILabel {
-        totalCell.rowContentView.sView
-    }
-
     var rowIconImageView: UIImageView {
         totalCell.rowContentView.fView.sView
     }
@@ -78,9 +69,9 @@ class AssetDetailsBalanceWidget: UIView {
         super.init(frame: frame)
 
         setupLayout()
+        setupStyle()
         setupActions()
         hideDetails()
-        clipsToBounds = true
     }
 
     @available(*, unavailable)
@@ -99,6 +90,11 @@ private extension AssetDetailsBalanceWidget {
         balanceTableView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
+    }
+
+    func setupStyle() {
+        clipsToBounds = true
+        totalCell.roundedBackgroundView.highlightedFillColor = .clear
     }
 
     func setupBalanceTableViewLayout() {
@@ -178,6 +174,16 @@ private extension AssetDetailsBalanceWidget {
 // MARK: Internal
 
 extension AssetDetailsBalanceWidget {
+    func bind(with model: AssetDetailsBalanceModel) {
+        totalCell.bind(with: model.total.balance)
+        totalCell.canSelect = model.total.interactive
+
+        lockCell.bind(viewModel: model.locked.balance)
+        lockCell.canSelect = model.locked.interactive
+
+        transferrableCell.bind(viewModel: model.transferrable)
+    }
+
     func set(locale: Locale) {
         let languages = locale.rLanguages
 

--- a/novawallet/Modules/AssetDetails/View/AssetDetailsStyles.swift
+++ b/novawallet/Modules/AssetDetails/View/AssetDetailsStyles.swift
@@ -36,3 +36,14 @@ extension IconDetailsView.Style {
         font: .regularSubheadline
     )
 }
+
+extension StackTitleValueIconView.Style {
+    static let balanceWidgetStaticPart = StackTitleValueIconView.Style(
+        title: .boldTitle2Primary,
+        value: .regularSubhedlineSecondary,
+        icon: R.image.iconSmallArrowDown()?
+            .tinted(with: R.color.colorIconChip()!)?
+            .withAlignmentRectInsets(.init(inset: -4)),
+        iconBorderStyle: .chips
+    )
+}

--- a/novawallet/Modules/AssetDetails/View/AssetDetailsViewModelFactory.swift
+++ b/novawallet/Modules/AssetDetails/View/AssetDetailsViewModelFactory.swift
@@ -19,7 +19,6 @@ protocol AssetDetailsViewModelFactoryProtocol {
     func createBalanceViewModel(params: AssetDetailsBalanceModelParams) -> AssetDetailsBalanceModel
 
     func createAssetDetailsModel(
-        balance: AssetBalance,
         priceData: PriceData?,
         chainAsset: ChainAsset,
         locale: Locale
@@ -136,7 +135,6 @@ extension AssetDetailsViewModelFactory: AssetDetailsViewModelFactoryProtocol {
     }
 
     func createAssetDetailsModel(
-        balance _: AssetBalance,
         priceData: PriceData?,
         chainAsset: ChainAsset,
         locale: Locale

--- a/novawallet/Modules/AssetDetails/View/AssetDetailsViewModelFactory.swift
+++ b/novawallet/Modules/AssetDetails/View/AssetDetailsViewModelFactory.swift
@@ -2,16 +2,21 @@ import Foundation
 import SoraFoundation
 import BigInt
 
+struct AssetDetailsBalanceModelParams {
+    let total: BigUInt
+    let locked: BigUInt
+    let transferrable: BigUInt
+    let externalBalances: [ExternalAssetBalance]
+    let assetDisplayInfo: AssetBalanceDisplayInfo
+    let priceData: PriceData?
+    let locale: Locale
+}
+
 protocol AssetDetailsViewModelFactoryProtocol {
     func amountFormatter(assetDisplayInfo: AssetBalanceDisplayInfo) -> LocalizableResource<TokenFormatter>
     func priceFormatter(priceId: Int?) -> LocalizableResource<TokenFormatter>
 
-    func createBalanceViewModel(
-        value: BigUInt,
-        assetDisplayInfo: AssetBalanceDisplayInfo,
-        priceData: PriceData?,
-        locale: Locale
-    ) -> BalanceViewModelProtocol
+    func createBalanceViewModel(params: AssetDetailsBalanceModelParams) -> AssetDetailsBalanceModel
 
     func createAssetDetailsModel(
         balance: AssetBalance,
@@ -21,7 +26,7 @@ protocol AssetDetailsViewModelFactoryProtocol {
     ) -> AssetDetailsModel
 }
 
-final class AssetDetailsViewModelFactory: AssetDetailsViewModelFactoryProtocol {
+final class AssetDetailsViewModelFactory {
     let networkViewModelFactory: NetworkViewModelFactoryProtocol
     let priceChangePercentFormatter: LocalizableResource<NumberFormatter>
     let priceAssetInfoFactory: PriceAssetInfoFactoryProtocol
@@ -41,56 +46,40 @@ final class AssetDetailsViewModelFactory: AssetDetailsViewModelFactoryProtocol {
         self.networkViewModelFactory = networkViewModelFactory
         self.priceChangePercentFormatter = priceChangePercentFormatter
     }
+}
 
-    func createBalanceViewModel(
-        value: BigUInt,
+private extension AssetDetailsViewModelFactory {
+    func createBalanceModel(
+        for value: BigUInt,
         assetDisplayInfo: AssetBalanceDisplayInfo,
         priceData: PriceData?,
         locale: Locale
-    ) -> BalanceViewModelProtocol {
+    ) -> BalanceViewModel {
         let formatter = amountFormatter(assetDisplayInfo: assetDisplayInfo).value(for: locale)
         let amount = value.decimal(precision: UInt16(assetDisplayInfo.assetPrecision))
         let amountString = formatter.stringFromDecimal(amount) ?? ""
-        guard let priceData = priceData, let price = Decimal(string: priceData.price) else {
+
+        guard
+            let priceData = priceData,
+            let price = Decimal(string: priceData.price)
+        else {
             return BalanceViewModel(
                 amount: amountString,
                 price: ""
             )
         }
+
         let priceString = priceFormatter(priceId: priceData.currencyId)
             .value(for: locale)
             .stringFromDecimal(price * amount) ?? ""
+
         return BalanceViewModel(
             amount: amountString,
             price: priceString
         )
     }
 
-    func createAssetDetailsModel(
-        balance: AssetBalance,
-        priceData: PriceData?,
-        chainAsset: ChainAsset,
-        locale: Locale
-    ) -> AssetDetailsModel {
-        let networkViewModel = networkViewModelFactory.createViewModel(from: chainAsset.chain)
-        let assetIcon = assetIconViewModelFactory.createAssetIconViewModel(for: chainAsset.asset.icon)
-
-        return AssetDetailsModel(
-            tokenName: chainAsset.asset.symbol,
-            assetIcon: assetIcon,
-            price: createPriceState(
-                balance: balance,
-                precision: chainAsset.asset.precision,
-                priceData: priceData,
-                locale: locale
-            ),
-            network: networkViewModel
-        )
-    }
-
-    private func createPriceState(
-        balance _: AssetBalance,
-        precision _: UInt16,
+    func createPriceState(
         priceData: PriceData?,
         locale: Locale
     ) -> AssetPriceViewModel {
@@ -112,6 +101,59 @@ final class AssetDetailsViewModelFactory: AssetDetailsViewModelFactoryProtocol {
             .value(for: locale)
             .stringFromDecimal(price) ?? ""
         return AssetPriceViewModel(amount: priceString, change: priceChange)
+    }
+}
+
+extension AssetDetailsViewModelFactory: AssetDetailsViewModelFactoryProtocol {
+    func createBalanceViewModel(params: AssetDetailsBalanceModelParams) -> AssetDetailsBalanceModel {
+        let models = [
+            params.total,
+            params.locked,
+            params.transferrable
+        ].map { value in
+            createBalanceModel(
+                for: value,
+                assetDisplayInfo: params.assetDisplayInfo,
+                priceData: params.priceData,
+                locale: params.locale
+            )
+        }
+
+        let totalModel = AssetDetailsInteractiveBalanceModel(
+            balance: models[0],
+            interactive: params.total > 0
+        )
+        let lockedModel = AssetDetailsInteractiveBalanceModel(
+            balance: models[1],
+            interactive: params.locked > 0 || !params.externalBalances.isEmpty
+        )
+
+        return AssetDetailsBalanceModel(
+            total: totalModel,
+            locked: lockedModel,
+            transferrable: models[2]
+        )
+    }
+
+    func createAssetDetailsModel(
+        balance _: AssetBalance,
+        priceData: PriceData?,
+        chainAsset: ChainAsset,
+        locale: Locale
+    ) -> AssetDetailsModel {
+        let networkViewModel = networkViewModelFactory.createViewModel(from: chainAsset.chain)
+        let assetIcon = assetIconViewModelFactory.createAssetIconViewModel(for: chainAsset.asset.icon)
+        let price = createPriceState(
+            priceData: priceData,
+            locale: locale
+        )
+
+        return AssetDetailsModel(
+            tokenName: chainAsset.asset.symbol,
+            assetIcon: assetIcon,
+            price: price,
+            network: networkViewModel
+        )
     }
 
     func priceFormatter(priceId: Int?) -> LocalizableResource<TokenFormatter> {

--- a/novawallet/Modules/AssetDetails/View/StackTitleValueIconView.swift
+++ b/novawallet/Modules/AssetDetails/View/StackTitleValueIconView.swift
@@ -10,6 +10,14 @@ class StackTitleValueIconView: RowView<
         UILabel
     >
 >, StackTableViewCellProtocol {
+    var canSelect: Bool = true {
+        didSet {
+            if oldValue != canSelect {
+                updateSelection()
+            }
+        }
+    }
+
     convenience init() {
         self.init(frame: CGRect(origin: .zero, size: CGSize(width: 340, height: 44.0)))
     }
@@ -26,14 +34,29 @@ class StackTitleValueIconView: RowView<
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+}
 
-    private func configure() {
+private extension StackTitleValueIconView {
+    func configure() {
         rowContentView.makeVertical()
         rowContentView.spacing = 4
         rowContentView.fView.makeHorizontal()
-        rowContentView.fView.fView.apply(style: .boldTitle2Primary)
-        rowContentView.sView.apply(style: .regularSubhedlineSecondary)
+    }
 
-        isUserInteractionEnabled = true
+    func updateSelection() {
+        if canSelect {
+            isUserInteractionEnabled = true
+            rowContentView.fView.sView.isHidden = false
+        } else {
+            isUserInteractionEnabled = false
+            rowContentView.fView.sView.isHidden = true
+        }
+    }
+}
+
+extension StackTitleValueIconView {
+    func bind(with model: BalanceViewModelProtocol) {
+        rowContentView.fView.fView.text = model.amount
+        rowContentView.sView.text = model.price
     }
 }

--- a/novawallet/Modules/AssetPriceChart/AssetPriceChartViewController.swift
+++ b/novawallet/Modules/AssetPriceChart/AssetPriceChartViewController.swift
@@ -6,16 +6,19 @@ final class AssetPriceChartViewController: UIViewController, ViewHolder {
 
     private let presenter: AssetPriceChartPresenterProtocol
     private let seekHapticPlayer: ProgressiveHapticPlayer
+    private let chartLongPressHapticPlayer: HapticPlayer
     private let periodControlHapticPlayer: HapticPlayer
     private let dataSource: AssetPriceChartViewDataSourceProtocol
 
     init(
         presenter: AssetPriceChartPresenterProtocol,
         seekHapticPlayer: ProgressiveHapticPlayer,
+        chartLongPressHapticPlayer: HapticPlayer,
         periodControlHapticPlayer: HapticPlayer
     ) {
         self.presenter = presenter
         self.seekHapticPlayer = seekHapticPlayer
+        self.chartLongPressHapticPlayer = chartLongPressHapticPlayer
         self.periodControlHapticPlayer = periodControlHapticPlayer
         dataSource = AssetPriceChartViewDataSource()
         super.init(nibName: nil, bundle: nil)
@@ -186,7 +189,7 @@ private extension AssetPriceChartViewController {
             target: self,
             action: #selector(handleLongPress)
         )
-        longPressGestureRecognizer.minimumPressDuration = 0.1
+        longPressGestureRecognizer.minimumPressDuration = 0.05
         longPressGestureRecognizer.allowableMovement = 0
 
         rootView.chartView.addGestureRecognizer(longPressGestureRecognizer)
@@ -207,13 +210,19 @@ private extension AssetPriceChartViewController {
     }
 
     @objc func handleLongPress(gestureRecognizer: UILongPressGestureRecognizer) {
+        if gestureRecognizer.state == .began {
+            chartLongPressHapticPlayer.play()
+        }
+
         switch gestureRecognizer.state {
         case .began, .changed:
             let locationOnChart = gestureRecognizer.location(in: rootView.chartView)
             let highlight = rootView.chartView.getHighlightByTouchPoint(locationOnChart)
-            let entry = rootView.chartView.getEntryByTouchPoint(point: locationOnChart)
 
-            handleChartEntrySelected(entry, highlight: highlight)
+            rootView.chartView.highlightValue(
+                highlight,
+                callDelegate: true
+            )
         case .ended, .cancelled, .failed:
             handleEntrySelectionEnded()
         default:

--- a/novawallet/Modules/AssetPriceChart/Factory/AssetPriceChartViewFactory.swift
+++ b/novawallet/Modules/AssetPriceChart/Factory/AssetPriceChartViewFactory.swift
@@ -47,14 +47,15 @@ struct AssetPriceChartViewFactory {
         let seekHapticPlayer = HapticPlayerFactory.createProgressivePlayer(
             patternConfiguration: .chartSeek
         )
-        let periodControlHapticPlayer = HapticPlayerFactory.createHapticPlayer(
+        let singleTapHapticPlayer = HapticPlayerFactory.createHapticPlayer(
             patternConfiguration: .singleTap
         )
 
         let view = AssetPriceChartViewController(
             presenter: presenter,
             seekHapticPlayer: seekHapticPlayer,
-            periodControlHapticPlayer: periodControlHapticPlayer
+            chartLongPressHapticPlayer: singleTapHapticPlayer,
+            periodControlHapticPlayer: singleTapHapticPlayer
         )
 
         presenter.view = view

--- a/novawallet/Modules/AssetPriceChart/Factory/AssetPriceChartViewModelFactory.swift
+++ b/novawallet/Modules/AssetPriceChart/Factory/AssetPriceChartViewModelFactory.swift
@@ -66,7 +66,7 @@ private extension AssetPriceChartViewModelFactory {
             .value(for: locale)
             .stringFromDecimal(periodChangeDecimal) ?? ""
 
-        var percent = if firstEntry.value > 0 {
+        let percent = if firstEntry.value > 0 {
             periodChangeDecimal / firstEntry.value
         } else {
             periodChangeDecimal

--- a/novawallet/Modules/Currency/View/CurrencyViewController.swift
+++ b/novawallet/Modules/Currency/View/CurrencyViewController.swift
@@ -62,6 +62,7 @@ final class CurrencyViewController: UIViewController, ViewHolder {
             )
             let section = self.dataSource.snapshot().sectionIdentifiers[indexPath.section]
             header?.bind(title: section.title)
+            header?.titleLabel.apply(style: .footnoteSecondary)
             header?.contentInsets = .zero
             return header
         }

--- a/novawallet/Modules/Currency/View/CurrencyViewLayout.swift
+++ b/novawallet/Modules/Currency/View/CurrencyViewLayout.swift
@@ -52,11 +52,11 @@ final class CurrencyViewLayout: UIView {
 extension CurrencyViewLayout {
     private enum Constants {
         static let estimatedRowHeight: CGFloat = 56
-        static let absoluteHeaderHeight: CGFloat = 24
+        static let absoluteHeaderHeight: CGFloat = 18
         static let sectionContentInsets = NSDirectionalEdgeInsets(
-            top: 12,
+            top: 4,
             leading: 16,
-            bottom: 28,
+            bottom: 16,
             trailing: 16
         )
         static let interGroupSpacing: CGFloat = 0


### PR DESCRIPTION
### SUMMARY

This PR contains fixes for bugs found during pre-release testing:

- Use original price decimal to calculate price change. Previously, we used values of `Double` type received from the chart. Due to precision differences, the resulting values were incorrect. To resolve this problem, we now store all prices by timestamp using a dictionary. This way we can retrieve the original price for any selected entry and use it to calculate price change accurately.
Described difference is demonstrated in **SCREEN RECORDINGS** section.
- Add haptic feedback for the long press `began` state.
- Disable highlighting for the balance widget's total cell.
- Hide chevron and disable expanding/collapsing behavior for zero balances.
- Fix header fonts and insets on the `Currency` screen.

Additionally:

- The view's balance update logic has been refactored.
- `AssetDetailsBalanceWidget` now supports common styling API.

### SCREEN RECORDINGS

Before:

https://github.com/user-attachments/assets/81c3da50-22c3-4d0f-955b-934f94fcd05f

Fixed:

https://github.com/user-attachments/assets/e44d8720-0831-4915-81c6-6df5326942e5

### SCREENSHOTS

<img src="https://github.com/user-attachments/assets/e9c78c3a-6879-4e1b-801f-d2ac56bfc6c8" width=45% height=45%>
<img src="https://github.com/user-attachments/assets/e736769f-4bc1-4559-89c0-9a97d5706991" width=45% height=45%>
