### PR TITLE
Ledger upload optimization

### DIFF
--- a/novawallet/Common/Ledger/LedgerTransport.swift
+++ b/novawallet/Common/Ledger/LedgerTransport.swift
@@ -2,7 +2,7 @@ import Foundation
 
 protocol LedgerTransportProtocol {
     func reset()
-    func prepareRequest(from message: Data) -> [Data]
+    func prepareRequest(from message: Data, using mtu: Int) -> [Data]
     func receive(partialResponseData: Data) throws -> Data?
 }
 
@@ -38,12 +38,6 @@ final class LedgerTransport {
     }
 
     private var partialResponse: Response?
-
-    let mtu: Int
-
-    init(mtu: Int = 23) {
-        self.mtu = mtu
-    }
 }
 
 extension LedgerTransport: LedgerTransportProtocol {
@@ -51,7 +45,7 @@ extension LedgerTransport: LedgerTransportProtocol {
         partialResponse = nil
     }
 
-    func prepareRequest(from message: Data) -> [Data] {
+    func prepareRequest(from message: Data, using mtu: Int) -> [Data] {
         let totalLength = message.count
         var offest: Int = 0
         var chunks: [Data] = []

--- a/novawalletTests/Common/Ledger/LedgerTransportTests.swift
+++ b/novawalletTests/Common/Ledger/LedgerTransportTests.swift
@@ -2,18 +2,19 @@ import XCTest
 @testable import novawallet
 
 class LedgerTransportTests: XCTestCase {
+    static let mtu: Int = 153
 
     func testSingleChunk() {
         // given
 
         let transport = LedgerTransport()
-        let messageSize = transport.mtu - 5
+        let messageSize = Self.mtu - 5
         let message = Data.random(of: messageSize)!
 
         do {
             // when
 
-            let chunks = transport.prepareRequest(from: message)
+            let chunks = transport.prepareRequest(from: message, using: Self.mtu)
 
             XCTAssertEqual(chunks.count, 1)
 
@@ -34,14 +35,14 @@ class LedgerTransportTests: XCTestCase {
         // given
 
         let transport = LedgerTransport()
-        let packetSize = transport.mtu - 5
+        let packetSize = Self.mtu - 5
         let packetsCount = 5
         let message = Data.random(of: packetsCount * packetSize)!
 
         do {
             // when
 
-            let chunks = transport.prepareRequest(from: message)
+            let chunks = transport.prepareRequest(from: message, using: Self.mtu)
 
             XCTAssertEqual(chunks.count, packetsCount)
 


### PR DESCRIPTION
## Purpose

Previously the MTU was set to minimal value (23) when sending data to Ledger device. The PR introduces the logic that derives negotiated MTU value that is much higher than minimum one. For example, for iPhone XS negotiated MTU is 156 bytes. That allows faster data transmission to Ledger. The signing time is now approx. 3x faster than previously