### PR TITLE
Feature/history for legacy address

### DIFF
--- a/novawallet/Common/Helpers/AddressConversion.swift
+++ b/novawallet/Common/Helpers/AddressConversion.swift
@@ -50,7 +50,7 @@ extension AccountAddress {
                 prefix
             }
 
-            return try SS58AddressFactory().accountId(
+            return try factory.accountId(
                 fromAddress: self,
                 type: correspondingPrefix
             )
@@ -109,6 +109,19 @@ extension AccountAddress {
 
     func normalize(for chainFormat: ChainFormat) -> AccountAddress? {
         try? toAccountId(using: chainFormat).toAddress(using: chainFormat)
+    }
+
+    func toLegacySubstrateAddress(for chainFormat: ChainFormat) throws -> AccountAddress? {
+        guard
+            case let .substrate(prefix, legacyPrefix) = chainFormat,
+            let legacyPrefix
+        else { return nil }
+
+        let factory = SS58AddressFactory()
+        let accountId = try toAccountId(using: chainFormat)
+        let legacyAddress = try factory.address(fromAccountId: accountId, type: legacyPrefix)
+
+        return legacyAddress
     }
 }
 

--- a/novawallet/Common/Helpers/AddressConversion.swift
+++ b/novawallet/Common/Helpers/AddressConversion.swift
@@ -113,7 +113,7 @@ extension AccountAddress {
 
     func toLegacySubstrateAddress(for chainFormat: ChainFormat) throws -> AccountAddress? {
         guard
-            case let .substrate(prefix, legacyPrefix) = chainFormat,
+            case let .substrate(_, legacyPrefix) = chainFormat,
             let legacyPrefix
         else { return nil }
 

--- a/novawallet/Common/Helpers/TransactionHistory/TransactionHistoryMergeManager.swift
+++ b/novawallet/Common/Helpers/TransactionHistory/TransactionHistoryMergeManager.swift
@@ -83,14 +83,9 @@ enum TransactionHistoryMergeItem {
 }
 
 final class TransactionHistoryMergeManager {
-    let address: String
     let chainAsset: ChainAsset
 
-    init(
-        address: String,
-        chainAsset: ChainAsset
-    ) {
-        self.address = address
+    init(chainAsset: ChainAsset) {
         self.chainAsset = chainAsset
     }
 

--- a/novawallet/Common/Network/Etherscan/ERC20/EtherscanERC20OperationFactory.swift
+++ b/novawallet/Common/Network/Etherscan/ERC20/EtherscanERC20OperationFactory.swift
@@ -8,15 +8,13 @@ final class EtherscanERC20OperationFactory: EtherscanBaseOperationFactory {
     init(
         contractAddress: AccountAddress,
         baseUrl: URL,
-        chainId: ChainModel.Id,
-        operationManager: OperationManagerProtocol
+        chainId: ChainModel.Id
     ) {
         self.contractAddress = contractAddress
 
         super.init(
             baseUrl: baseUrl,
-            chainId: chainId,
-            operationManager: operationManager
+            chainId: chainId
         )
     }
 }
@@ -43,28 +41,22 @@ private extension EtherscanERC20OperationFactory {
         return components.url
     }
 
-    func createInfoOperation(
+    func createInfo(
         accountId: AccountId,
         chainFormat: ChainFormat,
         pagination: EtherscanPagination
-    ) -> BaseOperation<EtherscanERC20HistoryInfo> {
-        ClosureOperation { [weak self] in
-            guard let self else {
-                throw BaseOperationError.parentOperationCancelled
-            }
+    ) throws -> EtherscanERC20HistoryInfo {
+        let address = try accountId.toAddress(using: chainFormat)
+        let ethereumAddress = address.toEthereumAddressWithChecksum() ?? address
 
-            let address = try accountId.toAddress(using: chainFormat)
-            let ethereumAddress = address.toEthereumAddressWithChecksum() ?? address
+        let info = EtherscanERC20HistoryInfo(
+            address: ethereumAddress,
+            contractaddress: contractAddress,
+            page: pagination.page,
+            offset: pagination.offset
+        )
 
-            let info = EtherscanERC20HistoryInfo(
-                address: ethereumAddress,
-                contractaddress: contractAddress,
-                page: pagination.page,
-                offset: pagination.offset
-            )
-
-            return info
-        }
+        return info
     }
 
     func createFetchWrapper(
@@ -72,37 +64,24 @@ private extension EtherscanERC20OperationFactory {
         chainFormat: ChainFormat,
         pagination: EtherscanPagination
     ) -> CompoundOperationWrapper<WalletRemoteHistoryData> {
-        let infoOperation = createInfoOperation(
+        guard let info = try? createInfo(
             accountId: accountId,
             chainFormat: chainFormat,
             pagination: pagination
-        )
-
-        let wrapper: CompoundOperationWrapper<WalletRemoteHistoryData>
-        wrapper = OperationCombiningService.compoundNonOptionalWrapper(
-            operationManager: operationManager
-        ) { [weak self] in
-            guard let self else {
-                return .createWithError(BaseOperationError.parentOperationCancelled)
-            }
-
-            let info = try infoOperation.extractNoCancellableResultData()
-
-            guard let url = buildUrl(for: info) else {
-                return CompoundOperationWrapper.createWithError(NetworkBaseError.invalidUrl)
-            }
-
-            return createFetchWrapper(
-                for: url,
-                page: info.page,
-                offset: info.offset,
-                responseType: EtherscanERC20HistoryResponse.self
-            )
+        ) else {
+            return .createWithError(WalletRemoteHistoryError.fetchParamsCreation)
         }
 
-        wrapper.addDependency(operations: [infoOperation])
+        guard let url = buildUrl(for: info) else {
+            return CompoundOperationWrapper.createWithError(NetworkBaseError.invalidUrl)
+        }
 
-        return wrapper.insertingHead(operations: [infoOperation])
+        return createFetchWrapper(
+            for: url,
+            page: info.page,
+            offset: info.offset,
+            responseType: EtherscanERC20HistoryResponse.self
+        )
     }
 }
 

--- a/novawallet/Common/Network/Etherscan/ERC20/EtherscanERC20OperationFactory.swift
+++ b/novawallet/Common/Network/Etherscan/ERC20/EtherscanERC20OperationFactory.swift
@@ -4,13 +4,16 @@ import SoraFoundation
 
 final class EtherscanERC20OperationFactory: EtherscanBaseOperationFactory {
     let contractAddress: AccountAddress
+    let chainFormat: ChainFormat
 
     init(
         contractAddress: AccountAddress,
+        chainFormat: ChainFormat,
         baseUrl: URL,
         chainId: ChainModel.Id
     ) {
         self.contractAddress = contractAddress
+        self.chainFormat = chainFormat
 
         super.init(
             baseUrl: baseUrl,
@@ -95,7 +98,6 @@ extension EtherscanERC20OperationFactory: WalletRemoteHistoryFactoryProtocol {
 
     func createOperationWrapper(
         for accountId: AccountId,
-        chainFormat: ChainFormat,
         pagination: Pagination
     ) -> CompoundOperationWrapper<WalletRemoteHistoryData> {
         guard let etherscanPagination = preparePagination(from: pagination) else {

--- a/novawallet/Common/Network/Etherscan/EtherscanBaseOperationFactory.swift
+++ b/novawallet/Common/Network/Etherscan/EtherscanBaseOperationFactory.swift
@@ -4,16 +4,13 @@ import Operation_iOS
 class EtherscanBaseOperationFactory {
     let baseUrl: URL
     let chainId: ChainModel.Id
-    let operationManager: OperationManagerProtocol
 
     init(
         baseUrl: URL,
-        chainId: ChainModel.Id,
-        operationManager: OperationManagerProtocol
+        chainId: ChainModel.Id
     ) {
         self.baseUrl = baseUrl
         self.chainId = chainId
-        self.operationManager = operationManager
     }
 
     func createFetchWrapper<R: EtherscanWalletHistoryDecodable>(

--- a/novawallet/Common/Network/Etherscan/EtherscanBaseOperationFactory.swift
+++ b/novawallet/Common/Network/Etherscan/EtherscanBaseOperationFactory.swift
@@ -4,10 +4,16 @@ import Operation_iOS
 class EtherscanBaseOperationFactory {
     let baseUrl: URL
     let chainId: ChainModel.Id
+    let operationManager: OperationManagerProtocol
 
-    init(baseUrl: URL, chainId: ChainModel.Id) {
+    init(
+        baseUrl: URL,
+        chainId: ChainModel.Id,
+        operationManager: OperationManagerProtocol
+    ) {
         self.baseUrl = baseUrl
         self.chainId = chainId
+        self.operationManager = operationManager
     }
 
     func createFetchWrapper<R: EtherscanWalletHistoryDecodable>(

--- a/novawallet/Common/Network/Etherscan/Native/EtherscanNativeOperationFactory.swift
+++ b/novawallet/Common/Network/Etherscan/Native/EtherscanNativeOperationFactory.swift
@@ -4,13 +4,16 @@ import SoraFoundation
 
 final class EtherscanNativeOperationFactory: EtherscanBaseOperationFactory {
     let filter: WalletHistoryFilter
+    let chainFormat: ChainFormat
 
     init(
         filter: WalletHistoryFilter,
+        chainFormat: ChainFormat,
         baseUrl: URL,
         chainId: ChainModel.Id
     ) {
         self.filter = filter
+        self.chainFormat = chainFormat
 
         super.init(
             baseUrl: baseUrl,
@@ -116,7 +119,6 @@ private extension EtherscanNativeOperationFactory {
 extension EtherscanNativeOperationFactory: WalletRemoteHistoryFactoryProtocol {
     func createOperationWrapper(
         for accountId: AccountId,
-        chainFormat: ChainFormat,
         pagination: Pagination
     ) -> CompoundOperationWrapper<WalletRemoteHistoryData> {
         guard let etherscanPagination = preparePagination(from: pagination) else {

--- a/novawallet/Common/Network/Subquery/SubqueryHistoryOperationFactory+RemoteHistory.swift
+++ b/novawallet/Common/Network/Subquery/SubqueryHistoryOperationFactory+RemoteHistory.swift
@@ -8,7 +8,6 @@ extension SubqueryHistoryOperationFactory: WalletRemoteHistoryFactoryProtocol {
 
     func createOperationWrapper(
         for accountId: AccountId,
-        chainFormat: ChainFormat,
         pagination: Pagination
     ) -> CompoundOperationWrapper<WalletRemoteHistoryData> {
         guard !isComplete(pagination: pagination) else {
@@ -20,7 +19,6 @@ extension SubqueryHistoryOperationFactory: WalletRemoteHistoryFactoryProtocol {
 
         let fetchOperation = createOperation(
             accountId: accountId,
-            chainFormat: chainFormat,
             count: pagination.count,
             cursor: subqueryContext.cursor
         )

--- a/novawallet/Common/Network/Subquery/SubqueryHistoryOperationFactory.swift
+++ b/novawallet/Common/Network/Subquery/SubqueryHistoryOperationFactory.swift
@@ -158,10 +158,11 @@ private extension SubqueryHistoryOperationFactory {
             guard let self else { throw BaseOperationError.parentOperationCancelled }
 
             var address = try accountId.toAddress(using: chainFormat)
-            let legacyAddress = try address.toLegacySubstrateAddress(for: chainFormat)
+            var legacyAddress = try address.toLegacySubstrateAddress(for: chainFormat)
 
             if ethereumBased {
                 address = address.toEthereumAddressWithChecksum() ?? address
+                legacyAddress = legacyAddress?.toEthereumAddressWithChecksum() ?? legacyAddress
             }
 
             let after = cursor.map { "\"\($0)\"" } ?? "null"

--- a/novawallet/Common/Network/Subquery/SubqueryHistoryOperationFactory.swift
+++ b/novawallet/Common/Network/Subquery/SubqueryHistoryOperationFactory.swift
@@ -5,7 +5,6 @@ import SubstrateSdk
 protocol SubqueryHistoryOperationFactoryProtocol {
     func createOperation(
         accountId: AccountId,
-        chainFormat: ChainFormat,
         count: Int,
         cursor: String?
     ) -> BaseOperation<SubqueryHistoryData>
@@ -21,19 +20,22 @@ final class SubqueryHistoryOperationFactory {
     let assetId: String?
     let hasPoolStaking: Bool
     let hasSwaps: Bool
+    let chainFormat: ChainFormat
 
     init(
         url: URL,
         filter: WalletHistoryFilter,
         assetId: String?,
         hasPoolStaking: Bool,
-        hasSwaps: Bool
+        hasSwaps: Bool,
+        chainFormat: ChainFormat
     ) {
         self.url = url
         self.filter = filter
         self.assetId = assetId
         self.hasPoolStaking = hasPoolStaking
         self.hasSwaps = hasSwaps
+        self.chainFormat = chainFormat
     }
 }
 
@@ -148,7 +150,6 @@ private extension SubqueryHistoryOperationFactory {
 
     func createQuery(
         _ accountId: AccountId,
-        chainFormat: ChainFormat,
         count: Int,
         cursor: String?
     ) throws -> String {
@@ -208,13 +209,11 @@ private extension SubqueryHistoryOperationFactory {
 
     func createRequestFactory(
         accountId: AccountId,
-        chainFormat: ChainFormat,
         count: Int,
         cursor: String?
     ) throws -> BlockNetworkRequestFactory {
         let queryString = try createQuery(
             accountId,
-            chainFormat: chainFormat,
             count: count,
             cursor: cursor
         )
@@ -241,13 +240,11 @@ private extension SubqueryHistoryOperationFactory {
 extension SubqueryHistoryOperationFactory: SubqueryHistoryOperationFactoryProtocol {
     func createOperation(
         accountId: AccountId,
-        chainFormat: ChainFormat,
         count: Int,
         cursor: String?
     ) -> BaseOperation<SubqueryHistoryData> {
         guard let requestFactory = try? createRequestFactory(
             accountId: accountId,
-            chainFormat: chainFormat,
             count: count,
             cursor: cursor
         ) else {

--- a/novawallet/Modules/AssetReceive/Model/LegacyWalletQRCoderFactory.swift
+++ b/novawallet/Modules/AssetReceive/Model/LegacyWalletQRCoderFactory.swift
@@ -39,8 +39,8 @@ extension ChainFormat {
         switch self {
         case .ethereum:
             return .ethereum
-        case let .substrate(type):
-            return .substrate(type: type)
+        case let .substrate(prefix, _):
+            return .substrate(type: prefix)
         }
     }
 }

--- a/novawallet/Modules/TransactionHistory/Service/AssetHistoryFactoryFacade.swift
+++ b/novawallet/Modules/TransactionHistory/Service/AssetHistoryFactoryFacade.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Operation_iOS
 
 protocol AssetHistoryFactoryFacadeProtocol {
     func createOperationFactory(
@@ -8,6 +9,12 @@ protocol AssetHistoryFactoryFacadeProtocol {
 }
 
 final class AssetHistoryFacade {
+    let operationManager: OperationManagerProtocol
+
+    init(operationManager: OperationManagerProtocol = OperationManagerFacade.sharedManager) {
+        self.operationManager = operationManager
+    }
+
     func createSubqueryFactory(
         for chainAsset: ChainAsset,
         filter: WalletHistoryFilter
@@ -36,8 +43,10 @@ final class AssetHistoryFacade {
                 url: url,
                 filter: mappedFilter,
                 assetId: historyAssetId,
+                ethereumBased: chainAsset.chain.isEthereumBased,
                 hasPoolStaking: asset.hasPoolStaking,
-                hasSwaps: chainAsset.chain.hasSwaps
+                hasSwaps: chainAsset.chain.hasSwaps,
+                operationManager: operationManager
             )
         } catch {
             return nil
@@ -64,7 +73,8 @@ final class AssetHistoryFacade {
         return EtherscanERC20OperationFactory(
             contractAddress: contractAddress,
             baseUrl: url,
-            chainId: chainAsset.chain.chainId
+            chainId: chainAsset.chain.chainId,
+            operationManager: operationManager
         )
     }
 
@@ -80,7 +90,12 @@ final class AssetHistoryFacade {
             return nil
         }
 
-        return EtherscanNativeOperationFactory(filter: filter, baseUrl: url, chainId: chainAsset.chain.chainId)
+        return EtherscanNativeOperationFactory(
+            filter: filter,
+            baseUrl: url,
+            chainId: chainAsset.chain.chainId,
+            operationManager: operationManager
+        )
     }
 }
 

--- a/novawallet/Modules/TransactionHistory/Service/AssetHistoryFactoryFacade.swift
+++ b/novawallet/Modules/TransactionHistory/Service/AssetHistoryFactoryFacade.swift
@@ -9,12 +9,6 @@ protocol AssetHistoryFactoryFacadeProtocol {
 }
 
 final class AssetHistoryFacade {
-    let operationManager: OperationManagerProtocol
-
-    init(operationManager: OperationManagerProtocol = OperationManagerFacade.sharedManager) {
-        self.operationManager = operationManager
-    }
-
     func createSubqueryFactory(
         for chainAsset: ChainAsset,
         filter: WalletHistoryFilter
@@ -43,10 +37,8 @@ final class AssetHistoryFacade {
                 url: url,
                 filter: mappedFilter,
                 assetId: historyAssetId,
-                ethereumBased: chainAsset.chain.isEthereumBased,
                 hasPoolStaking: asset.hasPoolStaking,
-                hasSwaps: chainAsset.chain.hasSwaps,
-                operationManager: operationManager
+                hasSwaps: chainAsset.chain.hasSwaps
             )
         } catch {
             return nil
@@ -73,8 +65,7 @@ final class AssetHistoryFacade {
         return EtherscanERC20OperationFactory(
             contractAddress: contractAddress,
             baseUrl: url,
-            chainId: chainAsset.chain.chainId,
-            operationManager: operationManager
+            chainId: chainAsset.chain.chainId
         )
     }
 
@@ -93,8 +84,7 @@ final class AssetHistoryFacade {
         return EtherscanNativeOperationFactory(
             filter: filter,
             baseUrl: url,
-            chainId: chainAsset.chain.chainId,
-            operationManager: operationManager
+            chainId: chainAsset.chain.chainId
         )
     }
 }

--- a/novawallet/Modules/TransactionHistory/Service/AssetHistoryFactoryFacade.swift
+++ b/novawallet/Modules/TransactionHistory/Service/AssetHistoryFactoryFacade.swift
@@ -38,7 +38,8 @@ final class AssetHistoryFacade {
                 filter: mappedFilter,
                 assetId: historyAssetId,
                 hasPoolStaking: asset.hasPoolStaking,
-                hasSwaps: chainAsset.chain.hasSwaps
+                hasSwaps: chainAsset.chain.hasSwaps,
+                chainFormat: chainAsset.chain.chainFormat
             )
         } catch {
             return nil
@@ -64,6 +65,7 @@ final class AssetHistoryFacade {
 
         return EtherscanERC20OperationFactory(
             contractAddress: contractAddress,
+            chainFormat: chainAsset.chain.chainFormat,
             baseUrl: url,
             chainId: chainAsset.chain.chainId
         )
@@ -83,6 +85,7 @@ final class AssetHistoryFacade {
 
         return EtherscanNativeOperationFactory(
             filter: filter,
+            chainFormat: chainAsset.chain.chainFormat,
             baseUrl: url,
             chainId: chainAsset.chain.chainId
         )

--- a/novawallet/Modules/TransactionHistory/Service/TransactionHistoryHybridFetcher.swift
+++ b/novawallet/Modules/TransactionHistory/Service/TransactionHistoryHybridFetcher.swift
@@ -4,7 +4,7 @@ import Operation_iOS
 final class TransactionHistoryHybridFetcher {
     let remoteOperationFactory: WalletRemoteHistoryFactoryProtocol
     let repository: AnyDataProviderRepository<TransactionHistoryItem>
-    let address: AccountAddress
+    let accountId: AccountId
     let chainAsset: ChainAsset
     let pageSize: Int
     let operationQueue: OperationQueue
@@ -15,7 +15,7 @@ final class TransactionHistoryHybridFetcher {
     @Atomic(defaultValue: nil) private var syncService: TransactionHistorySyncService?
 
     init(
-        address: AccountAddress,
+        accountId: AccountId,
         chainAsset: ChainAsset,
         remoteOperationFactory: WalletRemoteHistoryFactoryProtocol,
         repository: AnyDataProviderRepository<TransactionHistoryItem>,
@@ -23,7 +23,7 @@ final class TransactionHistoryHybridFetcher {
         operationQueue: OperationQueue,
         pageSize: Int
     ) {
-        self.address = address
+        self.accountId = accountId
         self.chainAsset = chainAsset
         self.remoteOperationFactory = remoteOperationFactory
         self.repository = repository
@@ -34,7 +34,7 @@ final class TransactionHistoryHybridFetcher {
 
     private func createRemoteFetcher(from result: WalletRemoteHistoryData) {
         remoteFetcher = TransactionHistoryRemoteFetcher(
-            address: address,
+            accountId: accountId,
             chainAsset: chainAsset,
             operationFactory: remoteOperationFactory,
             operationQueue: operationQueue,
@@ -75,7 +75,7 @@ extension TransactionHistoryHybridFetcher: TransactionHistoryFetching {
 
         syncService = TransactionHistorySyncService(
             chainAsset: chainAsset,
-            address: address,
+            accountId: accountId,
             remoteOperationFactory: remoteOperationFactory,
             repository: repository,
             pageSize: pageSize,

--- a/novawallet/Modules/TransactionHistory/Service/TransactionHistoryRemoteFetcher.swift
+++ b/novawallet/Modules/TransactionHistory/Service/TransactionHistoryRemoteFetcher.swift
@@ -4,7 +4,7 @@ import Operation_iOS
 final class TransactionHistoryRemoteFetcher: AnyCancellableCleaning {
     let operationFactory: WalletRemoteHistoryFactoryProtocol
     let operationQueue: OperationQueue
-    let address: AccountAddress
+    let accountId: AccountId
     let chainAsset: ChainAsset
     let pageSize: Int
 
@@ -14,14 +14,14 @@ final class TransactionHistoryRemoteFetcher: AnyCancellableCleaning {
     weak var delegate: TransactionHistoryFetcherDelegate?
 
     init(
-        address: AccountAddress,
+        accountId: AccountId,
         chainAsset: ChainAsset,
         operationFactory: WalletRemoteHistoryFactoryProtocol,
         operationQueue: OperationQueue,
         pageSize: Int,
         initPagination: Pagination? = nil
     ) {
-        self.address = address
+        self.accountId = accountId
         self.chainAsset = chainAsset
         self.operationFactory = operationFactory
         self.operationQueue = operationQueue
@@ -40,15 +40,11 @@ final class TransactionHistoryRemoteFetcher: AnyCancellableCleaning {
 
         let currentPagination = pagination ?? Pagination(count: pageSize, context: nil)
 
-        let remoteAddress: AccountAddress
-
-        if chainAsset.chain.isEthereumBased {
-            remoteAddress = address.toEthereumAddressWithChecksum() ?? address
-        } else {
-            remoteAddress = address
-        }
-
-        let wrapper = operationFactory.createOperationWrapper(for: remoteAddress, pagination: currentPagination)
+        let wrapper = operationFactory.createOperationWrapper(
+            for: accountId,
+            chainFormat: chainAsset.chain.chainFormat,
+            pagination: currentPagination
+        )
 
         wrapper.targetOperation.completionBlock = { [weak self] in
             DispatchQueue.main.async {

--- a/novawallet/Modules/TransactionHistory/Service/TransactionHistoryRemoteFetcher.swift
+++ b/novawallet/Modules/TransactionHistory/Service/TransactionHistoryRemoteFetcher.swift
@@ -42,7 +42,6 @@ final class TransactionHistoryRemoteFetcher: AnyCancellableCleaning {
 
         let wrapper = operationFactory.createOperationWrapper(
             for: accountId,
-            chainFormat: chainAsset.chain.chainFormat,
             pagination: currentPagination
         )
 

--- a/novawallet/Modules/TransactionHistory/Service/TransactionHistorySyncService.swift
+++ b/novawallet/Modules/TransactionHistory/Service/TransactionHistorySyncService.swift
@@ -77,7 +77,6 @@ final class TransactionHistorySyncService: BaseSyncService, AnyCancellableCleani
 
         return remoteOperationFactory.createOperationWrapper(
             for: accountId,
-            chainFormat: chainAsset.chain.chainFormat,
             pagination: pagination
         )
     }

--- a/novawallet/Modules/TransactionHistory/Service/TransactionHistorySyncService.swift
+++ b/novawallet/Modules/TransactionHistory/Service/TransactionHistorySyncService.swift
@@ -6,7 +6,7 @@ typealias TransactionSyncResultClosure = (WalletRemoteHistoryData) -> Void
 final class TransactionHistorySyncService: BaseSyncService, AnyCancellableCleaning {
     let remoteOperationFactory: WalletRemoteHistoryFactoryProtocol
     let repository: AnyDataProviderRepository<TransactionHistoryItem>
-    let address: AccountAddress
+    let accountId: AccountId
     let chainAsset: ChainAsset
     let pageSize: Int
     let operationQueue: OperationQueue
@@ -16,7 +16,7 @@ final class TransactionHistorySyncService: BaseSyncService, AnyCancellableCleani
 
     init(
         chainAsset: ChainAsset,
-        address: AccountAddress,
+        accountId: AccountId,
         remoteOperationFactory: WalletRemoteHistoryFactoryProtocol,
         repository: AnyDataProviderRepository<TransactionHistoryItem>,
         pageSize: Int,
@@ -24,7 +24,7 @@ final class TransactionHistorySyncService: BaseSyncService, AnyCancellableCleani
         completionClosure: @escaping TransactionSyncResultClosure
     ) {
         self.remoteOperationFactory = remoteOperationFactory
-        self.address = address
+        self.accountId = accountId
         self.chainAsset = chainAsset
         self.repository = repository
         self.pageSize = pageSize
@@ -52,15 +52,14 @@ final class TransactionHistorySyncService: BaseSyncService, AnyCancellableCleani
     private func createHistoryMergeOperation(
         dependingOn remoteOperation: BaseOperation<WalletRemoteHistoryData>,
         localOperation: BaseOperation<[TransactionHistoryItem]>,
-        chainAsset: ChainAsset,
-        address: AccountAddress
+        chainAsset: ChainAsset
     ) -> BaseOperation<TransactionHistoryMergeResult> {
         ClosureOperation {
             let remoteTransactions = try remoteOperation.extractNoCancellableResultData().historyItems
             let localTransactions = try localOperation.extractNoCancellableResultData()
 
             if !localTransactions.isEmpty {
-                let manager = TransactionHistoryMergeManager(address: address, chainAsset: chainAsset)
+                let manager = TransactionHistoryMergeManager(chainAsset: chainAsset)
 
                 return manager.merge(remoteItems: remoteTransactions, localItems: localTransactions)
             } else {
@@ -74,17 +73,13 @@ final class TransactionHistorySyncService: BaseSyncService, AnyCancellableCleani
     }
 
     private func createRemoteOperationWrapper() -> CompoundOperationWrapper<WalletRemoteHistoryData> {
-        let remoteAddress: AccountAddress
-
-        if chainAsset.chain.isEthereumBased {
-            remoteAddress = address.toEthereumAddressWithChecksum() ?? address
-        } else {
-            remoteAddress = address
-        }
-
         let pagination = Pagination(count: pageSize, context: nil)
 
-        return remoteOperationFactory.createOperationWrapper(for: remoteAddress, pagination: pagination)
+        return remoteOperationFactory.createOperationWrapper(
+            for: accountId,
+            chainFormat: chainAsset.chain.chainFormat,
+            pagination: pagination
+        )
     }
 
     override func performSyncUp() {
@@ -96,8 +91,7 @@ final class TransactionHistorySyncService: BaseSyncService, AnyCancellableCleani
         let mergeOperation = createHistoryMergeOperation(
             dependingOn: remoteFetchWrapper.targetOperation,
             localOperation: localFetchOperation,
-            chainAsset: chainAsset,
-            address: address
+            chainAsset: chainAsset
         )
 
         mergeOperation.addDependency(localFetchOperation)

--- a/novawallet/Modules/TransactionHistory/Service/WalletRemoteHistoryProtocols.swift
+++ b/novawallet/Modules/TransactionHistory/Service/WalletRemoteHistoryProtocols.swift
@@ -37,3 +37,7 @@ protocol WalletRemoteHistoryFactoryProtocol {
         pagination: Pagination
     ) -> CompoundOperationWrapper<WalletRemoteHistoryData>
 }
+
+enum WalletRemoteHistoryError: Error {
+    case fetchParamsCreation
+}

--- a/novawallet/Modules/TransactionHistory/Service/WalletRemoteHistoryProtocols.swift
+++ b/novawallet/Modules/TransactionHistory/Service/WalletRemoteHistoryProtocols.swift
@@ -31,6 +31,9 @@ struct WalletRemoteHistoryData {
 protocol WalletRemoteHistoryFactoryProtocol {
     func isComplete(pagination: Pagination) -> Bool
 
-    func createOperationWrapper(for address: String, pagination: Pagination)
-        -> CompoundOperationWrapper<WalletRemoteHistoryData>
+    func createOperationWrapper(
+        for accountId: AccountId,
+        chainFormat: ChainFormat,
+        pagination: Pagination
+    ) -> CompoundOperationWrapper<WalletRemoteHistoryData>
 }

--- a/novawallet/Modules/TransactionHistory/Service/WalletRemoteHistoryProtocols.swift
+++ b/novawallet/Modules/TransactionHistory/Service/WalletRemoteHistoryProtocols.swift
@@ -33,7 +33,6 @@ protocol WalletRemoteHistoryFactoryProtocol {
 
     func createOperationWrapper(
         for accountId: AccountId,
-        chainFormat: ChainFormat,
         pagination: Pagination
     ) -> CompoundOperationWrapper<WalletRemoteHistoryData>
 }


### PR DESCRIPTION
### SUMMARY

This PR adds support for legacy address prefix to address conversion logic.

It also refactors the history fetching logic by modifying `WalletRemoteHistoryFactoryProtocol` and its implementations to use `accountId` and `chainFormat` instead of directly using addresses. The main goal is to ensure substrate factories use `accountId` and `chainFormat` to create legacyAddress without exposing this implementation detail to ethereum factories.