### PR TITLE
Allow total balance usage for OpenGov

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1022,7 +1022,6 @@
 		0CEB6B4F2CA6AC9700609DC2 /* UIEdgeInsets+Init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB6B4E2CA6AC9700609DC2 /* UIEdgeInsets+Init.swift */; };
 		0CEB6B512CA6B31800609DC2 /* VoteCardOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB6B502CA6B31800609DC2 /* VoteCardOverlayView.swift */; };
 		0CEB6B532CA6E92700609DC2 /* VotingPowerSetClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB6B522CA6E92700609DC2 /* VotingPowerSetClosure.swift */; };
-		0CEB6B552CA70CB400609DC2 /* AssetBalance+OpenGov.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB6B542CA70CB400609DC2 /* AssetBalance+OpenGov.swift */; };
 		0CEBAD4E2D5A2BD9000EBA45 /* SwapsDifferenceModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEBAD4D2D5A2BD9000EBA45 /* SwapsDifferenceModelFactory.swift */; };
 		0CEBAD502D5C5FDE000EBA45 /* CollatorStakingRewardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEBAD4F2D5C5FDE000EBA45 /* CollatorStakingRewardService.swift */; };
 		0CEBAD512D5C7433000EBA45 /* Decimal+Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84216FDD282B979900479375 /* Decimal+Conversion.swift */; };
@@ -1081,6 +1080,7 @@
 		0CFF823B2D8E8E5700DB17A4 /* Operation+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF823A2D8E8E5700DB17A4 /* Operation+Dependency.swift */; };
 		0CFF823C2D8E8E5700DB17A4 /* Operation+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF823A2D8E8E5700DB17A4 /* Operation+Dependency.swift */; };
 		0CFF824B2D91584500DB17A4 /* ChargeAssetTxSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF824A2D91584500DB17A4 /* ChargeAssetTxSerializer.swift */; };
+		0CFF824D2D91B0F100DB17A4 /* GovernanceBalanceCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF824C2D91B0F100DB17A4 /* GovernanceBalanceCalculator.swift */; };
 		0CFFB9D32D11A67C00172E8C /* XcmTokensArrivalDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFFB9D22D11A67C00172E8C /* XcmTokensArrivalDetector.swift */; };
 		0CFFB9D92D17592500172E8C /* OperatingSystemApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFFB9D82D17592500172E8C /* OperatingSystemApi.swift */; };
 		0D5245ED354CC52A842C85A0 /* TransferConfirmViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD8B98AB03AAF06AA891695 /* TransferConfirmViewLayout.swift */; };
@@ -6762,7 +6762,6 @@
 		0CEB6B4E2CA6AC9700609DC2 /* UIEdgeInsets+Init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIEdgeInsets+Init.swift"; sourceTree = "<group>"; };
 		0CEB6B502CA6B31800609DC2 /* VoteCardOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoteCardOverlayView.swift; sourceTree = "<group>"; };
 		0CEB6B522CA6E92700609DC2 /* VotingPowerSetClosure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VotingPowerSetClosure.swift; sourceTree = "<group>"; };
-		0CEB6B542CA70CB400609DC2 /* AssetBalance+OpenGov.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssetBalance+OpenGov.swift"; sourceTree = "<group>"; };
 		0CEBAD4D2D5A2BD9000EBA45 /* SwapsDifferenceModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapsDifferenceModelFactory.swift; sourceTree = "<group>"; };
 		0CEBAD4F2D5C5FDE000EBA45 /* CollatorStakingRewardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollatorStakingRewardService.swift; sourceTree = "<group>"; };
 		0CEBAD532D5F941E000EBA45 /* CallDispatchErrorDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallDispatchErrorDecoder.swift; sourceTree = "<group>"; };
@@ -6819,6 +6818,7 @@
 		0CFF82382D8E86C300DB17A4 /* DAppParsedAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppParsedAsset.swift; sourceTree = "<group>"; };
 		0CFF823A2D8E8E5700DB17A4 /* Operation+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Operation+Dependency.swift"; sourceTree = "<group>"; };
 		0CFF824A2D91584500DB17A4 /* ChargeAssetTxSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChargeAssetTxSerializer.swift; sourceTree = "<group>"; };
+		0CFF824C2D91B0F100DB17A4 /* GovernanceBalanceCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GovernanceBalanceCalculator.swift; sourceTree = "<group>"; };
 		0CFFB9D22D11A67C00172E8C /* XcmTokensArrivalDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmTokensArrivalDetector.swift; sourceTree = "<group>"; };
 		0CFFB9D82D17592500172E8C /* OperatingSystemApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatingSystemApi.swift; sourceTree = "<group>"; };
 		0D32A720511D1D3B0F479AFE /* DAppBrowserTabListProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppBrowserTabListProtocols.swift; sourceTree = "<group>"; };
@@ -23161,7 +23161,6 @@
 		84D8753B28EB1796004065BD /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				0CEB6B542CA70CB400609DC2 /* AssetBalance+OpenGov.swift */,
 				84D8753C28EB17B2004065BD /* GovernanceSharedState.swift */,
 				84A1742328ED3CF70096F943 /* ReferendumLocal.swift */,
 				84DD49F528EE974B00B804F3 /* ReferendumDecidingFunctionProtocol.swift */,
@@ -23186,6 +23185,7 @@
 				84002AA42992516D00A80672 /* GovernanceDelegateState.swift */,
 				84E2ABC72992724600A5D3C1 /* GovernanceDelegatorAction.swift */,
 				84F0D9FB299D87A700F82CBC /* GovernanceBalanceConviction.swift */,
+				0CFF824C2D91B0F100DB17A4 /* GovernanceBalanceCalculator.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -30198,7 +30198,6 @@
 				0CB4334C2CC10C3C00F2CB59 /* AssetsHydraExchangeProvider.swift in Sources */,
 				77A6F5AB2A2E0B31004AFD1A /* ReceiveAssetOperationPresenter.swift in Sources */,
 				845B891C295960AD00EE25B0 /* SecuredPresentable.swift in Sources */,
-				0CEB6B552CA70CB400609DC2 /* AssetBalance+OpenGov.swift in Sources */,
 				84B24F9E2A2E307F00F9BF59 /* StakingDashboardViewModelFactory.swift in Sources */,
 				99A4B2A357ADEA45EFF515A5 /* AccountExportPasswordProtocols.swift in Sources */,
 				84355CEC28B5611F004E5C5E /* LedgerAccountStackCell.swift in Sources */,
@@ -32068,6 +32067,7 @@
 				0C13D3262A8275400054BB6F /* StartStakingFeeIdFactory.swift in Sources */,
 				81ADC94E1CC47A2C6F0F1BEA /* GovernanceEditDelegationTracksProtocols.swift in Sources */,
 				78E0B6963A8D0A07E742232C /* GovernanceEditDelegationTracksWireframe.swift in Sources */,
+				0CFF824D2D91B0F100DB17A4 /* GovernanceBalanceCalculator.swift in Sources */,
 				C7E68F5B6EC7B21B8797F874 /* GovernanceEditDelegationTracksPresenter.swift in Sources */,
 				0C56B29DBA5245728AF7EDA4 /* GovernanceEditDelegationTracksViewController.swift in Sources */,
 				FF985AA0ABA33118AC02A761 /* GovernanceEditDelegationTracksViewFactory.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1081,6 +1081,7 @@
 		0CFF823C2D8E8E5700DB17A4 /* Operation+Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF823A2D8E8E5700DB17A4 /* Operation+Dependency.swift */; };
 		0CFF824B2D91584500DB17A4 /* ChargeAssetTxSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF824A2D91584500DB17A4 /* ChargeAssetTxSerializer.swift */; };
 		0CFF824D2D91B0F100DB17A4 /* GovernanceBalanceCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF824C2D91B0F100DB17A4 /* GovernanceBalanceCalculator.swift */; };
+		0CFF82512D9275C900DB17A4 /* AvailableBalanceMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF82502D9275C900DB17A4 /* AvailableBalanceMapping.swift */; };
 		0CFFB9D32D11A67C00172E8C /* XcmTokensArrivalDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFFB9D22D11A67C00172E8C /* XcmTokensArrivalDetector.swift */; };
 		0CFFB9D92D17592500172E8C /* OperatingSystemApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFFB9D82D17592500172E8C /* OperatingSystemApi.swift */; };
 		0D5245ED354CC52A842C85A0 /* TransferConfirmViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD8B98AB03AAF06AA891695 /* TransferConfirmViewLayout.swift */; };
@@ -6819,6 +6820,7 @@
 		0CFF823A2D8E8E5700DB17A4 /* Operation+Dependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Operation+Dependency.swift"; sourceTree = "<group>"; };
 		0CFF824A2D91584500DB17A4 /* ChargeAssetTxSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChargeAssetTxSerializer.swift; sourceTree = "<group>"; };
 		0CFF824C2D91B0F100DB17A4 /* GovernanceBalanceCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GovernanceBalanceCalculator.swift; sourceTree = "<group>"; };
+		0CFF82502D9275C900DB17A4 /* AvailableBalanceMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableBalanceMapping.swift; sourceTree = "<group>"; };
 		0CFFB9D22D11A67C00172E8C /* XcmTokensArrivalDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmTokensArrivalDetector.swift; sourceTree = "<group>"; };
 		0CFFB9D82D17592500172E8C /* OperatingSystemApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatingSystemApi.swift; sourceTree = "<group>"; };
 		0D32A720511D1D3B0F479AFE /* DAppBrowserTabListProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppBrowserTabListProtocols.swift; sourceTree = "<group>"; };
@@ -20639,6 +20641,7 @@
 				77C35CE62B56D07300308F16 /* ScanAddressPresentable.swift */,
 				0C1998EE2C4CC51D000EBFB8 /* SCLoadableControllerProtocol.swift */,
 				2D74CA3E2CF7262E004EAD8C /* BrowserOpening.swift */,
+				0CFF82502D9275C900DB17A4 /* AvailableBalanceMapping.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -28153,6 +28156,7 @@
 				2DA85A652C7D9B8B00591900 /* CardTopUpTransferSetupViewController.swift in Sources */,
 				844CB56E26F9CB1500396E13 /* CrowdloanLocalStorageSubscriber.swift in Sources */,
 				8401AEC32642A71D000B03E3 /* StakingRebondConfirmationViewController.swift in Sources */,
+				0CFF82512D9275C900DB17A4 /* AvailableBalanceMapping.swift in Sources */,
 				841AAC2D26F7315300F0A25E /* CrowdloanRemoteSubscriptionService.swift in Sources */,
 				842EBB392890A8E400B952D8 /* WalletSelectionViewProtocols.swift in Sources */,
 				2DAF6AB72CF46BE500A8D132 /* DAppBrowserTabLocalSubscriptionHandler.swift in Sources */,

--- a/novawallet/Common/Protocols/AvailableBalanceMapping.swift
+++ b/novawallet/Common/Protocols/AvailableBalanceMapping.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+protocol AvailableBalanceMapping {
+    func availableBalance(from assetBalance: AssetBalance) -> Balance
+}
+
+extension AvailableBalanceMapping {
+    func mapAvailableBalance(from assetBalance: AssetBalance?) -> Balance? {
+        assetBalance.map { availableBalance(from: $0) }
+    }
+
+    func availableBalanceElseZero(from assetBalance: AssetBalance?) -> Balance {
+        mapAvailableBalance(from: assetBalance) ?? 0
+    }
+}
+
+struct AvailableBalanceSliceMapper {
+    let balanceSlice: KeyPath<AssetBalance, Balance>
+}
+
+extension AvailableBalanceSliceMapper: AvailableBalanceMapping {
+    func availableBalance(from assetBalance: AssetBalance) -> Balance {
+        assetBalance[keyPath: balanceSlice]
+    }
+}

--- a/novawallet/Modules/ChainAssetSelection/ChainAssetSelectionBasePresenter.swift
+++ b/novawallet/Modules/ChainAssetSelection/ChainAssetSelectionBasePresenter.swift
@@ -10,9 +10,9 @@ class ChainAssetSelectionBasePresenter {
 
     let assetBalanceFormatterFactory: AssetBalanceFormatterFactoryProtocol
 
-    private(set) var assets: [ChainAsset]?
+    var assets: [ChainAsset]?
 
-    private var accountBalances: [ChainAssetId: Result<BigUInt?, Error>]?
+    private var accountBalances: [ChainAssetId: Result<AssetBalance?, Error>]?
     private var assetPrices: [ChainAssetId: PriceData]?
 
     private var viewModels: [SelectableIconDetailsListViewModel] = []
@@ -33,87 +33,105 @@ class ChainAssetSelectionBasePresenter {
         self.localizationManager = localizationManager
     }
 
-    private func extractAvailableBalanceInPlank(for chainAsset: ChainAsset) -> BigUInt? {
+    func extractAvailableBalanceInPlank(
+        for chainAsset: ChainAsset,
+        balanceMapper: AvailableBalanceMapping
+    ) -> BigUInt? {
         guard
             let balanceResult = accountBalances?[chainAsset.chainAssetId],
             case let .success(balance) = balanceResult else {
             return nil
         }
 
-        return balance ?? 0
+        return balanceMapper.availableBalanceElseZero(from: balance)
     }
 
-    private func extractFiatBalance(for chainAsset: ChainAsset) -> Decimal? {
+    func extractFiatBalance(for chainAsset: ChainAsset, balanceMapper: AvailableBalanceMapping) -> Decimal? {
         guard
-            let balanceResult = accountBalances?[chainAsset.chainAssetId],
-            case let .success(balance) = balanceResult,
+            let availableBalance = extractAvailableBalanceInPlank(
+                for: chainAsset,
+                balanceMapper: balanceMapper
+            ),
             let priceString = assetPrices?[chainAsset.chainAssetId]?.price,
-            let price = Decimal(string: priceString),
-            let balanceDecimal = Decimal.fromSubstrateAmount(
-                balance ?? 0,
-                precision: chainAsset.assetDisplayInfo.assetPrecision
-            ) else {
+            let price = Decimal(string: priceString) else {
             return nil
         }
+
+        let balanceDecimal = availableBalance.decimal(assetInfo: chainAsset.assetDisplayInfo)
 
         return balanceDecimal * price
     }
 
-    func extractFormattedBalance(for chainAsset: ChainAsset) -> String? {
+    func extractFormattedBalance(
+        for chainAsset: ChainAsset,
+        balanceMapper: AvailableBalanceMapping
+    ) -> String? {
         let assetInfo = chainAsset.assetDisplayInfo
 
-        let maybeBalance: Decimal?
+        let balanceInPlank = extractAvailableBalanceInPlank(
+            for: chainAsset,
+            balanceMapper: balanceMapper
+        ) ?? 0
 
-        if let balanceInPlank = extractAvailableBalanceInPlank(for: chainAsset) {
-            maybeBalance = Decimal.fromSubstrateAmount(
-                balanceInPlank,
-                precision: assetInfo.assetPrecision
-            )
-        } else {
-            maybeBalance = 0.0
-        }
-
-        guard let balance = maybeBalance else {
-            return nil
-        }
+        let balanceDecimal = balanceInPlank.decimal(assetInfo: assetInfo)
 
         let tokenFormatter = assetBalanceFormatterFactory.createTokenFormatter(for: assetInfo)
             .value(for: selectedLocale)
 
-        return tokenFormatter.stringFromDecimal(balance)
+        return tokenFormatter.stringFromDecimal(balanceDecimal)
     }
 
-    private func updateSorting() {
-        assets?.sort { chainAsset1, chainAsset2 in
-            let balance1 = extractAvailableBalanceInPlank(for: chainAsset1) ?? 0
-            let balance2 = extractAvailableBalanceInPlank(for: chainAsset2) ?? 0
+    func orderAssets(
+        _ chainAsset1: ChainAsset,
+        chainAsset2: ChainAsset,
+        balanceMapper: AvailableBalanceMapping
+    ) -> Bool {
+        let balance1 = extractAvailableBalanceInPlank(
+            for: chainAsset1,
+            balanceMapper: balanceMapper
+        ) ?? 0
 
-            let assetValue1 = extractFiatBalance(for: chainAsset1) ?? 0
-            let assetValue2 = extractFiatBalance(for: chainAsset2) ?? 0
+        let balance2 = extractAvailableBalanceInPlank(
+            for: chainAsset2,
+            balanceMapper: balanceMapper
+        ) ?? 0
 
-            let priorityAndTestnetResult = ChainModelCompator.priorityAndTestnetComparator(
-                chain1: chainAsset1.chain,
-                chain2: chainAsset2.chain
-            )
+        let assetValue1 = extractFiatBalance(
+            for: chainAsset1,
+            balanceMapper: balanceMapper
+        ) ?? 0
 
-            if priorityAndTestnetResult != .orderedSame {
-                return priorityAndTestnetResult == .orderedAscending
-            } else if assetValue1 > 0, assetValue2 > 0 {
-                return assetValue1 > assetValue2
-            } else if assetValue1 > 0 {
-                return true
-            } else if assetValue2 > 0 {
-                return false
-            } else if balance1 > 0, balance2 > 0 {
-                return balance1 > balance2
-            } else if balance1 > 0 {
-                return true
-            } else if balance2 > 0 {
-                return false
-            } else {
-                return chainAsset1.chain.name.lexicographicallyPrecedes(chainAsset2.chain.name)
-            }
+        let assetValue2 = extractFiatBalance(
+            for: chainAsset2,
+            balanceMapper: balanceMapper
+        ) ?? 0
+
+        let priorityAndTestnetResult = ChainModelCompator.priorityAndTestnetComparator(
+            chain1: chainAsset1.chain,
+            chain2: chainAsset2.chain
+        )
+
+        if priorityAndTestnetResult != .orderedSame {
+            return priorityAndTestnetResult == .orderedAscending
+        } else if assetValue1 > 0, assetValue2 > 0 {
+            return assetValue1 > assetValue2
+        } else if assetValue1 > 0 {
+            return true
+        } else if assetValue2 > 0 {
+            return false
+        } else if balance1 > 0, balance2 > 0 {
+            return balance1 > balance2
+        } else if balance1 > 0 {
+            return true
+        } else if balance2 > 0 {
+            return false
+        } else {
+            return chainAsset1.chain.name.lexicographicallyPrecedes(chainAsset2.chain.name)
         }
+    }
+
+    func updateAvailableOptions() {
+        fatalError("Child presenter must override this method")
     }
 
     func updateViewModels(_ viewModels: [SelectableIconDetailsListViewModel]) {
@@ -153,14 +171,14 @@ extension ChainAssetSelectionBasePresenter: ChainAssetSelectionInteractorOutputP
         case let .success(chainAssets):
             assets = chainAssets
 
-            updateSorting()
+            updateAvailableOptions()
             updateView()
         case let .failure(error):
             _ = baseWireframe.present(error: error, from: view, locale: selectedLocale)
         }
     }
 
-    func didReceiveBalance(results: [ChainAssetId: Result<BigUInt?, Error>]) {
+    func didReceiveBalance(results: [ChainAssetId: Result<AssetBalance?, Error>]) {
         if accountBalances == nil {
             accountBalances = [:]
         }
@@ -170,15 +188,13 @@ extension ChainAssetSelectionBasePresenter: ChainAssetSelectionInteractorOutputP
             case let .success(maybeAmount):
                 if let amount = maybeAmount {
                     accountBalances?[key] = .success(amount)
-                } else if accountBalances?[key] == nil {
-                    accountBalances?[key] = .success(0)
                 }
             case let .failure(error):
                 accountBalances?[key] = .failure(error)
             }
         }
 
-        updateSorting()
+        updateAvailableOptions()
         updateView()
     }
 
@@ -187,7 +203,7 @@ extension ChainAssetSelectionBasePresenter: ChainAssetSelectionInteractorOutputP
             accum[keyValue.key] = keyValue.value.item
         }
 
-        updateSorting()
+        updateAvailableOptions()
         updateView()
     }
 

--- a/novawallet/Modules/ChainAssetSelection/ChainAssetSelectionPresenter.swift
+++ b/novawallet/Modules/ChainAssetSelection/ChainAssetSelectionPresenter.swift
@@ -10,16 +10,19 @@ final class ChainAssetSelectionPresenter: ChainAssetSelectionBasePresenter {
     let assetIconViewModelFactory: AssetIconViewModelFactoryProtocol
 
     let selectedChainAssetId: ChainAssetId?
+    let balanceMapper: AvailableBalanceMapping
 
     init(
         interactor: ChainAssetSelectionInteractorInputProtocol,
         wireframe: ChainAssetSelectionWireframeProtocol,
         selectedChainAssetId: ChainAssetId?,
+        balanceMapper: AvailableBalanceMapping,
         assetBalanceFormatterFactory: AssetBalanceFormatterFactoryProtocol,
         assetIconViewModelFactory: AssetIconViewModelFactoryProtocol,
         localizationManager: LocalizationManagerProtocol
     ) {
         self.selectedChainAssetId = selectedChainAssetId
+        self.balanceMapper = balanceMapper
         self.assetIconViewModelFactory = assetIconViewModelFactory
 
         super.init(
@@ -43,7 +46,7 @@ final class ChainAssetSelectionPresenter: ChainAssetSelectionBasePresenter {
             let title = asset.name ?? chain.name
             let isSelected = selectedChainAssetId?.assetId == asset.assetId &&
                 selectedChainAssetId?.chainId == chain.chainId
-            let balance = extractFormattedBalance(for: chainAsset) ?? ""
+            let balance = extractFormattedBalance(for: chainAsset, balanceMapper: balanceMapper) ?? ""
 
             return SelectableIconDetailsListViewModel(
                 title: title,
@@ -64,5 +67,9 @@ final class ChainAssetSelectionPresenter: ChainAssetSelectionBasePresenter {
         }
 
         wireframe?.complete(on: view, selecting: assets[index])
+    }
+
+    override func updateAvailableOptions() {
+        assets?.sort { orderAssets($0, chainAsset2: $1, balanceMapper: balanceMapper) }
     }
 }

--- a/novawallet/Modules/ChainAssetSelection/ChainAssetSelectionProtocols.swift
+++ b/novawallet/Modules/ChainAssetSelection/ChainAssetSelectionProtocols.swift
@@ -23,7 +23,7 @@ protocol ChainAssetSelectionInteractorInputProtocol: AnyObject {
 
 protocol ChainAssetSelectionInteractorOutputProtocol: AnyObject {
     func didReceiveChainAssets(result: Result<[ChainAsset], Error>)
-    func didReceiveBalance(results: [ChainAssetId: Result<BigUInt?, Error>])
+    func didReceiveBalance(results: [ChainAssetId: Result<AssetBalance?, Error>])
     func didReceivePrice(changes: [ChainAssetId: DataProviderChange<PriceData>])
     func didReceivePrice(error: Error)
 }

--- a/novawallet/Modules/ChainAssetSelection/ChainAssetSelectionProtocols.swift
+++ b/novawallet/Modules/ChainAssetSelection/ChainAssetSelectionProtocols.swift
@@ -23,7 +23,7 @@ protocol ChainAssetSelectionInteractorInputProtocol: AnyObject {
 
 protocol ChainAssetSelectionInteractorOutputProtocol: AnyObject {
     func didReceiveChainAssets(result: Result<[ChainAsset], Error>)
-    func didReceiveBalance(results: [ChainAssetId: Result<AssetBalance?, Error>])
+    func didReceiveBalance(resultWithChanges: Result<[ChainAssetId: AssetBalance], Error>)
     func didReceivePrice(changes: [ChainAssetId: DataProviderChange<PriceData>])
     func didReceivePrice(error: Error)
 }

--- a/novawallet/Modules/ChainAssetSelection/ChainAssetSelectionViewFactory.swift
+++ b/novawallet/Modules/ChainAssetSelection/ChainAssetSelectionViewFactory.swift
@@ -20,7 +20,6 @@ struct ChainAssetSelectionViewFactory {
 
         let interactor = ChainAssetSelectionInteractor(
             selectedMetaAccount: SelectedWalletSettings.shared.value,
-            balanceSlice: balanceSlice ?? \.transferable,
             repository: AnyDataProviderRepository(repository),
             walletLocalSubscriptionFactory: WalletLocalSubscriptionFactory.shared,
             priceLocalSubscriptionFactory: PriceProviderFactory.shared,
@@ -41,6 +40,7 @@ struct ChainAssetSelectionViewFactory {
             interactor: interactor,
             wireframe: wireframe,
             selectedChainAssetId: selectedChainAssetId,
+            balanceMapper: AvailableBalanceSliceMapper(balanceSlice: balanceSlice ?? \.transferable),
             assetBalanceFormatterFactory: assetBalanceFormatterFactory,
             assetIconViewModelFactory: assetIconViewModelFactory,
             localizationManager: localizationManager

--- a/novawallet/Modules/Vote/Governance/Delegations/DelegateConfirm/GovernanceDelegateConfirmViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/Delegations/DelegateConfirm/GovernanceDelegateConfirmViewFactory.swift
@@ -78,7 +78,7 @@ struct GovernanceDelegateConfirmViewFactory {
 
         let referendumDisplayStringFactory = ReferendumDisplayStringFactory()
 
-        let dataValidatingFactory = GovernanceValidatorFactory.createFromPresentable(wireframe)
+        let dataValidatingFactory = GovernanceValidatorFactory.createFromPresentable(wireframe, govType: option.type)
 
         let presenter = GovernanceDelegateConfirmPresenter(
             interactor: interactor,

--- a/novawallet/Modules/Vote/Governance/Delegations/DelegateSetup/GovernanceDelegateSetupViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/Delegations/DelegateSetup/GovernanceDelegateSetupViewFactory.swift
@@ -89,7 +89,7 @@ struct GovernanceDelegateSetupViewFactory {
 
         let localizationManager = LocalizationManager.shared
 
-        let dataValidatingFactory = GovernanceValidatorFactory.createFromPresentable(wireframe)
+        let dataValidatingFactory = GovernanceValidatorFactory.createFromPresentable(wireframe, govType: option.type)
 
         let presenter = GovernanceDelegateSetupPresenter(
             interactor: interactor,
@@ -100,6 +100,7 @@ struct GovernanceDelegateSetupViewFactory {
             tracks: delegateDisplayInfo.additions,
             dataValidatingFactory: dataValidatingFactory,
             balanceViewModelFactory: balanceViewModelFactory,
+            govBalanceCalculator: GovernanceBalanceCalculator(governanceType: option.type),
             chainAssetViewModelFactory: chainAssetViewModelFactory,
             referendumStringsViewModelFactory: referendumDisplayStringFactory,
             lockChangeViewModelFactory: lockChangeViewModelFactory,

--- a/novawallet/Modules/Vote/Governance/Delegations/DelegateSetup/Presenter/GovernanceDelegateSetupPresenter+UpdateView.swift
+++ b/novawallet/Modules/Vote/Governance/Delegations/DelegateSetup/Presenter/GovernanceDelegateSetupPresenter+UpdateView.swift
@@ -2,11 +2,11 @@ import Foundation
 
 extension GovernanceDelegateSetupPresenter {
     func updateAvailableBalanceView() {
-        let freeInPlank = assetBalance?.freeInPlank ?? 0
+        let availableInPlank = govBalanceCalculator.availableBalanceElseZero(from: assetBalance)
 
         let precision = chain.utilityAsset()?.displayInfo.assetPrecision ?? 0
         let balanceDecimal = Decimal.fromSubstrateAmount(
-            freeInPlank,
+            availableInPlank,
             precision: precision
         ) ?? 0
 

--- a/novawallet/Modules/Vote/Governance/Delegations/DelegateSetup/Presenter/GovernanceDelegateSetupPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/Delegations/DelegateSetup/Presenter/GovernanceDelegateSetupPresenter.swift
@@ -17,6 +17,7 @@ final class GovernanceDelegateSetupPresenter {
     let referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol
     let lockChangeViewModelFactory: ReferendumLockChangeViewModelFactoryProtocol
     let dataValidatingFactory: GovernanceValidatorFactoryProtocol
+    let govBalanceCalculator: GovernanceBalanceCalculating
     let logger: LoggerProtocol
 
     var assetBalance: AssetBalance?
@@ -38,6 +39,7 @@ final class GovernanceDelegateSetupPresenter {
         tracks: [GovernanceTrackInfoLocal],
         dataValidatingFactory: GovernanceValidatorFactoryProtocol,
         balanceViewModelFactory: BalanceViewModelFactoryProtocol,
+        govBalanceCalculator: GovernanceBalanceCalculating,
         chainAssetViewModelFactory: ChainAssetViewModelFactoryProtocol,
         referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol,
         lockChangeViewModelFactory: ReferendumLockChangeViewModelFactoryProtocol,
@@ -51,6 +53,7 @@ final class GovernanceDelegateSetupPresenter {
         self.delegateId = delegateId
         self.tracks = tracks
         self.dataValidatingFactory = dataValidatingFactory
+        self.govBalanceCalculator = govBalanceCalculator
         self.balanceViewModelFactory = balanceViewModelFactory
         self.chainAssetViewModelFactory = chainAssetViewModelFactory
         self.referendumStringsViewModelFactory = referendumStringsViewModelFactory
@@ -60,7 +63,7 @@ final class GovernanceDelegateSetupPresenter {
     }
 
     func balanceMinusFee() -> Decimal {
-        let balanceValue = assetBalance?.freeInPlank ?? 0
+        let balanceValue = govBalanceCalculator.availableBalanceElseZero(from: assetBalance)
         let feeValue = fee?.amountForCurrentAccount ?? 0
 
         guard

--- a/novawallet/Modules/Vote/Governance/Delegations/DelegateSetup/Presenter/GovernanceDelegateSetupPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/Delegations/DelegateSetup/Presenter/GovernanceDelegateSetupPresenter.swift
@@ -17,7 +17,7 @@ final class GovernanceDelegateSetupPresenter {
     let referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol
     let lockChangeViewModelFactory: ReferendumLockChangeViewModelFactoryProtocol
     let dataValidatingFactory: GovernanceValidatorFactoryProtocol
-    let govBalanceCalculator: GovernanceBalanceCalculating
+    let govBalanceCalculator: AvailableBalanceMapping
     let logger: LoggerProtocol
 
     var assetBalance: AssetBalance?
@@ -39,7 +39,7 @@ final class GovernanceDelegateSetupPresenter {
         tracks: [GovernanceTrackInfoLocal],
         dataValidatingFactory: GovernanceValidatorFactoryProtocol,
         balanceViewModelFactory: BalanceViewModelFactoryProtocol,
-        govBalanceCalculator: GovernanceBalanceCalculating,
+        govBalanceCalculator: AvailableBalanceMapping,
         chainAssetViewModelFactory: ChainAssetViewModelFactoryProtocol,
         referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol,
         lockChangeViewModelFactory: ReferendumLockChangeViewModelFactoryProtocol,

--- a/novawallet/Modules/Vote/Governance/Delegations/RevokeDelegationConfirm/GovernanceRevokeDelegationConfirmViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/Delegations/RevokeDelegationConfirm/GovernanceRevokeDelegationConfirmViewFactory.swift
@@ -39,11 +39,9 @@ struct GovRevokeDelegationConfirmViewFactory {
             votingLockId: votingLockId
         )
 
-        let referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol
-
         let referendumDisplayStringFactory = ReferendumDisplayStringFactory()
 
-        let dataValidatingFactory = GovernanceValidatorFactory.createFromPresentable(wireframe)
+        let dataValidatingFactory = GovernanceValidatorFactory.createFromPresentable(wireframe, govType: option.type)
 
         let presenter = GovRevokeDelegationConfirmPresenter(
             interactor: interactor,

--- a/novawallet/Modules/Vote/Governance/Delegations/YourDelegations/GovernanceYourDelegationsViewController.swift
+++ b/novawallet/Modules/Vote/Governance/Delegations/YourDelegations/GovernanceYourDelegationsViewController.swift
@@ -40,7 +40,7 @@ final class GovernanceYourDelegationsViewController: UIViewController, ViewHolde
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        if !dataStore.isEmpty {
+        if dataStore.isEmpty {
             rootView.updateLoadingState()
         }
     }

--- a/novawallet/Modules/Vote/Governance/GovernanceChainSelection/GovernanceChainSelectionPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceChainSelection/GovernanceChainSelectionPresenter.swift
@@ -17,12 +17,14 @@ final class GovernanceChainSelectionPresenter: ChainAssetSelectionBasePresenter 
     private var selectedChainId: ChainModel.Id?
 
     private let assetIconViewModelFactory: AssetIconViewModelFactoryProtocol
+    private let balanceMapperFactory: GovBalanceCalculatorFactoryProtocol
 
     init(
         interactor: ChainAssetSelectionInteractorInputProtocol,
         wireframe: GovernanceChainSelectionWireframeProtocol,
         selectedChainId: ChainModel.Id?,
         selectedGovernanceType: GovernanceType?,
+        balanceMapperFactory: GovBalanceCalculatorFactoryProtocol,
         assetBalanceFormatterFactory: AssetBalanceFormatterFactoryProtocol,
         assetIconViewModelFactory: AssetIconViewModelFactoryProtocol,
         localizationManager: LocalizationManagerProtocol
@@ -30,6 +32,7 @@ final class GovernanceChainSelectionPresenter: ChainAssetSelectionBasePresenter 
         self.selectedChainId = selectedChainId
         self.selectedGovernanceType = selectedGovernanceType
         self.assetIconViewModelFactory = assetIconViewModelFactory
+        self.balanceMapperFactory = balanceMapperFactory
 
         super.init(
             interactor: interactor,
@@ -44,12 +47,13 @@ final class GovernanceChainSelectionPresenter: ChainAssetSelectionBasePresenter 
         governanceType: GovernanceType
     ) -> SelectableIconDetailsListViewModel {
         let chain = chainAsset.chain
-        let asset = chainAsset.asset
 
         let icon = ImageViewModelFactory.createChainIconOrDefault(from: chain.icon)
         let title = governanceType.title(for: chain)
         let isSelected = selectedChainId == chain.chainId && selectedGovernanceType == governanceType
-        let balance = extractFormattedBalance(for: chainAsset) ?? ""
+
+        let balanceMapper = balanceMapperFactory.createCalculator(for: governanceType)
+        let balance = extractFormattedBalance(for: chainAsset, balanceMapper: balanceMapper) ?? ""
 
         return SelectableIconDetailsListViewModel(
             title: title,
@@ -59,37 +63,56 @@ final class GovernanceChainSelectionPresenter: ChainAssetSelectionBasePresenter 
         )
     }
 
-    override func updateView() {
+    override func updateAvailableOptions() {
         guard let assets = assets, isReadyForDisplay else {
             return
         }
 
+        let gov2Mapper = balanceMapperFactory.createCalculator(for: .governanceV2)
+        let gov1Mapper = balanceMapperFactory.createCalculator(for: .governanceV1)
+
         // show gov2 options first but not testnets
-        availableOptions = assets.reduce(into: [Option]()) { accum, chainAsset in
+        let gov2Options: [Option] = assets.compactMap { chainAsset in
             if chainAsset.chain.hasGovernanceV2, !chainAsset.chain.isTestnet {
-                accum.append(.init(chainAsset: chainAsset, governanceType: .governanceV2))
+                Option(chainAsset: chainAsset, governanceType: .governanceV2)
+            } else {
+                nil
             }
-        }
+        }.sorted(by: { orderAssets($0.chainAsset, chainAsset2: $1.chainAsset, balanceMapper: gov2Mapper) })
 
         // then show gov1 options
-        availableOptions = assets.reduce(into: availableOptions) { accum, chainAsset in
+        let gov1Options: [Option] = assets.compactMap { chainAsset in
             if chainAsset.chain.hasGovernanceV1, !chainAsset.chain.isTestnet {
-                accum.append(.init(chainAsset: chainAsset, governanceType: .governanceV1))
+                Option(chainAsset: chainAsset, governanceType: .governanceV1)
+            } else {
+                nil
             }
-        }
+        }.sorted(by: { orderAssets($0.chainAsset, chainAsset2: $1.chainAsset, balanceMapper: gov1Mapper) })
 
         // then show gov2 testnets
-        availableOptions = assets.reduce(into: availableOptions) { accum, chainAsset in
+        let gov2Testnets: [Option] = assets.compactMap { chainAsset in
             if chainAsset.chain.hasGovernanceV2, chainAsset.chain.isTestnet {
-                accum.append(.init(chainAsset: chainAsset, governanceType: .governanceV2))
+                Option(chainAsset: chainAsset, governanceType: .governanceV2)
+            } else {
+                nil
             }
-        }
+        }.sorted(by: { orderAssets($0.chainAsset, chainAsset2: $1.chainAsset, balanceMapper: gov2Mapper) })
 
         // finally show gov1 testnets
-        availableOptions = assets.reduce(into: availableOptions) { accum, chainAsset in
+        let gov1Testnets: [Option] = assets.compactMap { chainAsset in
             if chainAsset.chain.hasGovernanceV1, chainAsset.chain.isTestnet {
-                accum.append(.init(chainAsset: chainAsset, governanceType: .governanceV1))
+                Option(chainAsset: chainAsset, governanceType: .governanceV1)
+            } else {
+                nil
             }
+        }.sorted(by: { orderAssets($0.chainAsset, chainAsset2: $1.chainAsset, balanceMapper: gov1Mapper) })
+
+        availableOptions = gov2Options + gov1Options + gov2Testnets + gov1Testnets
+    }
+
+    override func updateView() {
+        guard assets != nil, isReadyForDisplay else {
+            return
         }
 
         let viewModels = availableOptions.map {

--- a/novawallet/Modules/Vote/Governance/GovernanceChainSelection/GovernanceChainSelectionViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceChainSelection/GovernanceChainSelectionViewFactory.swift
@@ -19,7 +19,6 @@ final class GovernanceChainSelectionViewFactory {
 
         let interactor = ChainAssetSelectionInteractor(
             selectedMetaAccount: SelectedWalletSettings.shared.value,
-            balanceSlice: \.freeInPlank,
             repository: AnyDataProviderRepository(repository),
             walletLocalSubscriptionFactory: WalletLocalSubscriptionFactory.shared,
             priceLocalSubscriptionFactory: PriceProviderFactory.shared,
@@ -44,6 +43,7 @@ final class GovernanceChainSelectionViewFactory {
             wireframe: wireframe,
             selectedChainId: chainId,
             selectedGovernanceType: governanceType,
+            balanceMapperFactory: GovBalanceCalculatorFactory(),
             assetBalanceFormatterFactory: assetBalanceFormatterFactory,
             assetIconViewModelFactory: assetIconViewModelFactory,
             localizationManager: localizationManager

--- a/novawallet/Modules/Vote/Governance/GovernanceRemoveVotesConfirm/GovernanceRemoveVotesConfirmViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceRemoveVotesConfirm/GovernanceRemoveVotesConfirmViewFactory.swift
@@ -9,15 +9,18 @@ struct GovernanceRemoveVotesConfirmViewFactory {
     ) -> GovernanceRemoveVotesConfirmViewProtocol? {
         guard
             let currencyManager = CurrencyManager.shared,
-            let chain = state.settings.value?.chain,
-            let assetDisplayInfo = chain.utilityAssetDisplayInfo(),
+            let option = state.settings.value,
+            let assetDisplayInfo = option.chain.utilityAssetDisplayInfo(),
             let selectedAccount = SelectedWalletSettings.shared.value?.fetchMetaChainAccount(
-                for: chain.accountRequest()
+                for: option.chain.accountRequest()
             ),
             let interactor = createInteractor(for: state, currencyManager: currencyManager)
         else {
             return nil
         }
+
+        let chain = option.chain
+
         let wireframe = GovRemoveVotesConfirmWireframe(state: state)
 
         let localizationManager = LocalizationManager.shared
@@ -27,11 +30,7 @@ struct GovernanceRemoveVotesConfirmViewFactory {
             priceAssetInfoFactory: PriceAssetInfoFactory(currencyManager: currencyManager)
         )
 
-        let dataValidatingFactory = GovernanceValidatorFactory(
-            presentable: wireframe,
-            assetBalanceFormatterFactory: AssetBalanceFormatterFactory(),
-            quantityFormatter: NumberFormatter.quantity.localizableResource()
-        )
+        let dataValidatingFactory = GovernanceValidatorFactory.createFromPresentable(wireframe, govType: option.type)
 
         let presenter = GovernanceRemoveVotesConfirmPresenter(
             interactor: interactor,

--- a/novawallet/Modules/Vote/Governance/GovernanceUnlockConfirm/GovernanceUnlockConfirmViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/GovernanceUnlockConfirm/GovernanceUnlockConfirmViewFactory.swift
@@ -43,11 +43,7 @@ struct GovernanceUnlockConfirmViewFactory {
             votingLockId: votingLockId
         )
 
-        let dataValidatingFactory = GovernanceValidatorFactory(
-            presentable: wireframe,
-            assetBalanceFormatterFactory: AssetBalanceFormatterFactory(),
-            quantityFormatter: NumberFormatter.quantity.localizableResource()
-        )
+        let dataValidatingFactory = GovernanceValidatorFactory.createFromPresentable(wireframe, govType: option.type)
 
         let presenter = GovernanceUnlockConfirmPresenter(
             interactor: interactor,

--- a/novawallet/Modules/Vote/Governance/Model/AssetBalance+OpenGov.swift
+++ b/novawallet/Modules/Vote/Governance/Model/AssetBalance+OpenGov.swift
@@ -1,6 +1,0 @@
-import Foundation
-import BigInt
-
-extension AssetBalance {
-    var availableForOpenGov: BigUInt { freeInPlank }
-}

--- a/novawallet/Modules/Vote/Governance/Model/GovernanceBalanceCalculator.swift
+++ b/novawallet/Modules/Vote/Governance/Model/GovernanceBalanceCalculator.swift
@@ -1,24 +1,10 @@
 import Foundation
 
-protocol GovernanceBalanceCalculating {
-    func availableBalance(from assetBalance: AssetBalance) -> Balance
-}
-
-extension GovernanceBalanceCalculating {
-    func mapAvailableBalance(from assetBalance: AssetBalance?) -> Balance? {
-        assetBalance.map { availableBalance(from: $0) }
-    }
-
-    func availableBalanceElseZero(from assetBalance: AssetBalance?) -> Balance {
-        mapAvailableBalance(from: assetBalance) ?? 0
-    }
-}
-
 struct GovernanceBalanceCalculator {
     let governanceType: GovernanceType
 }
 
-extension GovernanceBalanceCalculator: GovernanceBalanceCalculating {
+extension GovernanceBalanceCalculator: AvailableBalanceMapping {
     func availableBalance(from assetBalance: AssetBalance) -> Balance {
         switch governanceType {
         case .governanceV1:
@@ -30,13 +16,13 @@ extension GovernanceBalanceCalculator: GovernanceBalanceCalculating {
 }
 
 protocol GovBalanceCalculatorFactoryProtocol {
-    func createCalculator(for governanceType: GovernanceType) -> GovernanceBalanceCalculating
+    func createCalculator(for governanceType: GovernanceType) -> AvailableBalanceMapping
 }
 
 final class GovBalanceCalculatorFactory {}
 
 extension GovBalanceCalculatorFactory: GovBalanceCalculatorFactoryProtocol {
-    func createCalculator(for governanceType: GovernanceType) -> GovernanceBalanceCalculating {
+    func createCalculator(for governanceType: GovernanceType) -> AvailableBalanceMapping {
         GovernanceBalanceCalculator(governanceType: governanceType)
     }
 }

--- a/novawallet/Modules/Vote/Governance/Model/GovernanceBalanceCalculator.swift
+++ b/novawallet/Modules/Vote/Governance/Model/GovernanceBalanceCalculator.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+protocol GovernanceBalanceCalculating {
+    func availableBalance(from assetBalance: AssetBalance) -> Balance
+}
+
+extension GovernanceBalanceCalculating {
+    func mapAvailableBalance(from assetBalance: AssetBalance?) -> Balance? {
+        assetBalance.map { availableBalance(from: $0) }
+    }
+
+    func availableBalanceElseZero(from assetBalance: AssetBalance?) -> Balance {
+        mapAvailableBalance(from: assetBalance) ?? 0
+    }
+}
+
+struct GovernanceBalanceCalculator {
+    let governanceType: GovernanceType
+}
+
+extension GovernanceBalanceCalculator: GovernanceBalanceCalculating {
+    func availableBalance(from assetBalance: AssetBalance) -> Balance {
+        switch governanceType {
+        case .governanceV1:
+            return assetBalance.freeInPlank
+        case .governanceV2:
+            return assetBalance.totalInPlank
+        }
+    }
+}
+
+protocol GovBalanceCalculatorFactoryProtocol {
+    func createCalculator(for governanceType: GovernanceType) -> GovernanceBalanceCalculating
+}
+
+final class GovBalanceCalculatorFactory {}
+
+extension GovBalanceCalculatorFactory: GovBalanceCalculatorFactoryProtocol {
+    func createCalculator(for governanceType: GovernanceType) -> GovernanceBalanceCalculating {
+        GovernanceBalanceCalculator(governanceType: governanceType)
+    }
+}

--- a/novawallet/Modules/Vote/Governance/ReferendumVoteConfirm/ReferendumVoteConfirmViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/ReferendumVoteConfirm/ReferendumVoteConfirmViewFactory.swift
@@ -51,7 +51,8 @@ struct ReferendumVoteConfirmViewFactory {
         let dataValidatingFactory = GovernanceValidatorFactory(
             presentable: wireframe,
             assetBalanceFormatterFactory: AssetBalanceFormatterFactory(),
-            quantityFormatter: NumberFormatter.quantity.localizableResource()
+            quantityFormatter: NumberFormatter.quantity.localizableResource(),
+            govBalanceCalculator: GovernanceBalanceCalculator(governanceType: option.type)
         )
 
         let presenter = ReferendumVoteConfirmPresenter(

--- a/novawallet/Modules/Vote/Governance/ReferendumVoteSetup/ReferendumVoteSetupPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/ReferendumVoteSetup/ReferendumVoteSetupPresenter.swift
@@ -16,6 +16,7 @@ final class ReferendumVoteSetupPresenter {
     let referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol
     let lockChangeViewModelFactory: ReferendumLockChangeViewModelFactoryProtocol
     let dataValidatingFactory: GovernanceValidatorFactoryProtocol
+    let govBalanceCalculator: GovernanceBalanceCalculating
     let logger: LoggerProtocol
 
     private var assetBalance: AssetBalance?
@@ -41,6 +42,7 @@ final class ReferendumVoteSetupPresenter {
         chainAssetViewModelFactory: ChainAssetViewModelFactoryProtocol,
         referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol,
         lockChangeViewModelFactory: ReferendumLockChangeViewModelFactoryProtocol,
+        govBalanceCalculator: GovernanceBalanceCalculating,
         interactor: ReferendumVoteSetupInteractorInputProtocol,
         wireframe: ReferendumVoteSetupWireframeProtocol,
         localizationManager: LocalizationManagerProtocol,
@@ -60,6 +62,7 @@ final class ReferendumVoteSetupPresenter {
         self.referendumFormatter = referendumFormatter
         self.referendumStringsViewModelFactory = referendumStringsViewModelFactory
         self.lockChangeViewModelFactory = lockChangeViewModelFactory
+        self.govBalanceCalculator = govBalanceCalculator
         self.interactor = interactor
         self.wireframe = wireframe
         self.logger = logger
@@ -72,7 +75,7 @@ final class ReferendumVoteSetupPresenter {
 
 extension ReferendumVoteSetupPresenter {
     private func balanceMinusFee() -> Decimal {
-        let balanceValue = assetBalance?.freeInPlank ?? 0
+        let balanceValue = govBalanceCalculator.availableBalanceElseZero(from: assetBalance)
         let feeValue = fee?.amountForCurrentAccount ?? 0
 
         guard
@@ -86,11 +89,11 @@ extension ReferendumVoteSetupPresenter {
     }
 
     private func updateAvailableBalanceView() {
-        let freeInPlank = assetBalance?.freeInPlank ?? 0
+        let availableInPlank = govBalanceCalculator.mapAvailableBalance(from: assetBalance) ?? 0
 
         let precision = chain.utilityAsset()?.displayInfo.assetPrecision ?? 0
         let balanceDecimal = Decimal.fromSubstrateAmount(
-            freeInPlank,
+            availableInPlank,
             precision: precision
         ) ?? 0
 

--- a/novawallet/Modules/Vote/Governance/ReferendumVoteSetup/ReferendumVoteSetupPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/ReferendumVoteSetup/ReferendumVoteSetupPresenter.swift
@@ -16,7 +16,7 @@ final class ReferendumVoteSetupPresenter {
     let referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol
     let lockChangeViewModelFactory: ReferendumLockChangeViewModelFactoryProtocol
     let dataValidatingFactory: GovernanceValidatorFactoryProtocol
-    let govBalanceCalculator: GovernanceBalanceCalculating
+    let govBalanceCalculator: AvailableBalanceMapping
     let logger: LoggerProtocol
 
     private var assetBalance: AssetBalance?
@@ -42,7 +42,7 @@ final class ReferendumVoteSetupPresenter {
         chainAssetViewModelFactory: ChainAssetViewModelFactoryProtocol,
         referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol,
         lockChangeViewModelFactory: ReferendumLockChangeViewModelFactoryProtocol,
-        govBalanceCalculator: GovernanceBalanceCalculating,
+        govBalanceCalculator: AvailableBalanceMapping,
         interactor: ReferendumVoteSetupInteractorInputProtocol,
         wireframe: ReferendumVoteSetupWireframeProtocol,
         localizationManager: LocalizationManagerProtocol,

--- a/novawallet/Modules/Vote/Governance/ReferendumVoteSetup/ReferendumVoteSetupViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/ReferendumVoteSetup/ReferendumVoteSetupViewFactory.swift
@@ -10,6 +10,7 @@ struct ReferendumVoteSetupViewFactory {
         initData: ReferendumVotingInitData
     ) -> ReferendumVoteSetupViewProtocol? {
         guard
+            let govOption = state.settings.value,
             let currencyManager = CurrencyManager.shared,
             let interactor = createInteractor(
                 for: state,
@@ -23,7 +24,8 @@ struct ReferendumVoteSetupViewFactory {
         let dataValidatingFactory = GovernanceValidatorFactory(
             presentable: wireframe,
             assetBalanceFormatterFactory: AssetBalanceFormatterFactory(),
-            quantityFormatter: NumberFormatter.quantity.localizableResource()
+            quantityFormatter: NumberFormatter.quantity.localizableResource(),
+            govBalanceCalculator: GovernanceBalanceCalculator(governanceType: govOption.type)
         )
 
         guard
@@ -97,6 +99,7 @@ struct ReferendumVoteSetupViewFactory {
             chainAssetViewModelFactory: chainAssetViewModelFactory,
             referendumStringsViewModelFactory: referendumDisplayStringFactory,
             lockChangeViewModelFactory: lockChangeViewModelFactory,
+            govBalanceCalculator: GovernanceBalanceCalculator(governanceType: option.type),
             interactor: interactor,
             wireframe: wireframe,
             localizationManager: LocalizationManager.shared,

--- a/novawallet/Modules/Vote/Governance/Referendums/Interactor/ReferendumsInteractor.swift
+++ b/novawallet/Modules/Vote/Governance/Referendums/Interactor/ReferendumsInteractor.swift
@@ -223,6 +223,8 @@ final class ReferendumsInteractor: AnyProviderAutoCleaning, AnyCancellableCleani
 
         if metadataProvider == nil {
             presenter?.didReceiveReferendumsMetadata([])
+        } else {
+            metadataProvider?.refresh()
         }
     }
 

--- a/novawallet/Modules/Vote/Governance/Referendums/Presenter/ReferendumsPresenter+ViewUpdate.swift
+++ b/novawallet/Modules/Vote/Governance/Referendums/Presenter/ReferendumsPresenter+ViewUpdate.swift
@@ -120,10 +120,13 @@ extension ReferendumsPresenter {
             return
         }
 
+        let govBalanceCalculator = govBalanceCalculatorFactory.createCalculator(for: governanceType)
+        let balanceInPlank = govBalanceCalculator.mapAvailableBalance(from: balance)
+
         let viewModel = chainBalanceFactory.createViewModel(
             from: governanceType.title(for: chain),
             chainAsset: ChainAsset(chain: chain, asset: asset),
-            balanceInPlank: freeBalance,
+            balanceInPlank: balanceInPlank,
             locale: selectedLocale
         )
 

--- a/novawallet/Modules/Vote/Governance/Referendums/Presenter/ReferendumsPresenter+ViewUpdate.swift
+++ b/novawallet/Modules/Vote/Governance/Referendums/Presenter/ReferendumsPresenter+ViewUpdate.swift
@@ -121,7 +121,7 @@ extension ReferendumsPresenter {
         }
 
         let govBalanceCalculator = govBalanceCalculatorFactory.createCalculator(for: governanceType)
-        let balanceInPlank = govBalanceCalculator.mapAvailableBalance(from: balance)
+        let balanceInPlank = govBalanceCalculator.availableBalanceElseZero(from: balance)
 
         let viewModel = chainBalanceFactory.createViewModel(
             from: governanceType.title(for: chain),

--- a/novawallet/Modules/Vote/Governance/Referendums/Presenter/ReferendumsPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/Referendums/Presenter/ReferendumsPresenter.swift
@@ -16,11 +16,12 @@ final class ReferendumsPresenter {
     let sorting: ReferendumsSorting
     let selectedMetaAccount: MetaAccountModel
     let accountManagementFilter: AccountManagementFilterProtocol
+    let govBalanceCalculatorFactory: GovBalanceCalculatorFactoryProtocol
     let logger: LoggerProtocol
 
     private(set) lazy var chainBalanceFactory = ChainBalanceViewModelFactory()
 
-    private(set) var freeBalance: BigUInt?
+    private(set) var balance: AssetBalance?
     private(set) var selectedOption: GovernanceSelectedOption?
     private(set) var price: PriceData?
     private(set) var sortedReferendums: [ReferendumLocal]?
@@ -78,6 +79,7 @@ final class ReferendumsPresenter {
         selectedMetaAccount: MetaAccountModel,
         accountManagementFilter: AccountManagementFilterProtocol,
         sorting: ReferendumsSorting,
+        govBalanceCalculatorFactory: GovBalanceCalculatorFactoryProtocol,
         localizationManager: LocalizationManagerProtocol,
         appearanceFacade: AppearanceFacadeProtocol,
         logger: LoggerProtocol
@@ -93,6 +95,7 @@ final class ReferendumsPresenter {
         self.selectedMetaAccount = selectedMetaAccount
         self.accountManagementFilter = accountManagementFilter
         self.sorting = sorting
+        self.govBalanceCalculatorFactory = govBalanceCalculatorFactory
         self.logger = logger
         self.localizationManager = localizationManager
         self.appearanceFacade = appearanceFacade
@@ -120,7 +123,7 @@ final class ReferendumsPresenter {
     }
 
     func clearState() {
-        freeBalance = nil
+        balance = nil
         price = nil
         sortedReferendums = nil
         observableState.state = .init(value: ReferendumsState())
@@ -379,7 +382,7 @@ extension ReferendumsPresenter: ReferendumsInteractorOutputProtocol {
     }
 
     func didReceiveAssetBalance(_ balance: AssetBalance?) {
-        freeBalance = balance?.freeInPlank ?? 0
+        self.balance = balance
 
         provideChainBalance()
     }

--- a/novawallet/Modules/Vote/Governance/Referendums/Presenter/ReferendumsPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/Referendums/Presenter/ReferendumsPresenter.swift
@@ -424,25 +424,17 @@ extension ReferendumsPresenter: ReferendumsInteractorOutputProtocol {
                     self?.interactor.saveSelected(option: option)
                 }
             }
-        case .referendumsFetchFailed:
-            wireframe.presentRequestStatus(on: view, locale: selectedLocale) { [weak self] in
-                self?.interactor.refreshReferendums()
-            }
         case .blockNumberSubscriptionFailed, .priceSubscriptionFailed, .balanceSubscriptionFailed,
              .metadataSubscriptionFailed, .blockTimeServiceFailed, .votingSubscriptionFailed:
             wireframe.presentRequestStatus(on: view, locale: selectedLocale) { [weak self] in
                 self?.interactor.remakeSubscriptions()
             }
-        case .blockTimeFetchFailed:
-            wireframe.presentRequestStatus(on: view, locale: selectedLocale) { [weak self] in
-                self?.interactor.retryBlockTime()
-            }
         case .unlockScheduleFetchFailed:
             wireframe.presentRequestStatus(on: view, locale: selectedLocale) { [weak self] in
                 self?.refreshUnlockSchedule()
             }
-        case .offchainVotingFetchFailed:
-            // we don't bother user with offchain retry and wait next block
+        case .offchainVotingFetchFailed, .referendumsFetchFailed, .blockTimeFetchFailed:
+            // we don't bother user with retry and wait next block
             break
         }
     }

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovPresenter.swift
@@ -12,7 +12,7 @@ final class SwipeGovPresenter {
     private let balanceViewModelFactory: BalanceViewModelFactoryProtocol
     private let localizationManager: LocalizationManagerProtocol
     private let utilityAssetInfo: AssetBalanceDisplayInfo
-    private let govBalanceCalculator: GovernanceBalanceCalculating
+    private let govBalanceCalculator: AvailableBalanceMapping
 
     private var model: SwipeGovModelBuilder.Result.Model?
     private var votingPower: VotingPowerLocal?
@@ -25,7 +25,7 @@ final class SwipeGovPresenter {
         viewModelFactory: SwipeGovViewModelFactoryProtocol,
         cardsViewModelFactory: VoteCardViewModelFactoryProtocol,
         balanceViewModelFactory: BalanceViewModelFactoryProtocol,
-        govBalanceCalculator: GovernanceBalanceCalculating,
+        govBalanceCalculator: AvailableBalanceMapping,
         utilityAssetInfo: AssetBalanceDisplayInfo,
         localizationManager: LocalizationManagerProtocol
     ) {

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovPresenter.swift
@@ -12,6 +12,7 @@ final class SwipeGovPresenter {
     private let balanceViewModelFactory: BalanceViewModelFactoryProtocol
     private let localizationManager: LocalizationManagerProtocol
     private let utilityAssetInfo: AssetBalanceDisplayInfo
+    private let govBalanceCalculator: GovernanceBalanceCalculating
 
     private var model: SwipeGovModelBuilder.Result.Model?
     private var votingPower: VotingPowerLocal?
@@ -24,6 +25,7 @@ final class SwipeGovPresenter {
         viewModelFactory: SwipeGovViewModelFactoryProtocol,
         cardsViewModelFactory: VoteCardViewModelFactoryProtocol,
         balanceViewModelFactory: BalanceViewModelFactoryProtocol,
+        govBalanceCalculator: GovernanceBalanceCalculating,
         utilityAssetInfo: AssetBalanceDisplayInfo,
         localizationManager: LocalizationManagerProtocol
     ) {
@@ -32,6 +34,7 @@ final class SwipeGovPresenter {
         self.viewModelFactory = viewModelFactory
         self.cardsViewModelFactory = cardsViewModelFactory
         self.balanceViewModelFactory = balanceViewModelFactory
+        self.govBalanceCalculator = govBalanceCalculator
         self.utilityAssetInfo = utilityAssetInfo
         self.localizationManager = localizationManager
     }
@@ -163,7 +166,7 @@ private extension SwipeGovPresenter {
             return false
         }
 
-        let availableBalance = optBalance?.availableForOpenGov ?? 0
+        let availableBalance = govBalanceCalculator.availableBalanceElseZero(from: optBalance)
 
         if availableBalance == 0 || votingPower.amount > availableBalance {
             interruptAndOfferChangeVotingPower(

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGov/SwipeGovViewFactory.swift
@@ -47,6 +47,7 @@ struct SwipeGovViewFactory {
             viewModelFactory: viewModelFactory,
             cardsViewModelFactory: cardsViewModelFactory,
             balanceViewModelFactory: balanceViewModelFactory,
+            govBalanceCalculator: GovernanceBalanceCalculator(governanceType: option.type),
             utilityAssetInfo: assetInfo,
             localizationManager: localizationManager
         )

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovSetup/SwipeGovSetupPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovSetup/SwipeGovSetupPresenter.swift
@@ -17,6 +17,7 @@ final class SwipeGovSetupPresenter {
     let referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol
     let lockChangeViewModelFactory: ReferendumLockChangeViewModelFactoryProtocol
     let dataValidatingFactory: GovernanceValidatorFactoryProtocol
+    let govBalanceCalculator: GovernanceBalanceCalculating
     let logger: LoggerProtocol
 
     private(set) var assetBalance: AssetBalance?
@@ -42,6 +43,7 @@ final class SwipeGovSetupPresenter {
         chainAssetViewModelFactory: ChainAssetViewModelFactoryProtocol,
         referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol,
         lockChangeViewModelFactory: ReferendumLockChangeViewModelFactoryProtocol,
+        govBalanceCalculator: GovernanceBalanceCalculating,
         interactor: SwipeGovSetupInteractorInputProtocol,
         wireframe: SwipeGovSetupWireframeProtocol,
         localizationManager: LocalizationManagerProtocol,
@@ -60,6 +62,7 @@ final class SwipeGovSetupPresenter {
         self.balanceViewModelFactory = balanceViewModelFactory
         self.chainAssetViewModelFactory = chainAssetViewModelFactory
         self.referendumStringsViewModelFactory = referendumStringsViewModelFactory
+        self.govBalanceCalculator = govBalanceCalculator
         self.lockChangeViewModelFactory = lockChangeViewModelFactory
         self.interactor = interactor
         self.wireframe = wireframe
@@ -364,7 +367,7 @@ private extension SwipeGovSetupPresenter {
     }
 
     func balance() -> Decimal {
-        let balanceValue = assetBalance?.freeInPlank ?? 0
+        let balanceValue = govBalanceCalculator.availableBalanceElseZero(from: assetBalance)
 
         guard
             let precision = chain.utilityAsset()?.displayInfo.assetPrecision,
@@ -376,11 +379,11 @@ private extension SwipeGovSetupPresenter {
     }
 
     private func updateAvailableBalanceView() {
-        let freeInPlank = assetBalance?.freeInPlank ?? 0
+        let availableInPlank = govBalanceCalculator.availableBalanceElseZero(from: assetBalance)
 
         let precision = chain.utilityAsset()?.displayInfo.assetPrecision ?? 0
         let balanceDecimal = Decimal.fromSubstrateAmount(
-            freeInPlank,
+            availableInPlank,
             precision: precision
         ) ?? 0
 

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovSetup/SwipeGovSetupPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovSetup/SwipeGovSetupPresenter.swift
@@ -17,7 +17,7 @@ final class SwipeGovSetupPresenter {
     let referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol
     let lockChangeViewModelFactory: ReferendumLockChangeViewModelFactoryProtocol
     let dataValidatingFactory: GovernanceValidatorFactoryProtocol
-    let govBalanceCalculator: GovernanceBalanceCalculating
+    let govBalanceCalculator: AvailableBalanceMapping
     let logger: LoggerProtocol
 
     private(set) var assetBalance: AssetBalance?
@@ -43,7 +43,7 @@ final class SwipeGovSetupPresenter {
         chainAssetViewModelFactory: ChainAssetViewModelFactoryProtocol,
         referendumStringsViewModelFactory: ReferendumDisplayStringFactoryProtocol,
         lockChangeViewModelFactory: ReferendumLockChangeViewModelFactoryProtocol,
-        govBalanceCalculator: GovernanceBalanceCalculating,
+        govBalanceCalculator: AvailableBalanceMapping,
         interactor: SwipeGovSetupInteractorInputProtocol,
         wireframe: SwipeGovSetupWireframeProtocol,
         localizationManager: LocalizationManagerProtocol,

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovSetup/SwipeGovSetupViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovSetup/SwipeGovSetupViewFactory.swift
@@ -13,18 +13,15 @@ struct SwipeGovSetupViewFactory {
             let swipeGovSetupInteractor = createInteractor(
                 for: state,
                 currencyManager: currencyManager
-            )
+            ),
+            let option = state.settings.value
         else {
             return nil
         }
 
         let wireframe = SwipeGovSetupWireframe(newVotingPowerClosure: newVotingPowerClosure)
 
-        let dataValidatingFactory = GovernanceValidatorFactory(
-            presentable: wireframe,
-            assetBalanceFormatterFactory: AssetBalanceFormatterFactory(),
-            quantityFormatter: NumberFormatter.quantity.localizableResource()
-        )
+        let dataValidatingFactory = GovernanceValidatorFactory.createFromPresentable(wireframe, govType: option.type)
 
         guard
             let presenter = createPresenter(
@@ -97,6 +94,7 @@ struct SwipeGovSetupViewFactory {
             chainAssetViewModelFactory: chainAssetViewModelFactory,
             referendumStringsViewModelFactory: referendumDisplayStringFactory,
             lockChangeViewModelFactory: lockChangeViewModelFactory,
+            govBalanceCalculator: GovernanceBalanceCalculator(governanceType: option.type),
             interactor: swipeGovSetupInteractor,
             wireframe: wireframe,
             localizationManager: LocalizationManager.shared,

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingConfirm/SwipeGovVotingConfirmViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingConfirm/SwipeGovVotingConfirmViewFactory.swift
@@ -45,11 +45,7 @@ struct SwipeGovVotingConfirmViewFactory {
 
         let wireframe = SwipeGovVotingConfirmWireframe()
 
-        let dataValidatingFactory = GovernanceValidatorFactory(
-            presentable: wireframe,
-            assetBalanceFormatterFactory: AssetBalanceFormatterFactory(),
-            quantityFormatter: NumberFormatter.quantity.localizableResource()
-        )
+        let dataValidatingFactory = GovernanceValidatorFactory.createFromPresentable(wireframe, govType: option.type)
 
         let presenter = SwipeGovVotingConfirmPresenter(
             initData: initData,

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListInteractor.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListInteractor.swift
@@ -7,7 +7,7 @@ final class SwipeGovVotingListInteractor: AnyProviderAutoCleaning {
     let votingBasketSubscriptionFactory: VotingBasketLocalSubscriptionFactoryProtocol
     let walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol
     let govMetadataLocalSubscriptionFactory: GovMetadataLocalSubscriptionFactoryProtocol
-    let govBalanceCalculator: GovernanceBalanceCalculating
+    let govBalanceCalculator: AvailableBalanceMapping
 
     private let observableState: ReferendumsObservableState
 
@@ -38,7 +38,7 @@ final class SwipeGovVotingListInteractor: AnyProviderAutoCleaning {
         votingBasketSubscriptionFactory: VotingBasketLocalSubscriptionFactoryProtocol,
         walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol,
         govMetadataLocalSubscriptionFactory: GovMetadataLocalSubscriptionFactoryProtocol,
-        govBalanceCalculator: GovernanceBalanceCalculating,
+        govBalanceCalculator: AvailableBalanceMapping,
         operationQueue: OperationQueue
     ) {
         self.observableState = observableState

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListInteractor.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListInteractor.swift
@@ -7,6 +7,7 @@ final class SwipeGovVotingListInteractor: AnyProviderAutoCleaning {
     let votingBasketSubscriptionFactory: VotingBasketLocalSubscriptionFactoryProtocol
     let walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol
     let govMetadataLocalSubscriptionFactory: GovMetadataLocalSubscriptionFactoryProtocol
+    let govBalanceCalculator: GovernanceBalanceCalculating
 
     private let observableState: ReferendumsObservableState
 
@@ -37,6 +38,7 @@ final class SwipeGovVotingListInteractor: AnyProviderAutoCleaning {
         votingBasketSubscriptionFactory: VotingBasketLocalSubscriptionFactoryProtocol,
         walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol,
         govMetadataLocalSubscriptionFactory: GovMetadataLocalSubscriptionFactoryProtocol,
+        govBalanceCalculator: GovernanceBalanceCalculating,
         operationQueue: OperationQueue
     ) {
         self.observableState = observableState
@@ -47,6 +49,7 @@ final class SwipeGovVotingListInteractor: AnyProviderAutoCleaning {
         self.votingBasketSubscriptionFactory = votingBasketSubscriptionFactory
         self.walletLocalSubscriptionFactory = walletLocalSubscriptionFactory
         self.govMetadataLocalSubscriptionFactory = govMetadataLocalSubscriptionFactory
+        self.govBalanceCalculator = govBalanceCalculator
         self.operationQueue = operationQueue
     }
 }
@@ -246,6 +249,6 @@ private extension SwipeGovVotingListInteractor {
             return false
         }
 
-        return votingItem.amount <= balance.availableForOpenGov
+        return votingItem.amount <= govBalanceCalculator.availableBalance(from: balance)
     }
 }

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListPresenter.swift
@@ -14,7 +14,7 @@ final class SwipeGovVotingListPresenter {
 
     private let votingListViewModelFactory: SwipeGovVotingListViewModelFactory
     private let balanceViewModelFactory: BalanceViewModelFactoryProtocol
-    private let govBalanceCalculator: GovernanceBalanceCalculating
+    private let govBalanceCalculator: AvailableBalanceMapping
 
     private var votingListItems: [VotingBasketItemLocal] = []
     private var referendumsMetadata: [ReferendumMetadataLocal] = []
@@ -28,7 +28,7 @@ final class SwipeGovVotingListPresenter {
         observableState: ReferendumsObservableState,
         votingListViewModelFactory: SwipeGovVotingListViewModelFactory,
         balanceViewModelFactory: BalanceViewModelFactoryProtocol,
-        govBalanceCalculator: GovernanceBalanceCalculating,
+        govBalanceCalculator: AvailableBalanceMapping,
         localizationManager: LocalizationManagerProtocol
     ) {
         self.interactor = interactor

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListPresenter.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListPresenter.swift
@@ -14,6 +14,7 @@ final class SwipeGovVotingListPresenter {
 
     private let votingListViewModelFactory: SwipeGovVotingListViewModelFactory
     private let balanceViewModelFactory: BalanceViewModelFactoryProtocol
+    private let govBalanceCalculator: GovernanceBalanceCalculating
 
     private var votingListItems: [VotingBasketItemLocal] = []
     private var referendumsMetadata: [ReferendumMetadataLocal] = []
@@ -27,6 +28,7 @@ final class SwipeGovVotingListPresenter {
         observableState: ReferendumsObservableState,
         votingListViewModelFactory: SwipeGovVotingListViewModelFactory,
         balanceViewModelFactory: BalanceViewModelFactoryProtocol,
+        govBalanceCalculator: GovernanceBalanceCalculating,
         localizationManager: LocalizationManagerProtocol
     ) {
         self.interactor = interactor
@@ -35,6 +37,7 @@ final class SwipeGovVotingListPresenter {
         self.observableState = observableState
         self.votingListViewModelFactory = votingListViewModelFactory
         self.balanceViewModelFactory = balanceViewModelFactory
+        self.govBalanceCalculator = govBalanceCalculator
         self.localizationManager = localizationManager
     }
 }
@@ -198,7 +201,7 @@ private extension SwipeGovVotingListPresenter {
             return
         }
 
-        let availableBalance = balance?.availableForOpenGov ?? 0
+        let availableBalance = govBalanceCalculator.availableBalanceElseZero(from: balance)
 
         let availableBalanceString = balanceViewModelFactory.amountFromValue(
             availableBalance.decimal(assetInfo: assetInfo)

--- a/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListViewFactory.swift
+++ b/novawallet/Modules/Vote/Governance/SwipeGov/SwipeGovVotingList/SwipeGovVotingListViewFactory.swift
@@ -4,10 +4,9 @@ import Operation_iOS
 
 struct SwipeGovVotingListViewFactory {
     static func createView(with sharedState: GovernanceSharedState) -> SwipeGovVotingListViewProtocol? {
-        let chain = sharedState.settings.value.chain
-
         guard
-            let assetInfo = chain.utilityAssetDisplayInfo(),
+            let option = sharedState.settings.value,
+            let assetInfo = option.chain.utilityAssetDisplayInfo(),
             let currencyManager = CurrencyManager.shared,
             let interactor = createInteractor(for: sharedState) else {
             return nil
@@ -30,10 +29,11 @@ struct SwipeGovVotingListViewFactory {
         let presenter = SwipeGovVotingListPresenter(
             interactor: interactor,
             wireframe: wireframe,
-            chain: chain,
+            chain: option.chain,
             observableState: sharedState.observableState,
             votingListViewModelFactory: votingListViewModelFactory,
             balanceViewModelFactory: balanceViewModelFactory,
+            govBalanceCalculator: GovernanceBalanceCalculator(governanceType: option.type),
             localizationManager: localizationManager
         )
 
@@ -50,11 +50,12 @@ struct SwipeGovVotingListViewFactory {
 
     private static func createInteractor(for state: GovernanceSharedState) -> SwipeGovVotingListInteractor? {
         guard
-            let metaAccount = SelectedWalletSettings.shared.value else {
+            let metaAccount = SelectedWalletSettings.shared.value,
+            let option = state.settings.value else {
             return nil
         }
 
-        let chain = state.settings.value.chain
+        let chain = option.chain
         let operationManager = OperationManagerFacade.sharedManager
         let logger = Logger.shared
         let operationQueue = OperationManagerFacade.sharedDefaultQueue
@@ -83,6 +84,7 @@ struct SwipeGovVotingListViewFactory {
             votingBasketSubscriptionFactory: votingBasketSubscriptionFactory,
             walletLocalSubscriptionFactory: WalletLocalSubscriptionFactory.shared,
             govMetadataLocalSubscriptionFactory: govMetadataLocalSubscriptionFactory,
+            govBalanceCalculator: GovernanceBalanceCalculator(governanceType: option.type),
             operationQueue: operationQueue
         )
     }

--- a/novawallet/Modules/Vote/Governance/Validating/GovernanceValidatorFactory.swift
+++ b/novawallet/Modules/Vote/Governance/Validating/GovernanceValidatorFactory.swift
@@ -69,13 +69,13 @@ final class GovernanceValidatorFactory {
     let assetBalanceFormatterFactory: AssetBalanceFormatterFactoryProtocol
     let quantityFormatter: LocalizableResource<NumberFormatter>
     let presentable: GovernanceErrorPresentable
-    let govBalanceCalculator: GovernanceBalanceCalculating
+    let govBalanceCalculator: AvailableBalanceMapping
 
     init(
         presentable: GovernanceErrorPresentable,
         assetBalanceFormatterFactory: AssetBalanceFormatterFactoryProtocol,
         quantityFormatter: LocalizableResource<NumberFormatter>,
-        govBalanceCalculator: GovernanceBalanceCalculating
+        govBalanceCalculator: AvailableBalanceMapping
     ) {
         self.presentable = presentable
         self.assetBalanceFormatterFactory = assetBalanceFormatterFactory

--- a/novawallet/Modules/Vote/Governance/Validating/GovernanceValidatorFactory.swift
+++ b/novawallet/Modules/Vote/Governance/Validating/GovernanceValidatorFactory.swift
@@ -69,15 +69,18 @@ final class GovernanceValidatorFactory {
     let assetBalanceFormatterFactory: AssetBalanceFormatterFactoryProtocol
     let quantityFormatter: LocalizableResource<NumberFormatter>
     let presentable: GovernanceErrorPresentable
+    let govBalanceCalculator: GovernanceBalanceCalculating
 
     init(
         presentable: GovernanceErrorPresentable,
         assetBalanceFormatterFactory: AssetBalanceFormatterFactoryProtocol,
-        quantityFormatter: LocalizableResource<NumberFormatter>
+        quantityFormatter: LocalizableResource<NumberFormatter>,
+        govBalanceCalculator: GovernanceBalanceCalculating
     ) {
         self.presentable = presentable
         self.assetBalanceFormatterFactory = assetBalanceFormatterFactory
         self.quantityFormatter = quantityFormatter
+        self.govBalanceCalculator = govBalanceCalculator
     }
 }
 
@@ -90,20 +93,20 @@ extension GovernanceValidatorFactory: GovernanceValidatorFactoryProtocol {
         locale: Locale?
     ) -> DataValidating {
         ErrorConditionViolation(onError: { [weak self] in
-            guard let view = self?.view else {
+            guard let self, let view else {
                 return
             }
 
-            let amountFormatter = self?.assetBalanceFormatterFactory.createTokenFormatter(for: assetInfo)
-            let availableForOpenGov = assetBalance?.availableForOpenGov ?? 0
+            let amountFormatter = assetBalanceFormatterFactory.createTokenFormatter(for: assetInfo)
+            let availableForOpenGov = govBalanceCalculator.availableBalanceElseZero(from: assetBalance)
 
             let amountDecimal = availableForOpenGov.decimal(assetInfo: assetInfo)
-            let amountString = amountFormatter?.value(for: locale ?? Locale.current).stringFromDecimal(
+            let amountString = amountFormatter.value(for: locale ?? Locale.current).stringFromDecimal(
                 amountDecimal
             ) ?? ""
 
             if let maxAmountErrorClosure, availableForOpenGov > 0 {
-                self?.presentable.presentNotEnoughTokensToVote(
+                presentable.presentNotEnoughTokensToVote(
                     from: view,
                     available: amountString,
                     maxAction: {
@@ -112,21 +115,23 @@ extension GovernanceValidatorFactory: GovernanceValidatorFactoryProtocol {
                     locale: locale
                 )
             } else {
-                self?.presentable.presentNotEnoughTokensToVote(
+                presentable.presentNotEnoughTokensToVote(
                     from: view,
                     available: amountString,
                     maxAction: nil,
                     locale: locale
                 )
             }
-        }, preservesCondition: {
+        }, preservesCondition: { [weak self] in
             guard
-                let assetBalance = assetBalance,
+                let availableBalance = self?.govBalanceCalculator.mapAvailableBalance(
+                    from: assetBalance
+                ),
                 let votingAmount = votingAmount else {
                 return false
             }
 
-            return assetBalance.availableForOpenGov >= votingAmount
+            return availableBalance >= votingAmount
         })
     }
 
@@ -136,36 +141,37 @@ extension GovernanceValidatorFactory: GovernanceValidatorFactoryProtocol {
         locale: Locale?
     ) -> DataValidating {
         let availableForFee: BigUInt = if
-            let assetBalance = params.assetBalance,
+            let availableAmount = govBalanceCalculator.mapAvailableBalance(from: params.assetBalance),
+            let transferrableAmont = params.assetBalance?.transferable,
             let votingAmount = params.votingAmount {
-            min(assetBalance.availableForOpenGov.subtractOrZero(votingAmount), assetBalance.transferable)
+            min(availableAmount.subtractOrZero(votingAmount), transferrableAmont)
         } else {
             0
         }
 
         return ErrorConditionViolation(onError: { [weak self] in
-            guard let view = self?.view else {
+            guard let self, let view else {
                 return
             }
 
-            let amountFormatter = self?.assetBalanceFormatterFactory.createTokenFormatter(
+            let amountFormatter = assetBalanceFormatterFactory.createTokenFormatter(
                 for: params.assetInfo
             ).value(for: locale ?? Locale.current)
 
             let feeInPlank = params.fee?.amountForCurrentAccount ?? 0
             let transferableInPlank = params.assetBalance?.transferable ?? 0
-            let availableForOpenGov = params.assetBalance?.availableForOpenGov ?? 0
+            let availableForGov = govBalanceCalculator.availableBalanceElseZero(from: params.assetBalance)
             let availableAfterFee = transferableInPlank >= feeInPlank ?
-                availableForOpenGov.subtractOrZero(feeInPlank) : 0
+                availableForGov.subtractOrZero(feeInPlank) : 0
 
             let amountDecimal = availableAfterFee.decimal(assetInfo: params.assetInfo)
-            let amountString = amountFormatter?.stringFromDecimal(amountDecimal) ?? ""
+            let amountString = amountFormatter.stringFromDecimal(amountDecimal) ?? ""
 
             let feeDecimal = feeInPlank.decimal(assetInfo: params.assetInfo)
-            let feeString = amountFormatter?.stringFromDecimal(feeDecimal) ?? ""
+            let feeString = amountFormatter.stringFromDecimal(feeDecimal) ?? ""
 
             if let maxAmountErrorClosure, availableAfterFee > 0 {
-                self?.presentable.presentUpToForFee(
+                presentable.presentUpToForFee(
                     from: view,
                     available: amountString,
                     fee: feeString,
@@ -175,7 +181,7 @@ extension GovernanceValidatorFactory: GovernanceValidatorFactoryProtocol {
                     locale: locale
                 )
             } else {
-                self?.presentable.presentUpToForFee(
+                presentable.presentUpToForFee(
                     from: view,
                     available: amountString,
                     fee: feeString,
@@ -359,11 +365,15 @@ extension GovernanceValidatorFactory: GovernanceValidatorFactoryProtocol {
 }
 
 extension GovernanceValidatorFactory {
-    static func createFromPresentable(_ presentable: GovernanceErrorPresentable) -> GovernanceValidatorFactory {
+    static func createFromPresentable(
+        _ presentable: GovernanceErrorPresentable,
+        govType: GovernanceType
+    ) -> GovernanceValidatorFactory {
         GovernanceValidatorFactory(
             presentable: presentable,
             assetBalanceFormatterFactory: AssetBalanceFormatterFactory(),
-            quantityFormatter: NumberFormatter.quantity.localizableResource()
+            quantityFormatter: NumberFormatter.quantity.localizableResource(),
+            govBalanceCalculator: GovernanceBalanceCalculator(governanceType: govType)
         )
     }
 }

--- a/novawallet/Modules/Vote/Parent/VoteChildPresenterFactory.swift
+++ b/novawallet/Modules/Vote/Parent/VoteChildPresenterFactory.swift
@@ -218,6 +218,7 @@ extension VoteChildPresenterFactory: VoteChildPresenterFactoryProtocol {
             selectedMetaAccount: wallet,
             accountManagementFilter: AccountManagementFilter(),
             sorting: ReferendumsTimeSortingProvider(),
+            govBalanceCalculatorFactory: GovBalanceCalculatorFactory(),
             localizationManager: localizationManager,
             appearanceFacade: AppearanceFacade.shared,
             logger: logger

--- a/novawalletTests/Mocks/ModuleMocks.swift
+++ b/novawalletTests/Mocks/ModuleMocks.swift
@@ -3865,16 +3865,16 @@ import Operation_iOS
     
     
     
-     func didReceiveBalance(results: [ChainAssetId: Result<BigUInt?, Error>])  {
+     func didReceiveBalance(resultWithChanges: Result<[ChainAssetId: AssetBalance], Error>)  {
         
-    return cuckoo_manager.call("didReceiveBalance(results: [ChainAssetId: Result<BigUInt?, Error>])",
-            parameters: (results),
-            escapingParameters: (results),
+    return cuckoo_manager.call("didReceiveBalance(resultWithChanges: Result<[ChainAssetId: AssetBalance], Error>)",
+            parameters: (resultWithChanges),
+            escapingParameters: (resultWithChanges),
             superclassCall:
                 
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
-            defaultCall: __defaultImplStub!.didReceiveBalance(results: results))
+            defaultCall: __defaultImplStub!.didReceiveBalance(resultWithChanges: resultWithChanges))
         
     }
     
@@ -3922,9 +3922,9 @@ import Operation_iOS
 	        return .init(stub: cuckoo_manager.createStub(for: MockChainAssetSelectionInteractorOutputProtocol.self, method: "didReceiveChainAssets(result: Result<[ChainAsset], Error>)", parameterMatchers: matchers))
 	    }
 	    
-	    func didReceiveBalance<M1: Cuckoo.Matchable>(results: M1) -> Cuckoo.ProtocolStubNoReturnFunction<([ChainAssetId: Result<BigUInt?, Error>])> where M1.MatchedType == [ChainAssetId: Result<BigUInt?, Error>] {
-	        let matchers: [Cuckoo.ParameterMatcher<([ChainAssetId: Result<BigUInt?, Error>])>] = [wrap(matchable: results) { $0 }]
-	        return .init(stub: cuckoo_manager.createStub(for: MockChainAssetSelectionInteractorOutputProtocol.self, method: "didReceiveBalance(results: [ChainAssetId: Result<BigUInt?, Error>])", parameterMatchers: matchers))
+	    func didReceiveBalance<M1: Cuckoo.Matchable>(resultWithChanges: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(Result<[ChainAssetId: AssetBalance], Error>)> where M1.MatchedType == Result<[ChainAssetId: AssetBalance], Error> {
+	        let matchers: [Cuckoo.ParameterMatcher<(Result<[ChainAssetId: AssetBalance], Error>)>] = [wrap(matchable: resultWithChanges) { $0 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockChainAssetSelectionInteractorOutputProtocol.self, method: "didReceiveBalance(resultWithChanges: Result<[ChainAssetId: AssetBalance], Error>)", parameterMatchers: matchers))
 	    }
 	    
 	    func didReceivePrice<M1: Cuckoo.Matchable>(changes: M1) -> Cuckoo.ProtocolStubNoReturnFunction<([ChainAssetId: DataProviderChange<PriceData>])> where M1.MatchedType == [ChainAssetId: DataProviderChange<PriceData>] {
@@ -3960,9 +3960,9 @@ import Operation_iOS
 	    }
 	    
 	    @discardableResult
-	    func didReceiveBalance<M1: Cuckoo.Matchable>(results: M1) -> Cuckoo.__DoNotUse<([ChainAssetId: Result<BigUInt?, Error>]), Void> where M1.MatchedType == [ChainAssetId: Result<BigUInt?, Error>] {
-	        let matchers: [Cuckoo.ParameterMatcher<([ChainAssetId: Result<BigUInt?, Error>])>] = [wrap(matchable: results) { $0 }]
-	        return cuckoo_manager.verify("didReceiveBalance(results: [ChainAssetId: Result<BigUInt?, Error>])", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    func didReceiveBalance<M1: Cuckoo.Matchable>(resultWithChanges: M1) -> Cuckoo.__DoNotUse<(Result<[ChainAssetId: AssetBalance], Error>), Void> where M1.MatchedType == Result<[ChainAssetId: AssetBalance], Error> {
+	        let matchers: [Cuckoo.ParameterMatcher<(Result<[ChainAssetId: AssetBalance], Error>)>] = [wrap(matchable: resultWithChanges) { $0 }]
+	        return cuckoo_manager.verify("didReceiveBalance(resultWithChanges: Result<[ChainAssetId: AssetBalance], Error>)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
 	    }
 	    
 	    @discardableResult
@@ -3994,7 +3994,7 @@ import Operation_iOS
     
     
     
-     func didReceiveBalance(results: [ChainAssetId: Result<BigUInt?, Error>])   {
+     func didReceiveBalance(resultWithChanges: Result<[ChainAssetId: AssetBalance], Error>)   {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     

--- a/novawalletTests/Modules/AssetSelection/AssetSelectionTests.swift
+++ b/novawalletTests/Modules/AssetSelection/AssetSelectionTests.swift
@@ -48,7 +48,6 @@ class AssetSelectionTests: XCTestCase {
 
         let interactor = ChainAssetSelectionInteractor(
             selectedMetaAccount: selectedAccount,
-            balanceSlice: \.transferable,
             repository: repository,
             walletLocalSubscriptionFactory: walletLocalSubscriptionFactory,
             priceLocalSubscriptionFactory: priceProviderFactory,
@@ -68,6 +67,7 @@ class AssetSelectionTests: XCTestCase {
             interactor: interactor,
             wireframe: wireframe,
             selectedChainAssetId: selectedChainAssetId,
+            balanceMapper: AvailableBalanceSliceMapper(balanceSlice: \.transferable),
             assetBalanceFormatterFactory: AssetBalanceFormatterFactory(),
             assetIconViewModelFactory: AssetIconViewModelFactory(),
             localizationManager: LocalizationManager.shared


### PR DESCRIPTION
## Purpose

- introduce `AvailableBalanceMapping` and `GovernanaceBalanceMapper` to incapsulate available balance logic
- inject different available balance logic depending on the governance type
- refresh governance metadata on provider creation on the referendums list - that fixes a bug that metadata not loaded for a new referendum
- Don't display error in the referendums list for the requests happening each block
- Fix shimmering on Your Delegations