### PR TITLE
Feature/view address format

### DIFF
--- a/novawallet/Modules/AssetReceive/AssetReceivePresenter.swift
+++ b/novawallet/Modules/AssetReceive/AssetReceivePresenter.swift
@@ -73,9 +73,11 @@ private extension AssetReceivePresenter {
         else {
             return
         }
+
         let addressViewModel = AccountAddressViewModel(
             walletName: account.chainAccount.name,
-            address: account.chainAccount.toAddress()
+            address: account.chainAccount.toAddress(),
+            hasLegacyAddress: chain.hasUnifiedAddressPrefix
         )
 
         view?.didReceive(
@@ -89,6 +91,22 @@ private extension AssetReceivePresenter {
 // MARK: AssetReceivePresenterProtocol
 
 extension AssetReceivePresenter: AssetReceivePresenterProtocol {
+    func viewAddressFormats() {
+        guard
+            let chain,
+            let address = account?.chainAccount.toAddress(),
+            let legacyAddress = try? address.toLegacySubstrateAddress(for: chain.chainFormat)
+        else {
+            return
+        }
+
+        wireframe.presentUnifiedAddressPopup(
+            from: view,
+            newAddress: address,
+            legacyAddress: legacyAddress
+        )
+    }
+
     func setup() {
         interactor.setup()
     }

--- a/novawallet/Modules/AssetReceive/AssetReceiveProtocols.swift
+++ b/novawallet/Modules/AssetReceive/AssetReceiveProtocols.swift
@@ -15,6 +15,7 @@ protocol AssetReceivePresenterProtocol: AnyObject {
     func set(qrCodeSize: CGSize)
     func share()
     func copyAddress()
+    func viewAddressFormats()
 }
 
 protocol AssetReceiveInteractorInputProtocol: AnyObject {

--- a/novawallet/Modules/AssetReceive/AssetReceiveViewController.swift
+++ b/novawallet/Modules/AssetReceive/AssetReceiveViewController.swift
@@ -43,8 +43,12 @@ final class AssetReceiveViewController: UIViewController, ViewHolder {
         cachedBoundsWidth = view.bounds.width
         presenter.set(qrCodeSize: qrCodeSize)
     }
+}
 
-    private func setupLocalization() {
+// MARK: Private
+
+private extension AssetReceiveViewController {
+    func setupLocalization() {
         let languages = selectedLocale.rLanguages
 
         rootView.shareButton.imageWithTitleView?.title = R.string.localizable.walletReceiveShareTitle(
@@ -53,22 +57,35 @@ final class AssetReceiveViewController: UIViewController, ViewHolder {
         rootView.accountAddressView.copyButton.imageWithTitleView?.title = R.string.localizable.commonCopyAddress(
             preferredLanguages: languages
         ).capitalized
+        rootView.legacyAddressMessageLabel.text = R.string.localizable.assetReceiveLookingForAddressMessage(
+            preferredLanguages: languages
+        )
+        rootView.viewAddressFormatsButton.setTitle(
+            R.string.localizable.assetReceiveViewAddressFormat(
+                preferredLanguages: languages
+            )
+        )
     }
 
-    private func setupHandlers() {
+    func setupHandlers() {
         rootView.shareButton.addTarget(
             self,
-            action: #selector(didTapShare),
+            action: #selector(actionShare),
             for: .touchUpInside
         )
         rootView.accountAddressView.copyButton.addTarget(
             self,
-            action: #selector(didTapCopyAddress),
+            action: #selector(actionCopyAddress),
+            for: .touchUpInside
+        )
+        rootView.viewAddressFormatsButton.addTarget(
+            self,
+            action: #selector(actionViewFormats),
             for: .touchUpInside
         )
     }
 
-    private func updateTitleDetails(
+    func updateTitleDetails(
         chainName: String,
         token: String
     ) {
@@ -86,23 +103,24 @@ final class AssetReceiveViewController: UIViewController, ViewHolder {
         )
     }
 
-    private func updateNavigationBar() {
+    func updateNavigationBar() {
         navigationItem.titleView = rootView.chainView
     }
 
-    @objc private func didTapShare() {
+    @objc func actionShare() {
         presenter.share()
     }
 
-    @objc private func didTapCopyAddress() {
+    @objc func actionCopyAddress() {
         presenter.copyAddress()
+    }
+
+    @objc func actionViewFormats() {
+        presenter.viewAddressFormats()
     }
 }
 
-struct AccountAddressViewModel {
-    let walletName: String?
-    let address: String?
-}
+// MARK: AssetReceiveViewProtocol
 
 extension AssetReceiveViewController: AssetReceiveViewProtocol {
     func didReceive(
@@ -117,6 +135,10 @@ extension AssetReceiveViewController: AssetReceiveViewProtocol {
 
         rootView.accountAddressView.titleLabel.text = addressViewModel.walletName
         rootView.accountAddressView.addressLabel.text = addressViewModel.address
+
+        if addressViewModel.hasLegacyAddress {
+            rootView.showLegacyAddressMessage()
+        }
     }
 
     func didReceive(qrResult: QRCodeWithLogoFactory.QRCreationResult) {
@@ -129,10 +151,18 @@ extension AssetReceiveViewController: AssetReceiveViewProtocol {
     }
 }
 
+// MARK: Localizable
+
 extension AssetReceiveViewController: Localizable {
     func applyLocalization() {
         if isViewLoaded {
             setupLocalization()
         }
     }
+}
+
+struct AccountAddressViewModel {
+    let walletName: String?
+    let address: String?
+    let hasLegacyAddress: Bool
 }

--- a/novawallet/Modules/AssetReceive/AssetReceiveViewLayout.swift
+++ b/novawallet/Modules/AssetReceive/AssetReceiveViewLayout.swift
@@ -21,6 +21,7 @@ final class AssetReceiveViewLayout: UIView {
         view.valueTop.numberOfLines = 0
 
         view.valueBottom.applyTextStyle()
+        view.valueBottom.imageWithTitleView?.titleFont = .semiBoldSubheadline
 
         view.spacing = .zero
     }

--- a/novawallet/Modules/AssetReceive/AssetReceiveViewLayout.swift
+++ b/novawallet/Modules/AssetReceive/AssetReceiveViewLayout.swift
@@ -16,6 +16,15 @@ final class AssetReceiveViewLayout: UIView {
         view.cornerRadius = Constants.qrContainerCornerRadius
     }
 
+    let legacyAddressMessageContainer: GenericMultiValueView<RoundedButton> = .create { view in
+        view.valueTop.apply(style: .footnoteSecondary)
+        view.valueTop.numberOfLines = 0
+
+        view.valueBottom.applyTextStyle()
+
+        view.spacing = .zero
+    }
+
     let chainView = AssetListChainView()
 
     let accountAddressView = AccountAddressView()
@@ -34,6 +43,14 @@ final class AssetReceiveViewLayout: UIView {
     let qrView: QRWithLogoDisplayView = .create {
         $0.contentInsets = Constants.qrViewContentInsets
         $0.backgroundView.shadowOpacity = .zero
+    }
+
+    var legacyAddressMessageLabel: UILabel {
+        legacyAddressMessageContainer.valueTop
+    }
+
+    var viewAddressFormatsButton: RoundedButton {
+        legacyAddressMessageContainer.valueBottom
     }
 
     let shareButton: TriangularedButton = .create {
@@ -56,7 +73,7 @@ final class AssetReceiveViewLayout: UIView {
     private func setupLayout() {
         addSubview(containerView)
         containerView.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide.snp.top)
+            $0.top.equalToSuperview().inset(Constants.verticalSpacing)
             $0.leading.trailing.bottom.equalToSuperview()
         }
         containerView.stackView.addArrangedSubview(titleLabel)
@@ -84,9 +101,17 @@ final class AssetReceiveViewLayout: UIView {
             after: titleLabel
         )
         containerView.stackView.setCustomSpacing(
-            Constants.detailsQRVerticalSpace,
+            Constants.verticalSpacing,
             after: detailsLabel
         )
+        containerView.stackView.setCustomSpacing(
+            Constants.verticalSpacing,
+            after: qrContainerView
+        )
+
+        viewAddressFormatsButton.snp.makeConstraints { make in
+            make.height.equalTo(Constants.viewFormatsButtonHeight)
+        }
 
         addSubview(shareButton)
         shareButton.snp.makeConstraints {
@@ -98,22 +123,32 @@ final class AssetReceiveViewLayout: UIView {
 }
 
 extension AssetReceiveViewLayout {
+    func showLegacyAddressMessage() {
+        containerView.stackView.addArrangedSubview(legacyAddressMessageContainer)
+        containerView.stackView.setCustomSpacing(
+            Constants.verticalSpacing,
+            after: legacyAddressMessageContainer
+        )
+    }
+}
+
+extension AssetReceiveViewLayout {
     enum Constants {
+        static let verticalSpacing: CGFloat = 24
         static let qrContainerCornerRadius: CGFloat = 16
         static let qrViewSizeRatio: CGFloat = 0.8
         static let qrViewPlaceHolderWidth: CGFloat = 280
         static let qrCodeMinimumWidth: CGFloat = 120
-        static let detailsQRVerticalSpace: CGFloat = 36
-        static let titleDetailsVerticalSpace: CGFloat = 4
+        static let titleDetailsVerticalSpace: CGFloat = 8
         static let qrViewContentInsets: CGFloat = 8
         static let containerHorizontalOffset: CGFloat = 16
-        static let shareButtonTopOffset: CGFloat = 24
         static let shareButtonHeight: CGFloat = 52
         static let addressViewBottomInset: CGFloat = 12
+        static let viewFormatsButtonHeight: CGFloat = 32.0
         static let containerInsets = UIEdgeInsets(
-            top: 40,
+            top: verticalSpacing,
             left: containerHorizontalOffset,
-            bottom: Constants.shareButtonHeight + shareButtonTopOffset,
+            bottom: Constants.shareButtonHeight + verticalSpacing,
             right: containerHorizontalOffset
         )
 

--- a/novawallet/en.lproj/Localizable.strings
+++ b/novawallet/en.lproj/Localizable.strings
@@ -1804,3 +1804,5 @@
 "unified.address.popup.checkbox.text" = "Do not show this again.\nYou can find legacy address in Receive.";
 "unified.address.new.format" = "New format";
 "unified.address.legacy.format" = "Legacy format";
+"asset.receive.looking.for.address.message" = "Looking for your legacy address for an exchange?";
+"asset.receive.view.address.format" = "View Address Formats";


### PR DESCRIPTION
### SUMMARY

This PR adds a "View Address Formats" option to the `AssetReceive` screen for chains with unified address format.

### SCREEN RECORDINGS

https://github.com/user-attachments/assets/76e9b027-3292-4ce5-8574-511e530ed27c

### SCREENSHOTS

<img src="https://github.com/user-attachments/assets/6b392b22-ee9f-4715-98ba-eb1db11bb829" width=45% height=45%>
<img src="https://github.com/user-attachments/assets/8de3c500-0ecf-4c51-afd4-4665cbc421a2" width=45% height=45%>