### PR TITLE
Fix scheduler crash

### DIFF
--- a/novawallet/Common/Helpers/Scheduler.swift
+++ b/novawallet/Common/Helpers/Scheduler.swift
@@ -48,10 +48,12 @@ final class Scheduler: NSObject, SchedulerProtocol {
         }
 
         clearTimer()
+        
+        let milliseconds = Int(min(Double(Int.max), 1000.0 * seconds))
 
         timer = DispatchSource.makeTimerSource()
         timer?.schedule(
-            deadline: .now() + .milliseconds(Int(1000.0 * seconds)),
+            deadline: .now() + .milliseconds(milliseconds),
             repeating: DispatchTimeInterval.never
         )
         timer?.setEventHandler { [weak self] in


### PR DESCRIPTION
### SUMMARY

The PR adds clamping for milliseconds value, preventing it from overflowing `Int` during conversion from `Double`.