### PR TITLE
Fallback for assetId usage in DApp

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1078,6 +1078,8 @@
 		0CFA161E2B0CED07007AF885 /* GovTreasurySpentLocalHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA161D2B0CED07007AF885 /* GovTreasurySpentLocalHandler.swift */; };
 		0CFA16202B0CEF31007AF885 /* GovTreasuryApproveHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA161F2B0CEF31007AF885 /* GovTreasuryApproveHandler.swift */; };
 		0CFF82392D8E86C300DB17A4 /* DAppParsedAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF82382D8E86C300DB17A4 /* DAppParsedAsset.swift */; };
+		0CFF823B2D8E8E5700DB17A4 /* Operation+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF823A2D8E8E5700DB17A4 /* Operation+Dependency.swift */; };
+		0CFF823C2D8E8E5700DB17A4 /* Operation+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF823A2D8E8E5700DB17A4 /* Operation+Dependency.swift */; };
 		0CFFB9D32D11A67C00172E8C /* XcmTokensArrivalDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFFB9D22D11A67C00172E8C /* XcmTokensArrivalDetector.swift */; };
 		0CFFB9D92D17592500172E8C /* OperatingSystemApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFFB9D82D17592500172E8C /* OperatingSystemApi.swift */; };
 		0D5245ED354CC52A842C85A0 /* TransferConfirmViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD8B98AB03AAF06AA891695 /* TransferConfirmViewLayout.swift */; };
@@ -6814,6 +6816,7 @@
 		0CFA161D2B0CED07007AF885 /* GovTreasurySpentLocalHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GovTreasurySpentLocalHandler.swift; sourceTree = "<group>"; };
 		0CFA161F2B0CEF31007AF885 /* GovTreasuryApproveHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GovTreasuryApproveHandler.swift; sourceTree = "<group>"; };
 		0CFF82382D8E86C300DB17A4 /* DAppParsedAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppParsedAsset.swift; sourceTree = "<group>"; };
+		0CFF823A2D8E8E5700DB17A4 /* Operation+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Operation+Dependency.swift"; sourceTree = "<group>"; };
 		0CFFB9D22D11A67C00172E8C /* XcmTokensArrivalDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmTokensArrivalDetector.swift; sourceTree = "<group>"; };
 		0CFFB9D82D17592500172E8C /* OperatingSystemApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatingSystemApi.swift; sourceTree = "<group>"; };
 		0D32A720511D1D3B0F479AFE /* DAppBrowserTabListProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppBrowserTabListProtocols.swift; sourceTree = "<group>"; };
@@ -21657,6 +21660,7 @@
 				84BB3CFF267D364D00676FFE /* CompoundOperationWrapper+Dependency.swift */,
 				849C0670276516F900394C82 /* BaseOperation+Cancellable.swift */,
 				0CD3A67F2AEAC3C90059BBEC /* CompoundOperationWrapper+Add.swift */,
+				0CFF823A2D8E8E5700DB17A4 /* Operation+Dependency.swift */,
 			);
 			path = Operation;
 			sourceTree = "<group>";
@@ -27396,6 +27400,7 @@
 				0CCD18B02BA1C2D80068D73A /* AssetBalanceDisplayInfo.swift in Sources */,
 				77EDF9232B96D74E003266B1 /* MetaAccountModel.swift in Sources */,
 				778215E72B95C432006C7D13 /* StakingRewardsHandler.swift in Sources */,
+				0CFF823C2D8E8E5700DB17A4 /* Operation+Dependency.swift in Sources */,
 				7778FE5D2B910B7D0023E801 /* SettingsExtension.swift in Sources */,
 				77EDF9282B96DDA9003266B1 /* MultiassetCryptoType.swift in Sources */,
 				7778FE6B2B910D1B0023E801 /* AssetType.swift in Sources */,
@@ -27571,6 +27576,7 @@
 				0CA719962B79CA7E000B086E /* HydraOmnipool+Call.swift in Sources */,
 				F4CE0FC727344F600094CD8A /* AcalaContributionConfirmProtocols.swift in Sources */,
 				842E9E9D2A2C591C00759972 /* StakingDashboardInteractorError.swift in Sources */,
+				0CFF823B2D8E8E5700DB17A4 /* Operation+Dependency.swift in Sources */,
 				8490145224A93FD1008F705E /* NovaLoadingViewPresenter.swift in Sources */,
 				880855F828D09DA8004255E7 /* CrowdloanContributionDataMapper.swift in Sources */,
 				882AA13028AE64DC0093BC63 /* CrowdloanYourContributionsTotalCell.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1080,6 +1080,7 @@
 		0CFF82392D8E86C300DB17A4 /* DAppParsedAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF82382D8E86C300DB17A4 /* DAppParsedAsset.swift */; };
 		0CFF823B2D8E8E5700DB17A4 /* Operation+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF823A2D8E8E5700DB17A4 /* Operation+Dependency.swift */; };
 		0CFF823C2D8E8E5700DB17A4 /* Operation+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF823A2D8E8E5700DB17A4 /* Operation+Dependency.swift */; };
+		0CFF824B2D91584500DB17A4 /* ChargeAssetTxSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF824A2D91584500DB17A4 /* ChargeAssetTxSerializer.swift */; };
 		0CFFB9D32D11A67C00172E8C /* XcmTokensArrivalDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFFB9D22D11A67C00172E8C /* XcmTokensArrivalDetector.swift */; };
 		0CFFB9D92D17592500172E8C /* OperatingSystemApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFFB9D82D17592500172E8C /* OperatingSystemApi.swift */; };
 		0D5245ED354CC52A842C85A0 /* TransferConfirmViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD8B98AB03AAF06AA891695 /* TransferConfirmViewLayout.swift */; };
@@ -6817,6 +6818,7 @@
 		0CFA161F2B0CEF31007AF885 /* GovTreasuryApproveHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GovTreasuryApproveHandler.swift; sourceTree = "<group>"; };
 		0CFF82382D8E86C300DB17A4 /* DAppParsedAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppParsedAsset.swift; sourceTree = "<group>"; };
 		0CFF823A2D8E8E5700DB17A4 /* Operation+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Operation+Dependency.swift"; sourceTree = "<group>"; };
+		0CFF824A2D91584500DB17A4 /* ChargeAssetTxSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChargeAssetTxSerializer.swift; sourceTree = "<group>"; };
 		0CFFB9D22D11A67C00172E8C /* XcmTokensArrivalDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmTokensArrivalDetector.swift; sourceTree = "<group>"; };
 		0CFFB9D82D17592500172E8C /* OperatingSystemApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatingSystemApi.swift; sourceTree = "<group>"; };
 		0D32A720511D1D3B0F479AFE /* DAppBrowserTabListProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppBrowserTabListProtocols.swift; sourceTree = "<group>"; };
@@ -13886,6 +13888,7 @@
 			children = (
 				0CEB6B3D2CA50C9400609DC2 /* CrosschainAssetConversionFactory.swift */,
 				0CEB6B482CA561AC00609DC2 /* ParachainResolver.swift */,
+				0CFF824A2D91584500DB17A4 /* ChargeAssetTxSerializer.swift */,
 			);
 			path = AssetConverters;
 			sourceTree = "<group>";
@@ -28083,6 +28086,7 @@
 				849014CB24AA8B75008F705E /* RootControllerAnimationCoordinator.swift in Sources */,
 				84DED3FC266651EB00A153BB /* ReferralCrowdloanViewModel.swift in Sources */,
 				8428766924ADF27D00D91AD8 /* AuthorizationPresentable.swift in Sources */,
+				0CFF824B2D91584500DB17A4 /* ChargeAssetTxSerializer.swift in Sources */,
 				8842105B289BBA8D00306F2C /* CurrencyInteractor.swift in Sources */,
 				8499FE7927BE549200712589 /* UniquesOperationFactory.swift in Sources */,
 				AEA0C8AA267B6B4300F9666F /* SelectedValidatorListViewController.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1077,6 +1077,7 @@
 		0CFA161C2B0CE851007AF885 /* Utility+Calls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA161B2B0CE851007AF885 /* Utility+Calls.swift */; };
 		0CFA161E2B0CED07007AF885 /* GovTreasurySpentLocalHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA161D2B0CED07007AF885 /* GovTreasurySpentLocalHandler.swift */; };
 		0CFA16202B0CEF31007AF885 /* GovTreasuryApproveHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA161F2B0CEF31007AF885 /* GovTreasuryApproveHandler.swift */; };
+		0CFF82392D8E86C300DB17A4 /* DAppParsedAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF82382D8E86C300DB17A4 /* DAppParsedAsset.swift */; };
 		0CFFB9D32D11A67C00172E8C /* XcmTokensArrivalDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFFB9D22D11A67C00172E8C /* XcmTokensArrivalDetector.swift */; };
 		0CFFB9D92D17592500172E8C /* OperatingSystemApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFFB9D82D17592500172E8C /* OperatingSystemApi.swift */; };
 		0D5245ED354CC52A842C85A0 /* TransferConfirmViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD8B98AB03AAF06AA891695 /* TransferConfirmViewLayout.swift */; };
@@ -6812,6 +6813,7 @@
 		0CFA161B2B0CE851007AF885 /* Utility+Calls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Utility+Calls.swift"; sourceTree = "<group>"; };
 		0CFA161D2B0CED07007AF885 /* GovTreasurySpentLocalHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GovTreasurySpentLocalHandler.swift; sourceTree = "<group>"; };
 		0CFA161F2B0CEF31007AF885 /* GovTreasuryApproveHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GovTreasuryApproveHandler.swift; sourceTree = "<group>"; };
+		0CFF82382D8E86C300DB17A4 /* DAppParsedAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppParsedAsset.swift; sourceTree = "<group>"; };
 		0CFFB9D22D11A67C00172E8C /* XcmTokensArrivalDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmTokensArrivalDetector.swift; sourceTree = "<group>"; };
 		0CFFB9D82D17592500172E8C /* OperatingSystemApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatingSystemApi.swift; sourceTree = "<group>"; };
 		0D32A720511D1D3B0F479AFE /* DAppBrowserTabListProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppBrowserTabListProtocols.swift; sourceTree = "<group>"; };
@@ -17435,6 +17437,7 @@
 				843612C62790032400DC739E /* DAppOperationProcessedResult.swift */,
 				84E8BA0A29FF760400FD9F40 /* DAppExtrinsicBuilderOperationFactory.swift */,
 				0C28DF282D2D38CF0016DB8E /* DAppMessageSignFactory.swift */,
+				0CFF82382D8E86C300DB17A4 /* DAppParsedAsset.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -31343,6 +31346,7 @@
 				2BB0D54988107FA0C484C530 /* ParaStkSelectCollatorsWireframe.swift in Sources */,
 				DEF53463C2C780D702E9C2CA /* CollatorStakingSelectPresenter.swift in Sources */,
 				1710F415F6AC7BBC622F4BD2 /* CollatorStakingSelectInteractor.swift in Sources */,
+				0CFF82392D8E86C300DB17A4 /* DAppParsedAsset.swift in Sources */,
 				ED3CE3F47E3681AA29C802E0 /* CollatorStakingSelectViewController.swift in Sources */,
 				F85E4E18D7D535538D52B950 /* CollatorStakingSelectViewLayout.swift in Sources */,
 				C5B6C00F8B0E3D89CBF1A8DB /* CollatorStakingSelectViewFactory.swift in Sources */,

--- a/novawallet/Common/Extension/Operation/CompoundOperationWrapper+Add.swift
+++ b/novawallet/Common/Extension/Operation/CompoundOperationWrapper+Add.swift
@@ -6,6 +6,14 @@ extension CompoundOperationWrapper {
         .init(targetOperation: targetOperation, dependencies: operations + dependencies)
     }
 
+    func insertingHeadIfExists(operations: [Operation]?) -> CompoundOperationWrapper {
+        guard let operations else {
+            return self
+        }
+
+        return insertingHead(operations: operations)
+    }
+
     func insertingTail<T>(operation: BaseOperation<T>) -> CompoundOperationWrapper<T> {
         .init(targetOperation: operation, dependencies: allOperations)
     }

--- a/novawallet/Common/Extension/Operation/CompoundOperationWrapper+Dependency.swift
+++ b/novawallet/Common/Extension/Operation/CompoundOperationWrapper+Dependency.swift
@@ -10,7 +10,23 @@ extension CompoundOperationWrapper {
         }
     }
 
+    func addDependencyIfExists(operations: [Operation]?) {
+        guard let operations else {
+            return
+        }
+
+        addDependency(operations: operations)
+    }
+
     func addDependency<T>(wrapper: CompoundOperationWrapper<T>) {
         addDependency(operations: wrapper.allOperations)
+    }
+
+    func addDependencyIfExists<T>(wrapper: CompoundOperationWrapper<T>?) {
+        guard let wrapper else {
+            return
+        }
+
+        addDependency(wrapper: wrapper)
     }
 }

--- a/novawallet/Common/Extension/Operation/Operation+Dependency.swift
+++ b/novawallet/Common/Extension/Operation/Operation+Dependency.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Operation {
+    func addDependencyIfExists(_ prevOperation: Operation?) {
+        guard let prevOperation else {
+            return
+        }
+
+        addDependency(prevOperation)
+    }
+}

--- a/novawallet/Common/Services/AssetConversion/AssetHub/AssetHubTokensConverter.swift
+++ b/novawallet/Common/Services/AssetConversion/AssetHub/AssetHubTokensConverter.swift
@@ -183,24 +183,4 @@ enum AssetHubTokensConverter {
             )
         )
     }
-
-    static func convertRawFeeAssetToLocalAsset(
-        _ remoteAssetId: String,
-        on chain: ChainModel,
-        using codingFactory: RuntimeCoderFactoryProtocol
-    ) -> ChainAsset? {
-        guard
-            let remoteAsset = try? StatemineAssetSerializer.decodeFeeAssetId(
-                remoteAssetId,
-                codingFactory: codingFactory
-            ) else {
-            return nil
-        }
-
-        return AssetHubTokensConverter.convertToLocalAsset(
-            for: remoteAsset,
-            on: chain,
-            using: codingFactory
-        )
-    }
 }

--- a/novawallet/Common/Substrate/AssetConverters/ChargeAssetTxSerializer.swift
+++ b/novawallet/Common/Substrate/AssetConverters/ChargeAssetTxSerializer.swift
@@ -1,0 +1,43 @@
+import Foundation
+import SubstrateSdk
+
+enum ChargeAssetTxSerializerError: Error {
+    case feeAssetIdTypeNotFound
+}
+
+enum ChargeAssetTxSerializer {
+    private static func extractFeeAssetIdType(from codingFactory: RuntimeCoderFactoryProtocol) -> String? {
+        guard
+            let extensionType = codingFactory.metadata.getSignedExtensionType(
+                for: Extrinsic.SignedExtensionId.assetTxPayment
+            ),
+            let extensionTypeNode = codingFactory.getTypeNode(for: extensionType) as? StructNode,
+            let assetIdType = extensionTypeNode.typeMapping.first(
+                where: { $0.name == "assetId" }
+            )?.node.typeName else {
+            return nil
+        }
+
+        return assetIdType
+    }
+
+    static func decodeFeeAssetId(
+        _ assetId: String,
+        codingFactory: RuntimeCoderFactoryProtocol
+    ) throws -> JSON {
+        // assetId is either integer or complicated data structure
+        guard assetId.isHex() else {
+            return JSON.stringValue(assetId)
+        }
+
+        guard let assetIdType = extractFeeAssetIdType(from: codingFactory) else {
+            throw ChargeAssetTxSerializerError.feeAssetIdTypeNotFound
+        }
+
+        let data = try Data(hexString: assetId)
+
+        let decoder = try codingFactory.createDecoder(from: data)
+
+        return try decoder.read(type: assetIdType)
+    }
+}

--- a/novawallet/Common/Substrate/Extension/AssetConversionTxPayment.swift
+++ b/novawallet/Common/Substrate/Extension/AssetConversionTxPayment.swift
@@ -2,13 +2,13 @@ import Foundation
 import BigInt
 import SubstrateSdk
 
-class AssetConversionTxPayment: Codable, OnlyExtrinsicSignedExtending {
+class AssetConversionTxPayment<AssetId: Codable>: Codable, OnlyExtrinsicSignedExtending {
     public var signedExtensionId: String { "ChargeAssetTxPayment" }
 
     @StringCodable public var tip: BigUInt
-    let assetId: AssetConversionPallet.AssetId?
+    let assetId: AssetId?
 
-    init(tip: BigUInt = 0, assetId: AssetConversionPallet.AssetId? = nil) {
+    init(tip: BigUInt = 0, assetId: AssetId? = nil) {
         self.tip = tip
         self.assetId = assetId
     }

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Proccessing.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Proccessing.swift
@@ -46,31 +46,30 @@ extension DAppOperationConfirmInteractor {
         dependingOn extrinsicOperation: BaseOperation<PolkadotExtensionExtrinsic>,
         codingFactoryOperation: BaseOperation<RuntimeCoderFactoryProtocol>,
         chain: ChainModel
-    ) -> BaseOperation<ChainAsset?> {
+    ) -> BaseOperation<DAppParsedAsset?> {
         ClosureOperation {
             let extrinsic = try extrinsicOperation.extractNoCancellableResultData()
             let codingFactory = try codingFactoryOperation.extractNoCancellableResultData()
 
-            guard let assetId = extrinsic.assetId else {
-                return nil
-            }
-
-            guard chain.hasAssetHubFees else {
+            guard let remoteAssetId = extrinsic.assetId else {
                 return nil
             }
 
             guard
-                let localAsset = AssetHubTokensConverter.convertRawFeeAssetToLocalAsset(
-                    assetId,
-                    on: chain,
-                    using: codingFactory
+                let remoteAsset = try? StatemineAssetSerializer.decodeFeeAssetId(
+                    remoteAssetId,
+                    codingFactory: codingFactory
                 ) else {
-                throw DAppOperationConfirmInteractorError.extrinsicBadField(
-                    name: "Fee asset decoding failed"
-                )
+                return nil
             }
 
-            return localAsset
+            let localAsset = AssetHubTokensConverter.convertToLocalAsset(
+                for: remoteAsset,
+                on: chain,
+                using: codingFactory
+            )
+
+            return DAppParsedAsset(remoteAsset: remoteAsset, localAsset: localAsset)
         }
     }
 
@@ -141,6 +140,8 @@ extension DAppOperationConfirmInteractor {
                 throw DAppOperationConfirmInteractorError.extrinsicBadField(name: "era")
             }
 
+            let parsedAsset = try feeAssetOperation.extractNoCancellableResultData()
+
             let parsedExtrinsic = DAppParsedExtrinsic(
                 address: extrinsic.address,
                 blockHash: extrinsic.blockHash,
@@ -153,18 +154,16 @@ extension DAppOperationConfirmInteractor {
                 tip: tip,
                 transactionVersion: UInt32(transactionVersion),
                 metadataHash: extrinsic.metadataHash,
-                assetId: extrinsic.assetId,
+                assetId: parsedAsset?.remoteAsset,
                 withSignedTransaction: extrinsic.withSignedTransaction ?? false,
                 signedExtensions: extrinsic.signedExtensions,
                 version: extrinsic.version
             )
 
-            let feeAsset = try feeAssetOperation.extractNoCancellableResultData()
-
             return DAppOperationProcessedResult(
                 account: accountResponse,
                 extrinsic: parsedExtrinsic,
-                feeAsset: feeAsset
+                feeAsset: parsedAsset?.localAsset
             )
         }
 

--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Proccessing.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Proccessing.swift
@@ -56,7 +56,7 @@ extension DAppOperationConfirmInteractor {
             }
 
             guard
-                let remoteAsset = try? StatemineAssetSerializer.decodeFeeAssetId(
+                let remoteAsset = try? ChargeAssetTxSerializer.decodeFeeAssetId(
                     remoteAssetId,
                     codingFactory: codingFactory
                 ) else {

--- a/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppExtrinsicBuilderOperationFactory.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppExtrinsicBuilderOperationFactory.swift
@@ -111,7 +111,7 @@ final class DAppExtrinsicBuilderOperationFactory {
                 builder = builder.adding(extrinsicSignedExtension: txPayment)
             }
 
-            let isModifiedExtrinsic = metadataHashResult.modifiedOriginal || result.extrinsic.hasAssetId
+            let isModifiedExtrinsic = metadataHashResult.modifiedOriginal
 
             return ExtrinsicSenderBuilderResult(
                 sender: sender,

--- a/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppExtrinsicBuilderOperationFactory.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppExtrinsicBuilderOperationFactory.swift
@@ -48,6 +48,79 @@ final class DAppExtrinsicBuilderOperationFactory {
         self.metadataHashOperationFactory = metadataHashOperationFactory
     }
 
+    private func createExtrinsicBuilderResultOperation(
+        from result: DAppOperationProcessedResult,
+        metadataHashOperation: BaseOperation<MetadataHashResult>,
+        codingFactoryOperation: BaseOperation<RuntimeCoderFactoryProtocol>,
+        feeInstallerOperation: BaseOperation<ExtrinsicFeeInstalling>?
+    ) -> BaseOperation<ExtrinsicSenderBuilderResult> {
+        ClosureOperation<ExtrinsicSenderBuilderResult> {
+            let codingFactory = try codingFactoryOperation.extractNoCancellableResultData()
+            let metadataHashResult = try metadataHashOperation.extractNoCancellableResultData()
+            let feeInstaller = try feeInstallerOperation?.extractNoCancellableResultData()
+
+            let extrinsic = result.extrinsic
+
+            // DApp signing currently doesn't allow to modify extrinsic
+            let sender = ExtrinsicSenderResolution.current(result.account)
+
+            let address = MultiAddress.accoundId(sender.account.accountId)
+
+            let signedExtensionFactory = ExtrinsicSignedExtensionFacade().createFactory(
+                for: result.account.chainId
+            )
+
+            let runtimeContext = codingFactory.createRuntimeJsonContext()
+
+            var builder: ExtrinsicBuilderProtocol = try ExtrinsicBuilder(
+                specVersion: extrinsic.specVersion,
+                transactionVersion: extrinsic.transactionVersion,
+                genesisHash: extrinsic.genesisHash
+            )
+            .with(signaturePayloadFormat: sender.account.type.signaturePayloadFormat)
+            .with(runtimeJsonContext: runtimeContext)
+            .with(address: address)
+            .with(nonce: UInt32(extrinsic.nonce))
+            .with(era: extrinsic.era, blockHash: extrinsic.blockHash)
+
+            if let metadataHash = metadataHashResult.metadataHash {
+                builder = builder.with(metadataHash: metadataHash)
+            }
+
+            for signedExtension in signedExtensionFactory.createExtensions() {
+                builder = builder.adding(extrinsicSignedExtension: signedExtension)
+            }
+
+            builder = try result.extrinsic.method.accept(builder: builder)
+
+            if extrinsic.tip > 0 {
+                builder = builder.with(tip: extrinsic.tip)
+            }
+
+            if let feeInstaller {
+                builder = try feeInstaller.installingFeeSettings(
+                    to: builder,
+                    coderFactory: codingFactory
+                )
+            } else if let rawFeeAssetId = result.extrinsic.assetId {
+                let txPayment = AssetConversionTxPayment(
+                    tip: extrinsic.tip,
+                    assetId: rawFeeAssetId
+                )
+
+                builder = builder.adding(extrinsicSignedExtension: txPayment)
+            }
+
+            let isModifiedExtrinsic = metadataHashResult.modifiedOriginal || result.extrinsic.hasAssetId
+
+            return ExtrinsicSenderBuilderResult(
+                sender: sender,
+                builder: builder,
+                modifiedOriginalExtrinsic: isModifiedExtrinsic
+            )
+        }
+    }
+
     private func createActualMetadataHashWrapper(
         for result: DAppOperationProcessedResult,
         chain: ChainModel,
@@ -118,82 +191,19 @@ final class DAppExtrinsicBuilderOperationFactory {
             nil
         }
 
-        let builderOperation = ClosureOperation<ExtrinsicSenderBuilderResult> {
-            let codingFactory = try codingFactoryOperation.extractNoCancellableResultData()
-            let runtimeContext = codingFactory.createRuntimeJsonContext()
-            let metadataHashResult = try metadataHashWrapper.targetOperation.extractNoCancellableResultData()
-            let feeInstaller = try feeInstallerWrapper?.targetOperation.extractNoCancellableResultData()
-
-            let extrinsic = result.extrinsic
-
-            // DApp signing currently doesn't allow to modify extrinsic
-            let sender = ExtrinsicSenderResolution.current(result.account)
-
-            let address = MultiAddress.accoundId(sender.account.accountId)
-
-            let signedExtensionFactory = ExtrinsicSignedExtensionFacade().createFactory(
-                for: result.account.chainId
-            )
-
-            var builder: ExtrinsicBuilderProtocol = try ExtrinsicBuilder(
-                specVersion: extrinsic.specVersion,
-                transactionVersion: extrinsic.transactionVersion,
-                genesisHash: extrinsic.genesisHash
-            )
-            .with(signaturePayloadFormat: sender.account.type.signaturePayloadFormat)
-            .with(runtimeJsonContext: runtimeContext)
-            .with(address: address)
-            .with(nonce: UInt32(extrinsic.nonce))
-            .with(era: extrinsic.era, blockHash: extrinsic.blockHash)
-
-            if let metadataHash = metadataHashResult.metadataHash {
-                builder = builder.with(metadataHash: metadataHash)
-            }
-
-            for signedExtension in signedExtensionFactory.createExtensions() {
-                builder = builder.adding(extrinsicSignedExtension: signedExtension)
-            }
-
-            builder = try result.extrinsic.method.accept(builder: builder)
-
-            if extrinsic.tip > 0 {
-                builder = builder.with(tip: extrinsic.tip)
-            }
-
-            if let feeInstaller {
-                builder = try feeInstaller.installingFeeSettings(
-                    to: builder,
-                    coderFactory: codingFactory
-                )
-            } else if let rawFeeAssetId = result.extrinsic.assetId {
-                let txPayment = AssetConversionTxPayment(
-                    tip: extrinsic.tip,
-                    assetId: rawFeeAssetId
-                )
-
-                builder = builder.adding(extrinsicSignedExtension: txPayment)
-            }
-
-            let isModifiedExtrinsic = metadataHashResult.modifiedOriginal || result.extrinsic.hasAssetId
-
-            return ExtrinsicSenderBuilderResult(
-                sender: sender,
-                builder: builder,
-                modifiedOriginalExtrinsic: isModifiedExtrinsic
-            )
-        }
+        let builderOperation = createExtrinsicBuilderResultOperation(
+            from: result,
+            metadataHashOperation: metadataHashWrapper.targetOperation,
+            codingFactoryOperation: codingFactoryOperation,
+            feeInstallerOperation: feeInstallerWrapper?.targetOperation
+        )
 
         builderOperation.addDependency(metadataHashWrapper.targetOperation)
+        builderOperation.addDependencyIfExists(feeInstallerWrapper?.targetOperation)
 
-        if let feeInstallerWrapper {
-            builderOperation.addDependency(feeInstallerWrapper.targetOperation)
-
-            return metadataHashWrapper
-                .insertingHead(operations: feeInstallerWrapper.allOperations)
-                .insertingTail(operation: builderOperation)
-        } else {
-            return metadataHashWrapper.insertingTail(operation: builderOperation)
-        }
+        return metadataHashWrapper
+            .insertingHeadIfExists(operations: feeInstallerWrapper?.allOperations)
+            .insertingTail(operation: builderOperation)
     }
 
     private func createRawSignatureOperation(

--- a/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppExtrinsicBuilderOperationFactory.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppExtrinsicBuilderOperationFactory.swift
@@ -165,9 +165,16 @@ final class DAppExtrinsicBuilderOperationFactory {
                     to: builder,
                     coderFactory: codingFactory
                 )
+            } else if let rawFeeAssetId = result.extrinsic.assetId {
+                let txPayment = AssetConversionTxPayment(
+                    tip: extrinsic.tip,
+                    assetId: rawFeeAssetId
+                )
+
+                builder = builder.adding(extrinsicSignedExtension: txPayment)
             }
 
-            let isModifiedExtrinsic = metadataHashResult.modifiedOriginal || feeInstaller != nil
+            let isModifiedExtrinsic = metadataHashResult.modifiedOriginal || result.extrinsic.hasAssetId
 
             return ExtrinsicSenderBuilderResult(
                 sender: sender,

--- a/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppParsedAsset.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppParsedAsset.swift
@@ -1,0 +1,7 @@
+import Foundation
+import SubstrateSdk
+
+struct DAppParsedAsset {
+    let remoteAsset: JSON
+    let localAsset: ChainAsset?
+}

--- a/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppParsedExtrinsic.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/Model/DAppParsedExtrinsic.swift
@@ -14,8 +14,12 @@ struct DAppParsedExtrinsic: Encodable {
     let tip: BigUInt
     let transactionVersion: UInt32
     let metadataHash: String?
-    let assetId: String?
+    let assetId: JSON?
     let withSignedTransaction: Bool
     let signedExtensions: [String]
     let version: UInt
+
+    var hasAssetId: Bool {
+        assetId != nil
+    }
 }


### PR DESCRIPTION
## Purpose

Current implementation allows fee payment in custom asset via DApp Browser only for the Asset Hubs. The PR introduces an option of setting the assetId for any network where ChargeAssetTxPayment extension exists. However, as the app can't match local asset for non AH cases the fee is displayed in the native asset but payed in one provided in the assetId field.