### PR TITLE
Fix dapp corner cases

### DIFF
--- a/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/ChainModel.swift
@@ -606,6 +606,14 @@ extension ChainModel {
         let priceIds = assets.compactMap(\.priceId)
         return Set(priceIds)
     }
+
+    var genesisHash: Data? {
+        guard !isPureEvm else {
+            return nil
+        }
+
+        return try? Data(hexString: chainId)
+    }
 }
 
 extension ChainModel.AddressPrefix {

--- a/novawallet/Modules/DApp/DAppBrowser/StateMachine/DAppBrowserStateDataSource.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/StateMachine/DAppBrowserStateDataSource.swift
@@ -69,12 +69,11 @@ final class DAppBrowserStateDataSource {
                 return nil
             }
 
-            let genesisHash = try Data(hexString: chain.chainId)
             let name = wallet.name + " (\(chain.name))"
 
             return try createExtensionAccount(
                 for: chainAccount.accountId,
-                genesisHash: genesisHash,
+                genesisHash: chain.genesisHash,
                 name: name,
                 chainFormat: chain.chainFormat,
                 rawCryptoType: chainAccount.cryptoType

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Proccessing.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Proccessing.swift
@@ -97,15 +97,6 @@ extension DAppOperationConfirmInteractor {
                 throw DAppOperationConfirmInteractorError.extrinsicBadField(name: "blockNumber")
             }
 
-            let expectedSignedExtensions = codingFactory.metadata.getSignedExtensions()
-
-            guard expectedSignedExtensions == extrinsic.signedExtensions else {
-                throw DAppOperationConfirmInteractorError.signedExtensionsMismatch(
-                    actual: extrinsic.signedExtensions,
-                    expected: expectedSignedExtensions
-                )
-            }
-
             guard let method = try? callOperation.extractNoCancellableResultData() else {
                 throw DAppOperationConfirmInteractorError.extrinsicBadField(name: "method")
             }
@@ -127,7 +118,6 @@ extension DAppOperationConfirmInteractor {
                 transactionVersion: UInt32(transactionVersion),
                 metadataHash: extrinsic.metadataHash,
                 withSignedTransaction: extrinsic.withSignedTransaction ?? false,
-                signedExtensions: expectedSignedExtensions,
                 version: extrinsic.version
             )
 

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Proccessing.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Proccessing.swift
@@ -118,6 +118,7 @@ extension DAppOperationConfirmInteractor {
                 transactionVersion: UInt32(transactionVersion),
                 metadataHash: extrinsic.metadataHash,
                 withSignedTransaction: extrinsic.withSignedTransaction ?? false,
+                signedExtensions: extrinsic.signedExtensions,
                 version: extrinsic.version
             )
 

--- a/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppOperationConfirmInteractorError.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppOperationConfirmInteractorError.swift
@@ -3,7 +3,6 @@ import Foundation
 enum DAppOperationConfirmInteractorError: Error {
     case addressMismatch(actual: AccountAddress, expected: AccountAddress)
     case extrinsicBadField(name: String)
-    case signedExtensionsMismatch(actual: [String], expected: [String])
     case invalidRawSignature(data: Data)
     case signingFailed
 }
@@ -26,10 +25,6 @@ extension DAppOperationConfirmInteractorError: ErrorContentConvertible {
         case let .extrinsicBadField(name):
             message = R.string.localizable.dappConfirmationBadField(
                 name,
-                preferredLanguages: locale?.rLanguages
-            )
-        case .signedExtensionsMismatch:
-            message = R.string.localizable.dappConfirmationExtensionsMismatch(
                 preferredLanguages: locale?.rLanguages
             )
         case .invalidRawSignature:


### PR DESCRIPTION
## Purpose

- don't provide genesis hash for pure ethereum accounts
- remove unnecessary check for signed extensions during extrinsic confirmation