### PR TITLE
Fix polimec fee calc

### DIFF
--- a/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Proccessing.swift
+++ b/novawallet/Modules/DApp/DAppOperationConfirm/DAppOperationConfirmInteractor+Proccessing.swift
@@ -63,11 +63,15 @@ extension DAppOperationConfirmInteractor {
                 return nil
             }
 
-            let localAsset = AssetHubTokensConverter.convertToLocalAsset(
-                for: remoteAsset,
-                on: chain,
-                using: codingFactory
-            )
+            let localAsset: ChainAsset? = if chain.hasAssetHubFees {
+                AssetHubTokensConverter.convertToLocalAsset(
+                    for: remoteAsset,
+                    on: chain,
+                    using: codingFactory
+                )
+            } else {
+                nil
+            }
 
             return DAppParsedAsset(remoteAsset: remoteAsset, localAsset: localAsset)
         }


### PR DESCRIPTION
## Purpose

Current implementation could still inject fee token even for cases where fee calculation is custom token is not available. The PR introduce the manual check that fee calculation is available in the given chain and token