### PR TITLE
Introduce execute call builder

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1072,6 +1072,7 @@
 		0CED71A92D99599500F79C02 /* XcmGenericJunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71A82D99599500F79C02 /* XcmGenericJunction.swift */; };
 		0CED71B12D995CED00F79C02 /* XcmV5ModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71B02D995CED00F79C02 /* XcmV5ModelFactory.swift */; };
 		0CED71B32D995D4300F79C02 /* XcmV5WeightMessagesFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71B22D995D4300F79C02 /* XcmV5WeightMessagesFactory.swift */; };
+		0CED71B72D9C105200F79C02 /* XcmExecuteDerivator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71B62D9C105200F79C02 /* XcmExecuteDerivator.swift */; };
 		0CF193D12A843DA9003F12F6 /* StakingTypeBalanceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF193D02A843DA9003F12F6 /* StakingTypeBalanceFactory.swift */; };
 		0CF193D32A84FC7C003F12F6 /* SelectedStakingViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF193D22A84FC7C003F12F6 /* SelectedStakingViewModelFactory.swift */; };
 		0CF193D52A861926003F12F6 /* PredefinedTimeShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF193D42A861925003F12F6 /* PredefinedTimeShortcut.swift */; };
@@ -6855,6 +6856,7 @@
 		0CED71A82D99599500F79C02 /* XcmGenericJunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmGenericJunction.swift; sourceTree = "<group>"; };
 		0CED71B02D995CED00F79C02 /* XcmV5ModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmV5ModelFactory.swift; sourceTree = "<group>"; };
 		0CED71B22D995D4300F79C02 /* XcmV5WeightMessagesFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmV5WeightMessagesFactory.swift; sourceTree = "<group>"; };
+		0CED71B62D9C105200F79C02 /* XcmExecuteDerivator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmExecuteDerivator.swift; sourceTree = "<group>"; };
 		0CF193D02A843DA9003F12F6 /* StakingTypeBalanceFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StakingTypeBalanceFactory.swift; sourceTree = "<group>"; };
 		0CF193D22A84FC7C003F12F6 /* SelectedStakingViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedStakingViewModelFactory.swift; sourceTree = "<group>"; };
 		0CF193D42A861925003F12F6 /* PredefinedTimeShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredefinedTimeShortcut.swift; sourceTree = "<group>"; };
@@ -22911,6 +22913,7 @@
 				0CFF82362D8CD7BD00DB17A4 /* XcmCrosschainFeeCalculator.swift */,
 				0C1666852D7FEF90005E6CD3 /* XcmModelFactory.swift */,
 				0C16668B2D80055A005E6CD3 /* XcmWeightMessagesFactory.swift */,
+				0CED71B62D9C105200F79C02 /* XcmExecuteDerivator.swift */,
 			);
 			path = Xcm;
 			sourceTree = "<group>";
@@ -27854,6 +27857,7 @@
 				0CCD18C42BA1F03E0068D73A /* ChainModeModel+Remote.swift in Sources */,
 				0CFA16202B0CEF31007AF885 /* GovTreasuryApproveHandler.swift in Sources */,
 				8490141324A92F6D008F705E /* AttributedStringDecorator+Terms.swift in Sources */,
+				0CED71B72D9C105200F79C02 /* XcmExecuteDerivator.swift in Sources */,
 				849976CA27B2F9E000B14A6C /* DAppMetamaskAuthorizingState.swift in Sources */,
 				F484FF5F264BA2720015320F /* ControllerAccountConfirmationLayout.swift in Sources */,
 				841494402604E71C000D8D1A /* TotalRewardItem.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1073,6 +1073,8 @@
 		0CED71B12D995CED00F79C02 /* XcmV5ModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71B02D995CED00F79C02 /* XcmV5ModelFactory.swift */; };
 		0CED71B32D995D4300F79C02 /* XcmV5WeightMessagesFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71B22D995D4300F79C02 /* XcmV5WeightMessagesFactory.swift */; };
 		0CED71B72D9C105200F79C02 /* XcmExecuteDerivator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71B62D9C105200F79C02 /* XcmExecuteDerivator.swift */; };
+		0CED71BA2D9D253B00F79C02 /* XcmPaymentOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71B92D9D253B00F79C02 /* XcmPaymentOperationFactory.swift */; };
+		0CED71BC2D9D25A200F79C02 /* XcmPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71BB2D9D25A200F79C02 /* XcmPayment.swift */; };
 		0CF193D12A843DA9003F12F6 /* StakingTypeBalanceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF193D02A843DA9003F12F6 /* StakingTypeBalanceFactory.swift */; };
 		0CF193D32A84FC7C003F12F6 /* SelectedStakingViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF193D22A84FC7C003F12F6 /* SelectedStakingViewModelFactory.swift */; };
 		0CF193D52A861926003F12F6 /* PredefinedTimeShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF193D42A861925003F12F6 /* PredefinedTimeShortcut.swift */; };
@@ -6857,6 +6859,8 @@
 		0CED71B02D995CED00F79C02 /* XcmV5ModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmV5ModelFactory.swift; sourceTree = "<group>"; };
 		0CED71B22D995D4300F79C02 /* XcmV5WeightMessagesFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmV5WeightMessagesFactory.swift; sourceTree = "<group>"; };
 		0CED71B62D9C105200F79C02 /* XcmExecuteDerivator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmExecuteDerivator.swift; sourceTree = "<group>"; };
+		0CED71B92D9D253B00F79C02 /* XcmPaymentOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmPaymentOperationFactory.swift; sourceTree = "<group>"; };
+		0CED71BB2D9D25A200F79C02 /* XcmPayment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmPayment.swift; sourceTree = "<group>"; };
 		0CF193D02A843DA9003F12F6 /* StakingTypeBalanceFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StakingTypeBalanceFactory.swift; sourceTree = "<group>"; };
 		0CF193D22A84FC7C003F12F6 /* SelectedStakingViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedStakingViewModelFactory.swift; sourceTree = "<group>"; };
 		0CF193D42A861925003F12F6 /* PredefinedTimeShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredefinedTimeShortcut.swift; sourceTree = "<group>"; };
@@ -13787,6 +13791,7 @@
 		0CCE3AAD2BF5BBBF00D55F03 /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				0CED71B82D9D252500F79C02 /* XcmPaymentApi */,
 				0C277DA92D82E61D004FF053 /* DryRun */,
 				0CE862272D659AF000245992 /* Identity */,
 				0CE862262D659AE400245992 /* StateCall */,
@@ -14064,6 +14069,15 @@
 				0CED71B22D995D4300F79C02 /* XcmV5WeightMessagesFactory.swift */,
 			);
 			path = V5;
+			sourceTree = "<group>";
+		};
+		0CED71B82D9D252500F79C02 /* XcmPaymentApi */ = {
+			isa = PBXGroup;
+			children = (
+				0CED71B92D9D253B00F79C02 /* XcmPaymentOperationFactory.swift */,
+				0CED71BB2D9D25A200F79C02 /* XcmPayment.swift */,
+			);
+			path = XcmPaymentApi;
 			sourceTree = "<group>";
 		};
 		0CF3A6C72CE9422400F93C49 /* View */ = {
@@ -28536,6 +28550,7 @@
 				844DBC60274D1B3E009F8351 /* IconWithTitleSubtitleViewModel.swift in Sources */,
 				0CA5BDFB2C455790000A4CDD /* NominationPoolStakingMigrating.swift in Sources */,
 				2DAF6AC12CF4D52C00A8D132 /* DAppBrowserTabManager+Singleton.swift in Sources */,
+				0CED71BA2D9D253B00F79C02 /* XcmPaymentOperationFactory.swift in Sources */,
 				77A0B2F32A3CA37E00CBF653 /* StakingMoreOptionsViewModelFactory.swift in Sources */,
 				849014B924AA87E3008F705E /* PinSetupViewController.swift in Sources */,
 				84F98D8A25E3DD3F0040418E /* StorageCodingPath.swift in Sources */,
@@ -30316,6 +30331,7 @@
 				8434B608298D4FD500FACF4C /* GovernanceAddDelegationTracksWireframe.swift in Sources */,
 				8886020B29D101B000C6344C /* Web3NameServiceError.swift in Sources */,
 				84EBAB06265DC24C0015E446 /* CrowdloanContributionViewModelFactory.swift in Sources */,
+				0CED71BC2D9D25A200F79C02 /* XcmPayment.swift in Sources */,
 				84CA68DF26BEAA0F003B9453 /* ChainModelMapper.swift in Sources */,
 				846A682C274693F700D1A47A /* CrowdloanExternalContributionSource.swift in Sources */,
 				0C38B50C2B7DC40600882A8B /* KodaDotNft.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1076,6 +1076,7 @@
 		0CED71BA2D9D253B00F79C02 /* XcmPaymentOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71B92D9D253B00F79C02 /* XcmPaymentOperationFactory.swift */; };
 		0CED71BC2D9D25A200F79C02 /* XcmPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71BB2D9D25A200F79C02 /* XcmPayment.swift */; };
 		0CED71BE2D9D2DE600F79C02 /* XcmExecuteFeeCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71BD2D9D2DE600F79C02 /* XcmExecuteFeeCalculatorTests.swift */; };
+		0CED71C02D9D8B0600F79C02 /* SubstrateRuntimeApiOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71BF2D9D8B0600F79C02 /* SubstrateRuntimeApiOperationFactory.swift */; };
 		0CF193D12A843DA9003F12F6 /* StakingTypeBalanceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF193D02A843DA9003F12F6 /* StakingTypeBalanceFactory.swift */; };
 		0CF193D32A84FC7C003F12F6 /* SelectedStakingViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF193D22A84FC7C003F12F6 /* SelectedStakingViewModelFactory.swift */; };
 		0CF193D52A861926003F12F6 /* PredefinedTimeShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF193D42A861925003F12F6 /* PredefinedTimeShortcut.swift */; };
@@ -6863,6 +6864,7 @@
 		0CED71B92D9D253B00F79C02 /* XcmPaymentOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmPaymentOperationFactory.swift; sourceTree = "<group>"; };
 		0CED71BB2D9D25A200F79C02 /* XcmPayment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmPayment.swift; sourceTree = "<group>"; };
 		0CED71BD2D9D2DE600F79C02 /* XcmExecuteFeeCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmExecuteFeeCalculatorTests.swift; sourceTree = "<group>"; };
+		0CED71BF2D9D8B0600F79C02 /* SubstrateRuntimeApiOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubstrateRuntimeApiOperationFactory.swift; sourceTree = "<group>"; };
 		0CF193D02A843DA9003F12F6 /* StakingTypeBalanceFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StakingTypeBalanceFactory.swift; sourceTree = "<group>"; };
 		0CF193D22A84FC7C003F12F6 /* SelectedStakingViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedStakingViewModelFactory.swift; sourceTree = "<group>"; };
 		0CF193D42A861925003F12F6 /* PredefinedTimeShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredefinedTimeShortcut.swift; sourceTree = "<group>"; };
@@ -13961,6 +13963,7 @@
 				0C37AFC22B5796DD00009ECA /* StateCallRequestFactory.swift */,
 				0CE862242D659AB700245992 /* StateCallPath.swift */,
 				0CE862282D659B4100245992 /* StateCallRequestFactory+Additional.swift */,
+				0CED71BF2D9D8B0600F79C02 /* SubstrateRuntimeApiOperationFactory.swift */,
 			);
 			path = StateCall;
 			sourceTree = "<group>";
@@ -29476,6 +29479,7 @@
 				88C5F080297F06F0001CCADE /* Array+safe.swift in Sources */,
 				840302E0292CE4030013F356 /* CodingFactory+TypeCheck.swift in Sources */,
 				845B891E2959611C00EE25B0 /* SecurityLayerInteractor.swift in Sources */,
+				0CED71C02D9D8B0600F79C02 /* SubstrateRuntimeApiOperationFactory.swift in Sources */,
 				0C17BD972A42F162004AF9E7 /* WalletViewModelObserverContainer.swift in Sources */,
 				AEE5FB1626457AA9002B8FDC /* StakingRewardDestSetupPresenter.swift in Sources */,
 				88D42CF42977AA9600DDE01E /* ReferendumsDelegationViewModel.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1075,6 +1075,7 @@
 		0CED71B72D9C105200F79C02 /* XcmExecuteDerivator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71B62D9C105200F79C02 /* XcmExecuteDerivator.swift */; };
 		0CED71BA2D9D253B00F79C02 /* XcmPaymentOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71B92D9D253B00F79C02 /* XcmPaymentOperationFactory.swift */; };
 		0CED71BC2D9D25A200F79C02 /* XcmPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71BB2D9D25A200F79C02 /* XcmPayment.swift */; };
+		0CED71BE2D9D2DE600F79C02 /* XcmExecuteFeeCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED71BD2D9D2DE600F79C02 /* XcmExecuteFeeCalculatorTests.swift */; };
 		0CF193D12A843DA9003F12F6 /* StakingTypeBalanceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF193D02A843DA9003F12F6 /* StakingTypeBalanceFactory.swift */; };
 		0CF193D32A84FC7C003F12F6 /* SelectedStakingViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF193D22A84FC7C003F12F6 /* SelectedStakingViewModelFactory.swift */; };
 		0CF193D52A861926003F12F6 /* PredefinedTimeShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF193D42A861925003F12F6 /* PredefinedTimeShortcut.swift */; };
@@ -6861,6 +6862,7 @@
 		0CED71B62D9C105200F79C02 /* XcmExecuteDerivator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmExecuteDerivator.swift; sourceTree = "<group>"; };
 		0CED71B92D9D253B00F79C02 /* XcmPaymentOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmPaymentOperationFactory.swift; sourceTree = "<group>"; };
 		0CED71BB2D9D25A200F79C02 /* XcmPayment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmPayment.swift; sourceTree = "<group>"; };
+		0CED71BD2D9D2DE600F79C02 /* XcmExecuteFeeCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmExecuteFeeCalculatorTests.swift; sourceTree = "<group>"; };
 		0CF193D02A843DA9003F12F6 /* StakingTypeBalanceFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StakingTypeBalanceFactory.swift; sourceTree = "<group>"; };
 		0CF193D22A84FC7C003F12F6 /* SelectedStakingViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedStakingViewModelFactory.swift; sourceTree = "<group>"; };
 		0CF193D42A861925003F12F6 /* PredefinedTimeShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredefinedTimeShortcut.swift; sourceTree = "<group>"; };
@@ -13408,6 +13410,7 @@
 				844133BC2860532C00845987 /* XcmTransfersSync+Setup.swift */,
 				84264EE0285B6C6700BF6D4A /* XcmTransfersSyncTests.swift */,
 				844133BA2860528500845987 /* XcmTransfersFeeTests.swift */,
+				0CED71BD2D9D2DE600F79C02 /* XcmExecuteFeeCalculatorTests.swift */,
 			);
 			path = XcmTransfers;
 			sourceTree = "<group>";
@@ -27708,6 +27711,7 @@
 				0C8FDBA92CAE539900775D7F /* SwipeGovSummaryTests.swift in Sources */,
 				84C3420F2831A67200156569 /* BlockTimeEstimationServiceTests.swift in Sources */,
 				0CA7197B2B773172000B086E /* HydraStableswapTests.swift in Sources */,
+				0CED71BE2D9D2DE600F79C02 /* XcmExecuteFeeCalculatorTests.swift in Sources */,
 				84FACB6A25F5759C00F32ED4 /* AccountCreationHelper.swift in Sources */,
 				77DC54872B1FF31800C7E45A /* UserDataStorageTestFacade.swift in Sources */,
 				843E9B3827C8CAC1009C143A /* NftDownloadIntegrationTests.swift in Sources */,

--- a/novawallet/Common/Model/BlockWeights.swift
+++ b/novawallet/Common/Model/BlockWeights.swift
@@ -12,6 +12,10 @@ enum BlockchainWeight {
     struct WeightV2: Codable {
         @StringCodable var refTime: BigUInt
         @StringCodable var proofSize: UInt64
+
+        static var zero: Self {
+            .init(refTime: 0, proofSize: 0)
+        }
     }
 
     @propertyWrapper

--- a/novawallet/Common/Model/SubstrateAlias.swift
+++ b/novawallet/Common/Model/SubstrateAlias.swift
@@ -111,6 +111,15 @@ extension Optional where Wrapped == ParaId {
             return paraId.isSystemParachain
         }
     }
+
+    var isRelayOrSystemParachain: Bool {
+        switch self {
+        case .none:
+            return true
+        case let .some(paraId):
+            return paraId.isSystemParachain
+        }
+    }
 }
 
 extension ParaId {

--- a/novawallet/Common/Model/Xcm/XcmTransfers.swift
+++ b/novawallet/Common/Model/Xcm/XcmTransfers.swift
@@ -225,7 +225,7 @@ private extension XcmTransfers {
                 path: reservePath
             ),
             fee: .dynamic,
-            paysDeliveryFee: transfer.hasDeliveryFee ?? false
+            paysDeliveryFee: false
         )
     }
 }

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmCrosschainFeeCalculator.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmCrosschainFeeCalculator.swift
@@ -7,6 +7,7 @@ final class XcmCrosschainFeeCalculator {
 
     init(
         chainRegistry: ChainRegistryProtocol,
+        callDerivator: XcmCallDerivating,
         operationQueue: OperationQueue,
         wallet: MetaAccountModel,
         userStorageFacade: StorageFacadeProtocol,
@@ -25,6 +26,7 @@ final class XcmCrosschainFeeCalculator {
 
         dynamicCalculator = XcmDynamicCrosschainFeeCalculator(
             chainRegistry: chainRegistry,
+            callDerivator: callDerivator,
             operationQueue: operationQueue,
             logger: logger
         )

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmDynamicCrosschainFeeCalculator.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmDynamicCrosschainFeeCalculator.swift
@@ -56,17 +56,17 @@ final class XcmDynamicCrosschainFeeCalculator {
 
     init(
         chainRegistry: ChainRegistryProtocol,
+        callDerivator: XcmCallDerivating,
         operationQueue: OperationQueue,
         logger: LoggerProtocol
     ) {
         self.chainRegistry = chainRegistry
+        self.callDerivator = callDerivator
 
         dryRunOperationFactory = DryRunOperationFactory(
             chainRegistry: chainRegistry,
             operationQueue: operationQueue
         )
-
-        callDerivator = XcmCallDerivator(chainRegistry: chainRegistry)
 
         palletMetadataQueryFactory = XcmPalletMetadataQueryFactory()
         tokenMintingFactory = TokenBalanceMintingFactory(

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmExecuteDerivator.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmExecuteDerivator.swift
@@ -1,0 +1,322 @@
+import Foundation
+import Operation_iOS
+
+final class XcmExecuteDerivator {
+    enum TransferType {
+        case teleport
+        case localReserve
+        case destinationReserve
+        case remoteReserve(XcmV4.AbsoluteLocation)
+    }
+
+    let chainRegistry: ChainRegistryProtocol
+
+    init(chainRegistry: ChainRegistryProtocol) {
+        self.chainRegistry = chainRegistry
+    }
+}
+
+extension XcmExecuteDerivator {
+    func isTeleport(request: XcmUnweightedTransferRequest) -> Bool {
+        request.origin.parachainId.isRelayOrSystemParachain &&
+            request.destination.parachainId.isRelayOrSystemParachain &&
+            request.origin.chainAsset.isUtilityAsset
+    }
+
+    func determineTransferType(
+        for request: XcmUnweightedTransferRequest
+    ) -> TransferType {
+        if isTeleport(request: request) {
+            return .teleport
+        } else if request.origin.chainAsset.chainAssetId.chainId == request.reserve.chain.chainId {
+            return .localReserve
+        } else if request.destination.chain.chainId == request.reserve.chain.chainId {
+            return .destinationReserve
+        } else {
+            return .remoteReserve(XcmV4.AbsoluteLocation(paraId: request.reserve.parachainId))
+        }
+    }
+
+    func localReserveTransferProgram(
+        for transferRequest: XcmUnweightedTransferRequest
+    ) throws -> [XcmV4.Instruction] {
+        let originAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.origin.parachainId)
+        let destAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.destination.parachainId)
+
+        let assetLocation = try XcmV4.AbsoluteLocation.createWithRawPath(
+            transferRequest.metadata.reserve.path.path
+        )
+
+        let originAsset = XcmV4.Multiasset(
+            assetId: assetLocation.fromPointOfView(location: originAbsoluteLocation),
+            amount: transferRequest.amount
+        )
+
+        let destAsset = XcmV4.Multiasset(
+            assetId: assetLocation.fromPointOfView(location: destAbsoluteLocation),
+            amount: transferRequest.amount
+        )
+
+        let destinationLocation = destAbsoluteLocation.fromPointOfView(location: originAbsoluteLocation)
+        let beneficiary = destAbsoluteLocation.appendingAccountId(
+            transferRequest.destination.accountId,
+            isEthereumBase: transferRequest.destination.chain.isEthereumBased
+        ).fromPointOfView(location: destAbsoluteLocation)
+
+        return [
+            XcmV4.Instruction.withdrawAsset([
+                originAsset
+            ]),
+            XcmV4.Instruction.buyExecution(
+                XcmV4.BuyExecutionValue(
+                    fees: originAsset,
+                    weightLimit: .limited(weight: .init(refTime: 0, proofSize: 0))
+                )
+            ),
+            XcmV4.Instruction.depositReserveAsset(
+                XcmV4.DepositReserveAssetValue(
+                    assets: XcmV4.AssetFilter.wild(.all),
+                    dest: destinationLocation,
+                    xcm: [
+                        XcmV4.Instruction.buyExecution(
+                            XcmV4.BuyExecutionValue(
+                                fees: destAsset,
+                                weightLimit: .unlimited
+                            )
+                        ),
+                        XcmV4.Instruction.depositAsset(
+                            XcmV4.DepositAssetValue(
+                                assets: .wild(.all),
+                                beneficiary: beneficiary
+                            )
+                        )
+                    ]
+                )
+            )
+        ]
+    }
+
+    func destinationReserveTransferProgram(
+        for transferRequest: XcmUnweightedTransferRequest
+    ) throws -> [XcmV4.Instruction] {
+        let originAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.origin.parachainId)
+        let destAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.destination.parachainId)
+
+        let assetLocation = try XcmV4.AbsoluteLocation.createWithRawPath(
+            transferRequest.metadata.reserve.path.path
+        )
+
+        let originAsset = XcmV4.Multiasset(
+            assetId: assetLocation.fromPointOfView(location: originAbsoluteLocation),
+            amount: transferRequest.amount
+        )
+
+        let destAsset = XcmV4.Multiasset(
+            assetId: assetLocation.fromPointOfView(location: destAbsoluteLocation),
+            amount: transferRequest.amount
+        )
+
+        let beneficiary = destAbsoluteLocation.appendingAccountId(
+            transferRequest.destination.accountId,
+            isEthereumBase: transferRequest.destination.chain.isEthereumBased
+        ).fromPointOfView(location: destAbsoluteLocation)
+
+        return [
+            XcmV4.Instruction.withdrawAsset([originAsset]),
+            XcmV4.Instruction.buyExecution(
+                XcmV4.BuyExecutionValue(
+                    fees: originAsset,
+                    weightLimit: .limited(weight: .init(refTime: 0, proofSize: 0))
+                )
+            ),
+            XcmV4.Instruction.initiateReserveWithdraw(
+                XcmV4.InitiateReserveWithdrawValue(
+                    assets: .wild(.all),
+                    reserve: destAbsoluteLocation.fromPointOfView(location: originAbsoluteLocation),
+                    xcm: [
+                        XcmV4.Instruction.buyExecution(
+                            XcmV4.BuyExecutionValue(
+                                fees: destAsset,
+                                weightLimit: .unlimited
+                            )
+                        ),
+                        XcmV4.Instruction.depositAsset(
+                            XcmV4.DepositAssetValue(
+                                assets: .wild(.all),
+                                beneficiary: beneficiary
+                            )
+                        )
+                    ]
+                )
+            )
+        ]
+    }
+
+    func remoteReserveTransferProgram(
+        for transferRequest: XcmUnweightedTransferRequest
+    ) throws -> [XcmV4.Instruction] {
+        let originAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.origin.parachainId)
+        let destAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.destination.parachainId)
+        let reserveAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.destination.parachainId)
+
+        let assetLocation = try XcmV4.AbsoluteLocation.createWithRawPath(
+            transferRequest.metadata.reserve.path.path
+        )
+
+        let originAsset = XcmV4.Multiasset(
+            assetId: assetLocation.fromPointOfView(location: originAbsoluteLocation),
+            amount: transferRequest.amount
+        )
+
+        let reserveAsset = XcmV4.Multiasset(
+            assetId: assetLocation.fromPointOfView(location: reserveAbsoluteLocation),
+            amount: transferRequest.amount
+        )
+
+        let destAsset = XcmV4.Multiasset(
+            assetId: assetLocation.fromPointOfView(location: destAbsoluteLocation),
+            amount: transferRequest.amount
+        )
+
+        let beneficiary = destAbsoluteLocation.appendingAccountId(
+            transferRequest.destination.accountId,
+            isEthereumBase: transferRequest.destination.chain.isEthereumBased
+        ).fromPointOfView(location: destAbsoluteLocation)
+
+        return [
+            XcmV4.Instruction.withdrawAsset([originAsset]),
+            XcmV4.Instruction.buyExecution(
+                XcmV4.BuyExecutionValue(
+                    fees: originAsset,
+                    weightLimit: .limited(weight: .init(refTime: 0, proofSize: 0))
+                )
+            ),
+            XcmV4.Instruction.initiateReserveWithdraw(
+                XcmV4.InitiateReserveWithdrawValue(
+                    assets: .wild(.all),
+                    reserve: reserveAbsoluteLocation.fromPointOfView(location: originAbsoluteLocation),
+                    xcm: [
+                        XcmV4.Instruction.buyExecution(
+                            XcmV4.BuyExecutionValue(
+                                fees: reserveAsset,
+                                weightLimit: .unlimited
+                            )
+                        ),
+                        XcmV4.Instruction.depositReserveAsset(
+                            XcmV4.DepositReserveAssetValue(
+                                assets: XcmV4.AssetFilter.wild(.all),
+                                dest: destAbsoluteLocation.fromPointOfView(location: reserveAbsoluteLocation),
+                                xcm: [
+                                    XcmV4.Instruction.buyExecution(
+                                        XcmV4.BuyExecutionValue(
+                                            fees: destAsset,
+                                            weightLimit: .unlimited
+                                        )
+                                    ),
+                                    XcmV4.Instruction.depositAsset(
+                                        XcmV4.DepositAssetValue(
+                                            assets: .wild(.all),
+                                            beneficiary: beneficiary
+                                        )
+                                    )
+                                ]
+                            )
+                        )
+                    ]
+                )
+            )
+        ]
+    }
+
+    func teleportTransferProgram(
+        for transferRequest: XcmUnweightedTransferRequest
+    ) throws -> [XcmV4.Instruction] {
+        let originAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.origin.parachainId)
+        let destAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.destination.parachainId)
+
+        let assetLocation = try XcmV4.AbsoluteLocation.createWithRawPath(
+            transferRequest.metadata.reserve.path.path
+        )
+
+        let originAsset = XcmV4.Multiasset(
+            assetId: assetLocation.fromPointOfView(location: originAbsoluteLocation),
+            amount: transferRequest.amount
+        )
+
+        let destAsset = XcmV4.Multiasset(
+            assetId: assetLocation.fromPointOfView(location: destAbsoluteLocation),
+            amount: transferRequest.amount
+        )
+
+        let beneficiary = destAbsoluteLocation.appendingAccountId(
+            transferRequest.destination.accountId,
+            isEthereumBase: transferRequest.destination.chain.isEthereumBased
+        ).fromPointOfView(location: destAbsoluteLocation)
+
+        return [
+            XcmV4.Instruction.withdrawAsset([originAsset]),
+            XcmV4.Instruction.buyExecution(
+                XcmV4.BuyExecutionValue(
+                    fees: originAsset,
+                    weightLimit: .limited(weight: .init(refTime: 0, proofSize: 0))
+                )
+            ),
+            XcmV4.Instruction.initiateTeleport(
+                XcmV4.InitiateTeleportValue(
+                    assets: .wild(.all),
+                    dest: destAbsoluteLocation.fromPointOfView(location: originAbsoluteLocation),
+                    xcm: [
+                        XcmV4.Instruction.buyExecution(
+                            XcmV4.BuyExecutionValue(
+                                fees: destAsset,
+                                weightLimit: .unlimited
+                            )
+                        ),
+                        XcmV4.Instruction.depositAsset(
+                            XcmV4.DepositAssetValue(
+                                assets: .wild(.all),
+                                beneficiary: beneficiary
+                            )
+                        )
+                    ]
+                )
+            )
+        ]
+    }
+}
+
+extension XcmExecuteDerivator: XcmCallDerivating {
+    func createTransferCallDerivationWrapper(
+        for transferRequest: XcmUnweightedTransferRequest
+    ) -> CompoundOperationWrapper<RuntimeCallCollecting> {
+        do {
+            let transferType = determineTransferType(for: transferRequest)
+
+            let program: [XcmV4.Instruction] = switch transferType {
+            case .localReserve:
+                try localReserveTransferProgram(for: transferRequest)
+            case .destinationReserve:
+                try destinationReserveTransferProgram(for: transferRequest)
+            case .remoteReserve:
+                try remoteReserveTransferProgram(for: transferRequest)
+            case .teleport:
+                try teleportTransferProgram(for: transferRequest)
+            }
+
+            let message = Xcm.Message.V4(program)
+
+            let call = Xcm.ExecuteCall<BlockchainWeight.WeightV2>(
+                message: message,
+                maxWeight: .init(refTime: 0, proofSize: 0)
+            )
+
+            let collector = RuntimeCallCollector(
+                call: call.runtimeCall(for: "PalletXcm")
+            )
+
+            return .createWithResult(collector)
+        } catch {
+            return .createWithError(error)
+        }
+    }
+}

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmExecuteDerivator.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmExecuteDerivator.swift
@@ -29,13 +29,13 @@ final class XcmExecuteDerivator {
     }
 }
 
-extension XcmExecuteDerivator {
+private extension XcmExecuteDerivator {
     func half(asset: XcmV4.Multiasset) -> XcmV4.Multiasset {
         switch asset.fun {
         case let .fungible(amount):
-            return XcmV4.Multiasset(assetId: asset.assetId, amount: amount / 2)
+            XcmV4.Multiasset(assetId: asset.assetId, amount: amount / 2)
         case .nonFungible:
-            return asset
+            asset
         }
     }
 
@@ -49,13 +49,13 @@ extension XcmExecuteDerivator {
         for request: XcmUnweightedTransferRequest
     ) -> TransferType {
         if isTeleport(request: request) {
-            return .teleport
+            .teleport
         } else if request.origin.chainAsset.chainAssetId.chainId == request.reserve.chain.chainId {
-            return .localReserve
+            .localReserve
         } else if request.destination.chain.chainId == request.reserve.chain.chainId {
-            return .destinationReserve
+            .destinationReserve
         } else {
-            return .remoteReserve(XcmV4.AbsoluteLocation(paraId: request.reserve.parachainId))
+            .remoteReserve(XcmV4.AbsoluteLocation(paraId: request.reserve.parachainId))
         }
     }
 

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmExecuteDerivator.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmExecuteDerivator.swift
@@ -30,6 +30,15 @@ final class XcmExecuteDerivator {
 }
 
 extension XcmExecuteDerivator {
+    func half(asset: XcmV4.Multiasset) -> XcmV4.Multiasset {
+        switch asset.fun {
+        case let .fungible(amount):
+            return XcmV4.Multiasset(assetId: asset.assetId, amount: amount / 2)
+        case .nonFungible:
+            return asset
+        }
+    }
+
     func isTeleport(request: XcmUnweightedTransferRequest) -> Bool {
         request.origin.parachainId.isRelayOrSystemParachain &&
             request.destination.parachainId.isRelayOrSystemParachain &&
@@ -82,24 +91,24 @@ extension XcmExecuteDerivator {
             ]),
             XcmV4.Instruction.buyExecution(
                 XcmV4.BuyExecutionValue(
-                    fees: originAsset,
-                    weightLimit: .limited(weight: .init(refTime: 0, proofSize: 0))
+                    fees: half(asset: originAsset),
+                    weightLimit: .limited(weight: .zero)
                 )
             ),
             XcmV4.Instruction.depositReserveAsset(
                 XcmV4.DepositReserveAssetValue(
-                    assets: XcmV4.AssetFilter.wild(.all),
+                    assets: .wild(.allCounted(1)),
                     dest: destinationLocation,
                     xcm: [
                         XcmV4.Instruction.buyExecution(
                             XcmV4.BuyExecutionValue(
-                                fees: destAsset,
+                                fees: half(asset: destAsset),
                                 weightLimit: .unlimited
                             )
                         ),
                         XcmV4.Instruction.depositAsset(
                             XcmV4.DepositAssetValue(
-                                assets: .wild(.all),
+                                assets: .wild(.allCounted(1)),
                                 beneficiary: beneficiary
                             )
                         )
@@ -138,24 +147,24 @@ extension XcmExecuteDerivator {
             XcmV4.Instruction.withdrawAsset([originAsset]),
             XcmV4.Instruction.buyExecution(
                 XcmV4.BuyExecutionValue(
-                    fees: originAsset,
-                    weightLimit: .limited(weight: .init(refTime: 0, proofSize: 0))
+                    fees: half(asset: originAsset),
+                    weightLimit: .limited(weight: .zero)
                 )
             ),
             XcmV4.Instruction.initiateReserveWithdraw(
                 XcmV4.InitiateReserveWithdrawValue(
-                    assets: .wild(.all),
+                    assets: .wild(.allCounted(1)),
                     reserve: destAbsoluteLocation.fromPointOfView(location: originAbsoluteLocation),
                     xcm: [
                         XcmV4.Instruction.buyExecution(
                             XcmV4.BuyExecutionValue(
-                                fees: destAsset,
+                                fees: half(asset: destAsset),
                                 weightLimit: .unlimited
                             )
                         ),
                         XcmV4.Instruction.depositAsset(
                             XcmV4.DepositAssetValue(
-                                assets: .wild(.all),
+                                assets: .wild(.allCounted(1)),
                                 beneficiary: beneficiary
                             )
                         )
@@ -170,7 +179,7 @@ extension XcmExecuteDerivator {
     ) throws -> [XcmV4.Instruction] {
         let originAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.origin.parachainId)
         let destAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.destination.parachainId)
-        let reserveAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.destination.parachainId)
+        let reserveAbsoluteLocation = XcmV4.AbsoluteLocation(paraId: transferRequest.reserve.parachainId)
 
         let assetLocation = try XcmV4.AbsoluteLocation.createWithRawPath(
             transferRequest.metadata.reserve.path.path
@@ -200,35 +209,35 @@ extension XcmExecuteDerivator {
             XcmV4.Instruction.withdrawAsset([originAsset]),
             XcmV4.Instruction.buyExecution(
                 XcmV4.BuyExecutionValue(
-                    fees: originAsset,
-                    weightLimit: .limited(weight: .init(refTime: 0, proofSize: 0))
+                    fees: half(asset: originAsset),
+                    weightLimit: .limited(weight: .zero)
                 )
             ),
             XcmV4.Instruction.initiateReserveWithdraw(
                 XcmV4.InitiateReserveWithdrawValue(
-                    assets: .wild(.all),
+                    assets: .wild(.allCounted(1)),
                     reserve: reserveAbsoluteLocation.fromPointOfView(location: originAbsoluteLocation),
                     xcm: [
                         XcmV4.Instruction.buyExecution(
                             XcmV4.BuyExecutionValue(
-                                fees: reserveAsset,
+                                fees: half(asset: reserveAsset),
                                 weightLimit: .unlimited
                             )
                         ),
                         XcmV4.Instruction.depositReserveAsset(
                             XcmV4.DepositReserveAssetValue(
-                                assets: XcmV4.AssetFilter.wild(.all),
+                                assets: .wild(.allCounted(1)),
                                 dest: destAbsoluteLocation.fromPointOfView(location: reserveAbsoluteLocation),
                                 xcm: [
                                     XcmV4.Instruction.buyExecution(
                                         XcmV4.BuyExecutionValue(
-                                            fees: destAsset,
+                                            fees: half(asset: destAsset),
                                             weightLimit: .unlimited
                                         )
                                     ),
                                     XcmV4.Instruction.depositAsset(
                                         XcmV4.DepositAssetValue(
-                                            assets: .wild(.all),
+                                            assets: .wild(.allCounted(1)),
                                             beneficiary: beneficiary
                                         )
                                     )
@@ -270,7 +279,7 @@ extension XcmExecuteDerivator {
             XcmV4.Instruction.withdrawAsset([originAsset]),
             XcmV4.Instruction.buyExecution(
                 XcmV4.BuyExecutionValue(
-                    fees: originAsset,
+                    fees: half(asset: originAsset),
                     weightLimit: .limited(weight: .init(refTime: 0, proofSize: 0))
                 )
             ),
@@ -281,7 +290,7 @@ extension XcmExecuteDerivator {
                     xcm: [
                         XcmV4.Instruction.buyExecution(
                             XcmV4.BuyExecutionValue(
-                                fees: destAsset,
+                                fees: half(asset: destAsset),
                                 weightLimit: .unlimited
                             )
                         ),

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransferService.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransferService.swift
@@ -30,7 +30,15 @@ final class XcmTransferService {
         self.operationQueue = operationQueue
         self.customFeeEstimatingFactory = customFeeEstimatingFactory
 
-        callDerivator = XcmCallDerivator(chainRegistry: chainRegistry)
+        callDerivator = XcmExecuteDerivator(
+            chainRegistry: chainRegistry,
+            xcmPaymentFactory: XcmPaymentOperationFactory(
+                chainRegistry: chainRegistry,
+                operationQueue: operationQueue
+            ),
+            metadataFactory: XcmPalletMetadataQueryFactory()
+        )
+
         crosschainFeeCalculator = XcmCrosschainFeeCalculator(
             chainRegistry: chainRegistry,
             callDerivator: callDerivator,

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransferService.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransferService.swift
@@ -33,6 +33,7 @@ final class XcmTransferService {
         callDerivator = XcmCallDerivator(chainRegistry: chainRegistry)
         crosschainFeeCalculator = XcmCrosschainFeeCalculator(
             chainRegistry: chainRegistry,
+            callDerivator: callDerivator,
             operationQueue: operationQueue,
             wallet: wallet,
             userStorageFacade: userStorageFacade,

--- a/novawallet/Common/Substrate/AssetOperations/AssetFungibilityPreservationProvider.swift
+++ b/novawallet/Common/Substrate/AssetOperations/AssetFungibilityPreservationProvider.swift
@@ -23,16 +23,8 @@ extension AssetFungibilityPreservationProvider: AssetFungibilityPreservationProv
 extension AssetFungibilityPreservationProvider {
     static func createFromKnownChains() -> AssetFungibilityPreservationProvider {
         AssetFungibilityPreservationProvider(
-            allAssets: [
-                KnowChainId.polkadotAssetHub,
-                KnowChainId.kusamaAssetHub
-            ],
-            concreteAssets: [
-                ChainAssetId(
-                    chainId: KnowChainId.astar,
-                    assetId: AssetModel.utilityAssetId
-                )
-            ]
+            allAssets: [],
+            concreteAssets: []
         )
     }
 }

--- a/novawallet/Common/Substrate/Operations/DryRun/DryRunOperationFactory.swift
+++ b/novawallet/Common/Substrate/Operations/DryRun/DryRunOperationFactory.swift
@@ -17,45 +17,7 @@ protocol DryRunOperationFactoryProtocol {
     ) -> CompoundOperationWrapper<DryRun.XcmResult>
 }
 
-enum DryRunOperationFactoryError: Error {
-    case unexpectedParamsCount
-}
-
-final class DryRunOperationFactory {
-    let chainRegistry: ChainRegistryProtocol
-    let operationQueue: OperationQueue
-    let stateCallFactory = StateCallRequestFactory()
-
-    init(chainRegistry: ChainRegistryProtocol, operationQueue: OperationQueue) {
-        self.chainRegistry = chainRegistry
-        self.operationQueue = operationQueue
-    }
-}
-
-private extension DryRunOperationFactory {
-    func createDryRunWrapper<R: Decodable>(
-        for chainId: ChainModel.Id,
-        method: String,
-        paramsClosure: StateCallWithApiParamsClosure?
-    ) -> CompoundOperationWrapper<R> {
-        do {
-            let runtimeProvider = try chainRegistry.getRuntimeProviderOrError(for: chainId)
-            let connection = try chainRegistry.getConnectionOrError(for: chainId)
-
-            let path = StateCallPath(module: DryRun.apiName, method: method)
-
-            return stateCallFactory.createWrapper(
-                path: path,
-                paramsClosure: paramsClosure,
-                runtimeProvider: runtimeProvider,
-                connection: connection,
-                operationQueue: operationQueue
-            )
-        } catch {
-            return CompoundOperationWrapper.createWithError(error)
-        }
-    }
-}
+final class DryRunOperationFactory: SubstrateRuntimeApiOperationFactory {}
 
 extension DryRunOperationFactory: DryRunOperationFactoryProtocol {
     func createDryRunCallWrapper<C>(
@@ -64,11 +26,14 @@ extension DryRunOperationFactory: DryRunOperationFactoryProtocol {
         xcmVersion: Xcm.Version,
         chainId: ChainModel.Id
     ) -> CompoundOperationWrapper<DryRun.CallResult> {
-        createDryRunWrapper(for: chainId, method: "dry_run_call") { runtimeApi, encoder, context in
+        createRuntimeCallWrapper(
+            for: chainId,
+            path: StateCallPath(module: DryRun.apiName, method: "dry_run_call")
+        ) { runtimeApi, encoder, context in
             // dry run v2 has additional xcm version param
             let paramsCount = runtimeApi.method.inputs.count
             guard paramsCount == 2 || paramsCount == 3 else {
-                throw DryRunOperationFactoryError.unexpectedParamsCount
+                throw SubstrateRuntimeApiOperationFactoryError.unexpectedParamsCount
             }
 
             let originType = runtimeApi.method.inputs[0].paramType
@@ -104,9 +69,12 @@ extension DryRunOperationFactory: DryRunOperationFactoryProtocol {
         xcm: Xcm.Message,
         chainId: ChainModel.Id
     ) -> CompoundOperationWrapper<DryRun.XcmResult> {
-        createDryRunWrapper(for: chainId, method: "dry_run_xcm") { runtimeApi, encoder, context in
+        createRuntimeCallWrapper(
+            for: chainId,
+            path: StateCallPath(module: DryRun.apiName, method: "dry_run_xcm")
+        ) { runtimeApi, encoder, context in
             guard runtimeApi.method.inputs.count == 2 else {
-                throw DryRunOperationFactoryError.unexpectedParamsCount
+                throw SubstrateRuntimeApiOperationFactoryError.unexpectedParamsCount
             }
 
             let originType = runtimeApi.method.inputs[0].paramType

--- a/novawallet/Common/Substrate/Operations/StateCall/SubstrateRuntimeApiOperationFactory.swift
+++ b/novawallet/Common/Substrate/Operations/StateCall/SubstrateRuntimeApiOperationFactory.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Operation_iOS
+import SubstrateSdk
+
+class SubstrateRuntimeApiOperationFactory {
+    let chainRegistry: ChainRegistryProtocol
+    let operationQueue: OperationQueue
+    let stateCallFactory = StateCallRequestFactory()
+
+    init(chainRegistry: ChainRegistryProtocol, operationQueue: OperationQueue) {
+        self.chainRegistry = chainRegistry
+        self.operationQueue = operationQueue
+    }
+}
+
+enum SubstrateRuntimeApiOperationFactoryError: Error {
+    case unexpectedParamsCount
+}
+
+extension SubstrateRuntimeApiOperationFactory {
+    func createRuntimeCallWrapper<R: Decodable>(
+        for chainId: ChainModel.Id,
+        path: StateCallPath,
+        paramsClosure: StateCallWithApiParamsClosure?
+    ) -> CompoundOperationWrapper<R> {
+        do {
+            let runtimeProvider = try chainRegistry.getRuntimeProviderOrError(for: chainId)
+            let connection = try chainRegistry.getConnectionOrError(for: chainId)
+
+            return stateCallFactory.createWrapper(
+                path: path,
+                paramsClosure: paramsClosure,
+                runtimeProvider: runtimeProvider,
+                connection: connection,
+                operationQueue: operationQueue
+            )
+        } catch {
+            return CompoundOperationWrapper.createWithError(error)
+        }
+    }
+}

--- a/novawallet/Common/Substrate/Operations/XcmPaymentApi/XcmPayment.swift
+++ b/novawallet/Common/Substrate/Operations/XcmPaymentApi/XcmPayment.swift
@@ -1,0 +1,8 @@
+import Foundation
+import SubstrateSdk
+
+enum XcmPayment {
+    static let apiName = "XcmPaymentApi"
+
+    typealias WeightResult = Substrate.Result<BlockchainWeight.WeightV2, JSON>
+}

--- a/novawallet/Common/Substrate/Operations/XcmPaymentApi/XcmPaymentOperationFactory.swift
+++ b/novawallet/Common/Substrate/Operations/XcmPaymentApi/XcmPaymentOperationFactory.swift
@@ -1,0 +1,72 @@
+import Foundation
+import SubstrateSdk
+import Operation_iOS
+
+protocol XcmPaymentOperationFactoryProtocol {
+    func queryMessageWeight(
+        for message: Xcm.Message,
+        chainId: ChainModel.Id
+    ) -> CompoundOperationWrapper<XcmPayment.WeightResult>
+}
+
+final class XcmPaymentOperationFactory {
+    let chainRegistry: ChainRegistryProtocol
+    let operationQueue: OperationQueue
+    let stateCallFactory = StateCallRequestFactory()
+
+    init(chainRegistry: ChainRegistryProtocol, operationQueue: OperationQueue) {
+        self.chainRegistry = chainRegistry
+        self.operationQueue = operationQueue
+    }
+}
+
+private extension XcmPaymentOperationFactory {
+    // TODO: This a duplicate for the method in DryRun
+    func createXcmPaymentWrapper<R: Decodable>(
+        for chainId: ChainModel.Id,
+        method: String,
+        paramsClosure: StateCallWithApiParamsClosure?
+    ) -> CompoundOperationWrapper<R> {
+        do {
+            let runtimeProvider = try chainRegistry.getRuntimeProviderOrError(for: chainId)
+            let connection = try chainRegistry.getConnectionOrError(for: chainId)
+
+            let path = StateCallPath(module: XcmPayment.apiName, method: method)
+
+            return stateCallFactory.createWrapper(
+                path: path,
+                paramsClosure: paramsClosure,
+                runtimeProvider: runtimeProvider,
+                connection: connection,
+                operationQueue: operationQueue
+            )
+        } catch {
+            return CompoundOperationWrapper.createWithError(error)
+        }
+    }
+}
+
+extension XcmPaymentOperationFactory: XcmPaymentOperationFactoryProtocol {
+    func queryMessageWeight(
+        for message: Xcm.Message,
+        chainId: ChainModel.Id
+    ) -> CompoundOperationWrapper<XcmPayment.WeightResult> {
+        createXcmPaymentWrapper(
+            for: chainId,
+            method: "query_xcm_weight"
+        ) { runtimeApi, encoder, context in
+            let paramsCount = runtimeApi.method.inputs.count
+            guard paramsCount == 1 else {
+                throw DryRunOperationFactoryError.unexpectedParamsCount
+            }
+
+            let originType = runtimeApi.method.inputs[0].paramType
+
+            try encoder.append(
+                message,
+                ofType: originType.asTypeId(),
+                with: context.toRawContext()
+            )
+        }
+    }
+}

--- a/novawallet/Common/Substrate/Operations/XcmPaymentApi/XcmPaymentOperationFactory.swift
+++ b/novawallet/Common/Substrate/Operations/XcmPaymentApi/XcmPaymentOperationFactory.swift
@@ -9,55 +9,20 @@ protocol XcmPaymentOperationFactoryProtocol {
     ) -> CompoundOperationWrapper<XcmPayment.WeightResult>
 }
 
-final class XcmPaymentOperationFactory {
-    let chainRegistry: ChainRegistryProtocol
-    let operationQueue: OperationQueue
-    let stateCallFactory = StateCallRequestFactory()
-
-    init(chainRegistry: ChainRegistryProtocol, operationQueue: OperationQueue) {
-        self.chainRegistry = chainRegistry
-        self.operationQueue = operationQueue
-    }
-}
-
-private extension XcmPaymentOperationFactory {
-    // TODO: This a duplicate for the method in DryRun
-    func createXcmPaymentWrapper<R: Decodable>(
-        for chainId: ChainModel.Id,
-        method: String,
-        paramsClosure: StateCallWithApiParamsClosure?
-    ) -> CompoundOperationWrapper<R> {
-        do {
-            let runtimeProvider = try chainRegistry.getRuntimeProviderOrError(for: chainId)
-            let connection = try chainRegistry.getConnectionOrError(for: chainId)
-
-            let path = StateCallPath(module: XcmPayment.apiName, method: method)
-
-            return stateCallFactory.createWrapper(
-                path: path,
-                paramsClosure: paramsClosure,
-                runtimeProvider: runtimeProvider,
-                connection: connection,
-                operationQueue: operationQueue
-            )
-        } catch {
-            return CompoundOperationWrapper.createWithError(error)
-        }
-    }
-}
+class XcmPaymentOperationFactory: SubstrateRuntimeApiOperationFactory {}
 
 extension XcmPaymentOperationFactory: XcmPaymentOperationFactoryProtocol {
     func queryMessageWeight(
         for message: Xcm.Message,
         chainId: ChainModel.Id
     ) -> CompoundOperationWrapper<XcmPayment.WeightResult> {
-        createXcmPaymentWrapper(
+        createRuntimeCallWrapper(
             for: chainId,
-            method: "query_xcm_weight"
+            path: StateCallPath(module: XcmPayment.apiName, method: "query_xcm_weight")
         ) { runtimeApi, encoder, context in
             let paramsCount = runtimeApi.method.inputs.count
             guard paramsCount == 1 else {
-                throw DryRunOperationFactoryError.unexpectedParamsCount
+                throw SubstrateRuntimeApiOperationFactoryError.unexpectedParamsCount
             }
 
             let originType = runtimeApi.method.inputs[0].paramType

--- a/novawallet/Common/Substrate/Types/Xcm/V4/XcmV4Asset.swift
+++ b/novawallet/Common/Substrate/Types/Xcm/V4/XcmV4Asset.swift
@@ -45,6 +45,7 @@ extension XcmV4 {
 
         case all
         case allOf(AllOfValue)
+        case allCounted(UInt32)
         case other(String, JSON)
 
         init(from decoder: any Decoder) throws {
@@ -58,6 +59,9 @@ extension XcmV4 {
             case "AllOf":
                 let value = try container.decode(AllOfValue.self)
                 self = .allOf(value)
+            case "AllCounted":
+                let value = try container.decode(StringScaleMapper<UInt32>.self).value
+                self = .allCounted(value)
             default:
                 let value = try container.decode(JSON.self)
                 self = .other(type, value)
@@ -74,6 +78,9 @@ extension XcmV4 {
             case let .allOf(value):
                 try container.encode("AllOf")
                 try container.encode(value)
+            case let .allCounted(value):
+                try container.encode("AllCounted")
+                try container.encode(StringScaleMapper(value: value))
             case let .other(type, value):
                 try container.encode(type)
                 try container.encode(value)

--- a/novawallet/Common/Substrate/Types/Xcm/V4/XcmV4Instruction.swift
+++ b/novawallet/Common/Substrate/Types/Xcm/V4/XcmV4Instruction.swift
@@ -18,6 +18,18 @@ extension XcmV4 {
         let xcm: [Instruction]
     }
 
+    struct InitiateReserveWithdrawValue: Codable {
+        let assets: XcmV4.AssetFilter
+        let reserve: XcmV4.Multilocation
+        let xcm: [Instruction]
+    }
+
+    struct InitiateTeleportValue: Codable {
+        let assets: XcmV4.AssetFilter
+        let dest: XcmV4.Multilocation
+        let xcm: [Instruction]
+    }
+
     enum Instruction: Codable {
         static let fieldWithdrawAsset = "WithdrawAsset"
         static let fieldClearOrigin = "ClearOrigin"
@@ -26,6 +38,9 @@ extension XcmV4 {
         static let fieldDepositAsset = "DepositAsset"
         static let fieldDepositReserveAsset = "DepositReserveAsset"
         static let fieldReceiveTeleportedAsset = "ReceiveTeleportedAsset"
+        static let fieldBurnAsset = "BurnAsset"
+        static let fieldInitiateReserveWithdraw = "InitiateReserveWithdraw"
+        static let fieldInitiateTeleport = "InitiateTeleport"
 
         case withdrawAsset([XcmV4.Multiasset])
         case depositAsset(DepositAssetValue)
@@ -34,6 +49,9 @@ extension XcmV4 {
         case buyExecution(BuyExecutionValue)
         case depositReserveAsset(DepositReserveAssetValue)
         case receiveTeleportedAsset([XcmV4.Multiasset])
+        case burnAsset([XcmV4.Multiasset])
+        case initiateReserveWithdraw(InitiateReserveWithdrawValue)
+        case initiateTeleport(InitiateTeleportValue)
         case other(String, JSON)
 
         init(from decoder: any Decoder) throws {
@@ -62,6 +80,15 @@ extension XcmV4 {
             case Self.fieldReceiveTeleportedAsset:
                 let value = try container.decode([XcmV4.Multiasset].self)
                 self = .receiveTeleportedAsset(value)
+            case Self.fieldBurnAsset:
+                let value = try container.decode([XcmV4.Multiasset].self)
+                self = .burnAsset(value)
+            case Self.fieldInitiateReserveWithdraw:
+                let value = try container.decode(InitiateReserveWithdrawValue.self)
+                self = .initiateReserveWithdraw(value)
+            case Self.fieldInitiateTeleport:
+                let value = try container.decode(InitiateTeleportValue.self)
+                self = .initiateTeleport(value)
             default:
                 let value = try container.decode(JSON.self)
                 self = .other(type, value)
@@ -93,6 +120,15 @@ extension XcmV4 {
             case let .receiveTeleportedAsset(assets):
                 try container.encode(Self.fieldReceiveTeleportedAsset)
                 try container.encode(assets)
+            case let .burnAsset(assets):
+                try container.encode(Self.fieldBurnAsset)
+                try container.encode(assets)
+            case let .initiateReserveWithdraw(value):
+                try container.encode(Self.fieldInitiateReserveWithdraw)
+                try container.encode(value)
+            case let .initiateTeleport(value):
+                try container.encode(Self.fieldInitiateTeleport)
+                try container.encode(value)
             case let .other(type, value):
                 try container.encode(type)
                 try container.encode(value)

--- a/novawalletIntegrationTests/XcmTransfers/XcmExecuteFeeCalculatorTests.swift
+++ b/novawalletIntegrationTests/XcmTransfers/XcmExecuteFeeCalculatorTests.swift
@@ -20,6 +20,21 @@ final class XcmExecuteFeeCalculatorTests: XCTestCase {
         }
     }
     
+    func testDOTHydrationPolkadot() throws {
+        do {
+            let fee = try calculateFee(
+                for: KnowChainId.hydra,
+                originAssetSymbol: "DOT",
+                destinationChainId: KnowChainId.polkadot,
+                destinationAssetSymbol: "DOT"
+            )
+            
+            Logger.shared.debug("Fee: \(fee)")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
     func testDOTPolkadotPolkadotAssetHub() throws {
         do {
             let fee = try calculateFee(

--- a/novawalletIntegrationTests/XcmTransfers/XcmExecuteFeeCalculatorTests.swift
+++ b/novawalletIntegrationTests/XcmTransfers/XcmExecuteFeeCalculatorTests.swift
@@ -110,6 +110,21 @@ final class XcmExecuteFeeCalculatorTests: XCTestCase {
         }
     }
     
+    func testDOTBifrostHydra() throws {
+        do {
+            let fee = try calculateFee(
+                for: "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
+                originAssetSymbol: "DOT",
+                destinationChainId: KnowChainId.hydra,
+                destinationAssetSymbol: "DOT"
+            )
+            
+            Logger.shared.debug("Fee: \(fee)")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
     func testUSDTAssetHubHydra() throws {
         do {
             let fee = try calculateFee(

--- a/novawalletIntegrationTests/XcmTransfers/XcmExecuteFeeCalculatorTests.swift
+++ b/novawalletIntegrationTests/XcmTransfers/XcmExecuteFeeCalculatorTests.swift
@@ -4,7 +4,7 @@ import Operation_iOS
 import SubstrateSdk
 import BigInt
 
-final class XcmDynamicFeeCalculatorTests: XCTestCase {
+final class XcmExecuteFeeCalculatorTests: XCTestCase {
     func testDOTPolkadotHydration() throws {
         do {
             let fee = try calculateFee(
@@ -227,7 +227,14 @@ final class XcmDynamicFeeCalculatorTests: XCTestCase {
         let operationQueue = OperationQueue()
         let feeService = XcmDynamicCrosschainFeeCalculator(
             chainRegistry: chainRegistry,
-            callDerivator: XcmCallDerivator(chainRegistry: chainRegistry),
+            callDerivator: XcmExecuteDerivator(
+                chainRegistry: chainRegistry,
+                xcmPaymentFactory: XcmPaymentOperationFactory(
+                    chainRegistry: chainRegistry,
+                    operationQueue: operationQueue
+                ),
+                metadataFactory: XcmPalletMetadataQueryFactory()
+            ),
             operationQueue: operationQueue,
             logger: Logger.shared
         )


### PR DESCRIPTION
## Purpose

The PR introduces `XcmExecuteDerivator` a new call builder for xcm transactions that builds xcm program manually for each type of the transfer. This allow to pay all the fees from the amount being sent. Previously we had an issue that one can't pay delivery fee from the sending amount and also can't send all amount from the account.

Note: Will refactor xcm program construction in a separate PR by moving the logic from the call builder to the new xcm builder entity.