### PR TITLE
Fix/navigation

### DIFF
--- a/novawallet/Common/Protocols/Ramp/RampActionsPresentable.swift
+++ b/novawallet/Common/Protocols/Ramp/RampActionsPresentable.swift
@@ -11,23 +11,114 @@ private enum ManageActions: Int {
     case sell
 }
 
+enum RampActionAvailability {
+    case available(RampActionType)
+    case unavailable(RampActionType)
+
+    var type: RampActionType {
+        switch self {
+        case let .available(rampType), let .unavailable(rampType):
+            return rampType
+        }
+    }
+
+    var available: Bool {
+        switch self {
+        case .available: true
+        case .unavailable: false
+        }
+    }
+
+    func available(_ type: RampActionType) -> Bool {
+        switch self {
+        case let .available(rampType): rampType == type
+        case .unavailable: false
+        }
+    }
+}
+
+struct RampActionAvailabilityOptions: OptionSet {
+    typealias RawValue = UInt8
+
+    static let onRamp = RampActionAvailabilityOptions(rawValue: 1 << 0)
+    static let offRamp = RampActionAvailabilityOptions(rawValue: 1 << 1)
+    static let all: RampActionAvailabilityOptions = [.onRamp, .offRamp]
+    static let none: RampActionAvailabilityOptions = []
+
+    let rawValue: UInt8
+
+    var notEmpty: Bool {
+        self != Self.none
+    }
+
+    init(rawValue: RawValue) {
+        self.rawValue = rawValue
+    }
+
+    init(from rampType: RampActionType) {
+        switch rampType {
+        case .onRamp: self = .onRamp
+        case .offRamp: self = .offRamp
+        }
+    }
+}
+
+extension Array where Element == RampActionAvailability {
+    var options: RampActionAvailabilityOptions {
+        reduce(into: .init(rawValue: 0)) { result, availability in
+            switch availability.type {
+            case .onRamp where availability.available:
+                result.insert(.onRamp)
+            case .offRamp where availability.available:
+                result.insert(.offRamp)
+            default:
+                break
+            }
+        }
+    }
+}
+
 protocol RampActionsPresentable: ActionsManagePresentable {
     func presentRampActionsSheet(
         from view: ControllerBackedProtocol?,
+        availableTypes: [RampActionAvailability],
         delegate: ModalPickerViewControllerDelegate?,
+        locale: Locale,
         onActionSelect: @escaping (RampActionType) -> Void
     )
 }
 
-extension RampActionsPresentable {
+extension RampActionsPresentable where Self: AlertPresentable {
     func presentRampActionsSheet(
         from view: ControllerBackedProtocol?,
+        availableTypes: [RampActionAvailability],
         delegate: ModalPickerViewControllerDelegate?,
+        locale: Locale,
         onActionSelect: @escaping (RampActionType) -> Void
     ) {
         guard let view else { return }
 
-        let modalActionsContext = createModalActionsContext(onActionSelect: onActionSelect)
+        guard availableTypes.options.notEmpty else {
+            showRampNotSupported(
+                availableTypes: availableTypes,
+                from: view,
+                locale: locale
+            )
+
+            return
+        }
+
+        let modalActionsContext = createModalActionsContext(
+            availableTypes: availableTypes,
+            onActionAvailable: onActionSelect,
+            onActionUnavailable: { [weak self] in
+                self?.showRampNotSupported(
+                    availableTypes: availableTypes,
+                    from: view,
+                    locale: locale
+                )
+            }
+        )
 
         presentActionsManage(
             from: view,
@@ -37,34 +128,89 @@ extension RampActionsPresentable {
             context: modalActionsContext.context
         )
     }
+}
 
-    private func createModalActionsContext(onActionSelect: @escaping (RampActionType) -> Void) -> ModalActionsContext {
-        let actionViewModels: [LocalizableResource<ActionManageViewModel>] = [
-            LocalizableResource { locale in
-                ActionManageViewModel(
-                    icon: R.image.iconAddStroke(),
-                    title: R.string.localizable.tokenActionsPickerBuy(preferredLanguages: locale.rLanguages)
-                )
-            },
-            LocalizableResource { locale in
-                ActionManageViewModel(
-                    icon: R.image.iconSellStroke(),
-                    title: R.string.localizable.tokenActionsPickerSell(preferredLanguages: locale.rLanguages)
-                )
+private extension RampActionsPresentable where Self: AlertPresentable {
+    func createModalActionsContext(
+        availableTypes: [RampActionAvailability],
+        onActionAvailable: @escaping (RampActionType) -> Void,
+        onActionUnavailable: @escaping () -> Void
+    ) -> ModalActionsContext {
+        let actionViewModels: [LocalizableResource<ActionManageViewModel>] = availableTypes.map { rampAvailability in
+            let style: ActionManageStyle = rampAvailability.available == true
+                ? .available
+                : .unavailable
+
+            return switch rampAvailability.type {
+            case .onRamp:
+                LocalizableResource { locale in
+                    ActionManageViewModel(
+                        icon: R.image.iconAddStroke(),
+                        title: R.string.localizable.tokenActionsPickerBuy(preferredLanguages: locale.rLanguages),
+                        style: style
+                    )
+                }
+            case .offRamp:
+                LocalizableResource { locale in
+                    ActionManageViewModel(
+                        icon: R.image.iconSellStroke(),
+                        title: R.string.localizable.tokenActionsPickerSell(preferredLanguages: locale.rLanguages),
+                        style: style
+                    )
+                }
             }
-        ]
+        }
 
         let context = ModalPickerClosureContext { index in
             guard let manageAction = ManageActions(rawValue: index) else {
                 return
             }
 
-            switch manageAction {
-            case .buy: onActionSelect(.onRamp)
-            case .sell: onActionSelect(.offRamp)
+            let actionType: RampActionType = switch manageAction {
+            case .buy: .onRamp
+            case .sell: .offRamp
+            }
+
+            if availableTypes.options.contains(.init(from: actionType)) {
+                onActionAvailable(actionType)
+            } else {
+                onActionUnavailable()
             }
         }
 
         return (actionViewModels, context)
+    }
+
+    func showRampNotSupported(
+        availableTypes: [RampActionAvailability],
+        from view: ControllerBackedProtocol?,
+        locale: Locale
+    ) {
+        let languages = locale.rLanguages
+        let localizable = R.string.localizable.self
+
+        let (title, message): (String, String)
+
+        if !availableTypes.options.notEmpty {
+            title = localizable.rampNotSupportedAlertTitle(preferredLanguages: languages)
+            message = localizable.rampNotSupportedAlertMessage(preferredLanguages: languages)
+        } else if !availableTypes.options.contains(.onRamp) {
+            title = localizable.onRampNotSupportedAlertTitle(preferredLanguages: languages)
+            message = localizable.onRampNotSupportedAlertMessage(preferredLanguages: languages)
+        } else if !availableTypes.options.contains(.offRamp) {
+            title = localizable.offRampNotSupportedAlertTitle(preferredLanguages: languages)
+            message = localizable.offRampNotSupportedAlertMessage(preferredLanguages: languages)
+        } else {
+            return
+        }
+
+        let actionTitle = localizable.commonGotIt(preferredLanguages: languages)
+
+        present(
+            message: message,
+            title: title,
+            closeAction: actionTitle,
+            from: view
+        )
     }
 }

--- a/novawallet/Common/Protocols/Ramp/RampFlowManaging.swift
+++ b/novawallet/Common/Protocols/Ramp/RampFlowManaging.swift
@@ -7,8 +7,45 @@ protocol RampFlowManaging {
         rampType: RampActionType,
         wireframe: (RampPresentable & AlertPresentable)?,
         chainAsset: ChainAsset,
+        delegate: RampDelegate,
         locale: Locale
     )
+}
+
+extension RampFlowManaging {
+    func startRampFlow(
+        from view: ControllerBackedProtocol?,
+        actions: [RampAction],
+        rampType: RampActionType,
+        wireframe: (RampPresentable & AlertPresentable)?,
+        chainAsset: ChainAsset,
+        delegate: RampDelegate,
+        locale: Locale
+    ) {
+        let rampActions = actions.filter { $0.type == rampType }
+
+        guard !rampActions.isEmpty else {
+            return
+        }
+        if rampActions.count == 1 {
+            startFlow(
+                view: view,
+                action: rampActions[0],
+                chainAsset: chainAsset,
+                wireframe: wireframe,
+                locale: locale,
+                delegate: delegate
+            )
+        } else {
+            wireframe?.showRampProviders(
+                from: view,
+                actions: rampActions,
+                rampType: rampType,
+                chainAsset: chainAsset,
+                delegate: delegate
+            )
+        }
+    }
 }
 
 extension RampFlowManaging where Self: RampDelegate {
@@ -20,38 +57,26 @@ extension RampFlowManaging where Self: RampDelegate {
         chainAsset: ChainAsset,
         locale: Locale
     ) {
-        let rampActions = actions.filter { $0.type == rampType }
-
-        guard !rampActions.isEmpty else {
-            return
-        }
-        if rampActions.count == 1 {
-            startFlow(
-                from: view,
-                action: rampActions[0],
-                chainAsset: chainAsset,
-                wireframe: wireframe,
-                locale: locale
-            )
-        } else {
-            wireframe?.showRampProviders(
-                from: view,
-                actions: rampActions,
-                rampType: rampType,
-                chainAsset: chainAsset,
-                delegate: self
-            )
-        }
+        startRampFlow(
+            from: view,
+            actions: actions,
+            rampType: rampType,
+            wireframe: wireframe,
+            chainAsset: chainAsset,
+            delegate: self,
+            locale: locale
+        )
     }
 }
 
-private extension RampFlowManaging where Self: RampDelegate {
+private extension RampFlowManaging {
     func startFlow(
-        from view: ControllerBackedProtocol?,
+        view: ControllerBackedProtocol?,
         action: RampAction,
         chainAsset: ChainAsset,
         wireframe: (RampPresentable & AlertPresentable)?,
-        locale: Locale
+        locale: Locale,
+        delegate: RampDelegate
     ) {
         let title = R.string.localizable.commonAlertExternalLinkDisclaimerTitle(preferredLanguages: locale.rLanguages)
         let message = R.string.localizable.commonAlertExternalLinkDisclaimerMessage(
@@ -68,7 +93,7 @@ private extension RampFlowManaging where Self: RampDelegate {
                 from: view,
                 action: action,
                 chainAsset: chainAsset,
-                delegate: self
+                delegate: delegate
             )
         }
 

--- a/novawallet/Common/ViewController/ModalPicker/Cell/ActionManageTableViewCell.swift
+++ b/novawallet/Common/ViewController/ModalPicker/Cell/ActionManageTableViewCell.swift
@@ -43,12 +43,16 @@ final class ActionManageTableViewCell: UITableViewCell, ModalPickerCellProtocol 
         let iconColor: UIColor
         let textColor: UIColor
 
-        if model.isDestructive {
-            iconColor = R.color.colorIconNegative()!
-            textColor = R.color.colorTextNegative()!
-        } else {
+        switch model.style {
+        case .available:
             iconColor = R.color.colorIconPrimary()!
             textColor = R.color.colorTextPrimary()!
+        case .unavailable:
+            iconColor = R.color.colorIconInactive()!
+            textColor = R.color.colorButtonTextInactive()!
+        case .destructive:
+            iconColor = R.color.colorIconNegative()!
+            textColor = R.color.colorTextNegative()!
         }
 
         if model.allowsIconModification {

--- a/novawallet/Common/ViewController/ModalPicker/ModalPickerFactory.swift
+++ b/novawallet/Common/ViewController/ModalPicker/ModalPickerFactory.swift
@@ -31,8 +31,9 @@ enum ModalPickerFactory {
         let factory = ModalSheetPresentationFactory(configuration: ModalSheetPresentationConfiguration.nova)
         viewController.modalTransitioningFactory = factory
 
-        let height = viewController.headerHeight + CGFloat(actions.count) * viewController.cellHeight +
-            viewController.footerHeight
+        let height = title != nil ? viewController.headerHeight : .zero
+            + CGFloat(actions.count) * viewController.cellHeight
+            + viewController.footerHeight
         viewController.preferredContentSize = CGSize(width: 0.0, height: height)
 
         viewController.localizationManager = LocalizationManager.shared

--- a/novawallet/Common/ViewController/ModalPicker/ModalPickerViewController.swift
+++ b/novawallet/Common/ViewController/ModalPicker/ModalPickerViewController.swift
@@ -142,6 +142,7 @@ class ModalPickerViewController<C: UITableViewCell & ModalPickerCellProtocol, T>
             headerHeightConstraint.constant = headerHeight
         } else {
             headerHeightConstraint.constant = .zero
+            headerHeight = 0
         }
 
         headerBackgroundView.borderType = headerBorderType

--- a/novawallet/Common/ViewModel/ActionManageViewModel.swift
+++ b/novawallet/Common/ViewModel/ActionManageViewModel.swift
@@ -1,11 +1,17 @@
 import UIKit
 
+enum ActionManageStyle {
+    case available
+    case unavailable
+    case destructive
+}
+
 struct ActionManageViewModel {
     let icon: UIImage?
     let title: String
     let subtitle: String?
     let details: String?
-    let isDestructive: Bool
+    let style: ActionManageStyle
     let allowsIconModification: Bool
 
     init(
@@ -13,14 +19,14 @@ struct ActionManageViewModel {
         title: String,
         subtitle: String? = nil,
         details: String? = nil,
-        isDestructive: Bool = false,
+        style: ActionManageStyle = .available,
         allowsIconModification: Bool = true
     ) {
         self.icon = icon
         self.title = title
         self.subtitle = subtitle
         self.details = details
-        self.isDestructive = isDestructive
+        self.style = style
         self.allowsIconModification = allowsIconModification
     }
 }

--- a/novawallet/Modules/AssetDetails/AssetDetailsProtocols.swift
+++ b/novawallet/Modules/AssetDetails/AssetDetailsProtocols.swift
@@ -46,10 +46,6 @@ protocol AssetDetailsWireframeProtocol:
     func showLedgerNotSupport(for tokenName: String, from view: AssetDetailsViewProtocol?)
     func showLocks(from view: AssetDetailsViewProtocol?, model: AssetDetailsLocksViewModel)
     func showSwaps(from view: AssetDetailsViewProtocol?, chainAsset: ChainAsset)
-    func showRampNotSupported(
-        from view: AssetDetailsViewProtocol?,
-        locale: Locale
-    )
     func dropModalFlow(
         from view: AssetDetailsViewProtocol?,
         completion: @escaping () -> Void

--- a/novawallet/Modules/AssetDetails/AssetDetailsViewController.swift
+++ b/novawallet/Modules/AssetDetails/AssetDetailsViewController.swift
@@ -73,19 +73,9 @@ private extension AssetDetailsViewController {
     }
 
     func configureBuySellAction(for availableOperations: AssetDetailsOperation) {
-        let title = if availableOperations.buySellAvailable() || !availableOperations.rampAvailable() {
-            R.string.localizable.walletAssetBuySell(
-                preferredLanguages: selectedLocale.rLanguages
-            )
-        } else if availableOperations.buyAvailable() {
-            R.string.localizable.walletAssetBuy(
-                preferredLanguages: selectedLocale.rLanguages
-            )
-        } else {
-            R.string.localizable.walletAssetSell(
-                preferredLanguages: selectedLocale.rLanguages
-            )
-        }
+        let title = R.string.localizable.walletAssetBuySell(
+            preferredLanguages: selectedLocale.rLanguages
+        )
 
         let image = R.image.iconBuy()
 

--- a/novawallet/Modules/AssetDetails/AssetDetailsWireframe.swift
+++ b/novawallet/Modules/AssetDetails/AssetDetailsWireframe.swift
@@ -118,25 +118,6 @@ extension AssetDetailsWireframe: AssetDetailsWireframeProtocol {
         view?.controller.present(alertController, animated: true)
     }
 
-    func showRampNotSupported(
-        from view: AssetDetailsViewProtocol?,
-        locale: Locale
-    ) {
-        let languages = locale.rLanguages
-        let localizable = R.string.localizable.self
-
-        let title = localizable.rampNotSupportedAlertTitle(preferredLanguages: languages)
-        let message = localizable.rampNotSupportedAlertMessage(preferredLanguages: languages)
-        let actionTitle = localizable.commonGotIt(preferredLanguages: languages)
-
-        present(
-            message: message,
-            title: title,
-            closeAction: actionTitle,
-            from: view
-        )
-    }
-
     func dropModalFlow(
         from view: AssetDetailsViewProtocol?,
         completion: @escaping () -> Void

--- a/novawallet/Modules/AssetList/AssetListPresenter.swift
+++ b/novawallet/Modules/AssetList/AssetListPresenter.swift
@@ -534,9 +534,16 @@ extension AssetListPresenter: AssetListPresenterProtocol {
     }
 
     func buySell() {
+        let availableTypes: [RampActionAvailability] = [
+            .available(.onRamp),
+            .available(.offRamp)
+        ]
+
         wireframe.presentRampActionsSheet(
             from: view,
-            delegate: self
+            availableTypes: availableTypes,
+            delegate: self,
+            locale: selectedLocale
         ) { [weak self] rampAction in
             self?.wireframe.showRamp(
                 from: self?.view,

--- a/novawallet/Modules/CloudBackup/CloudBackupSettings/CloudBackupSettingsPresenter.swift
+++ b/novawallet/Modules/CloudBackup/CloudBackupSettings/CloudBackupSettingsPresenter.swift
@@ -63,7 +63,7 @@ final class CloudBackupSettingsPresenter {
                     ActionManageViewModel(
                         icon: R.image.iconDelete(),
                         title: R.string.localizable.commonDeleteBackup(preferredLanguages: locale.rLanguages),
-                        isDestructive: true
+                        style: .destructive
                     )
                 }
             }

--- a/novawallet/Modules/NetworkManagement/NetworkDetails/NetworkDetailsPresenter.swift
+++ b/novawallet/Modules/NetworkManagement/NetworkDetails/NetworkDetailsPresenter.swift
@@ -331,7 +331,7 @@ private extension NetworkDetailsPresenter {
                 ActionManageViewModel(
                     icon: R.image.iconDelete(),
                     title: R.string.localizable.networkManageDelete(preferredLanguages: locale.rLanguages),
-                    isDestructive: true
+                    style: .destructive
                 )
             }
         ]

--- a/novawallet/Modules/SelectRampProvider/SelectRampProviderPresenter.swift
+++ b/novawallet/Modules/SelectRampProvider/SelectRampProviderPresenter.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Foundation_iOS
 
-final class SelectRampProviderPresenter {
+final class SelectRampProviderPresenter: RampFlowManaging {
     weak var view: SelectRampProviderViewProtocol?
     let wireframe: SelectRampProviderWireframeProtocol
     let interactor: SelectRampProviderInteractorInputProtocol
@@ -61,7 +61,8 @@ extension SelectRampProviderPresenter: SelectRampProviderPresenterProtocol {
 
         wireframe.openRampProvider(
             from: view,
-            for: action
+            for: action,
+            locale: localizationManager.selectedLocale
         )
     }
 }

--- a/novawallet/Modules/SelectRampProvider/SelectRampProviderProtocols.swift
+++ b/novawallet/Modules/SelectRampProvider/SelectRampProviderProtocols.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 protocol SelectRampProviderViewProtocol: ControllerBackedProtocol {
     func didReceive(_ viewModel: SelectRampProvider.ViewModel)
 }
@@ -15,9 +17,13 @@ protocol SelectRampProviderInteractorOutputProtocol: AnyObject {
     func didReceive(_ rampActions: [RampAction])
 }
 
-protocol SelectRampProviderWireframeProtocol: AnyObject {
+protocol SelectRampProviderWireframeProtocol: AnyObject,
+    AlertPresentable,
+    RampPresentable,
+    RampFlowManaging {
     func openRampProvider(
-        from view: ControllerBackedProtocol?,
-        for action: RampAction
+        from view: (any ControllerBackedProtocol)?,
+        for action: RampAction,
+        locale: Locale
     )
 }

--- a/novawallet/Modules/SelectRampProvider/SelectRampProviderWireframe.swift
+++ b/novawallet/Modules/SelectRampProvider/SelectRampProviderWireframe.swift
@@ -17,17 +17,19 @@ final class SelectRampProviderWireframe {
 extension SelectRampProviderWireframe: SelectRampProviderWireframeProtocol {
     func openRampProvider(
         from view: (any ControllerBackedProtocol)?,
-        for action: RampAction
+        for action: RampAction,
+        locale: Locale
     ) {
-        guard let rampView = RampViewFactory.createView(
-            for: action,
-            chainAsset: chainAsset,
-            delegate: delegate
-        ) else { return }
+        guard let delegate else { return }
 
-        view?.controller.navigationController?.pushViewController(
-            rampView.controller,
-            animated: true
+        startRampFlow(
+            from: view,
+            actions: [action],
+            rampType: action.type,
+            wireframe: self,
+            chainAsset: chainAsset,
+            delegate: delegate,
+            locale: locale
         )
     }
 }

--- a/novawallet/Modules/Swaps/Setup/SwapSetupPresenter.swift
+++ b/novawallet/Modules/Swaps/Setup/SwapSetupPresenter.swift
@@ -908,10 +908,14 @@ extension SwapSetupPresenter: RampFlowManaging, RampDelegate {
         action: RampActionType,
         chainAsset _: ChainAsset
     ) {
-        wireframe.presentRampDidComplete(
-            view: view,
-            action: action,
-            locale: selectedLocale
-        )
+        wireframe.popTopControllers(from: view) { [weak self] in
+            guard let self else { return }
+
+            wireframe.presentRampDidComplete(
+                view: view,
+                action: action,
+                locale: selectedLocale
+            )
+        }
     }
 }

--- a/novawallet/Modules/Swaps/Setup/SwapSetupProtocols.swift
+++ b/novawallet/Modules/Swaps/Setup/SwapSetupProtocols.swift
@@ -99,6 +99,11 @@ protocol SwapSetupWireframeProtocol: SwapBaseWireframeProtocol,
         operations: [AssetExchangeMetaOperationProtocol],
         fee: AssetExchangeFee
     )
+
+    func popTopControllers(
+        from view: ControllerBackedProtocol?,
+        completion: @escaping () -> Void
+    )
 }
 
 enum SwapSetupViewIssue: Equatable {

--- a/novawallet/Modules/Swaps/Setup/SwapSetupWireframe.swift
+++ b/novawallet/Modules/Swaps/Setup/SwapSetupWireframe.swift
@@ -219,4 +219,30 @@ final class SwapSetupWireframe: SwapSetupWireframeProtocol {
 
         view?.controller.present(navigationController, animated: true)
     }
+
+    func popTopControllers(
+        from view: ControllerBackedProtocol?,
+        completion: @escaping () -> Void
+    ) {
+        guard let controller = view?.controller else { return }
+
+        if let presentedViewController = controller.presentedViewController {
+            // In case we have many providers, selection screen is presented modally
+            presentedViewController.dismiss(
+                animated: true,
+                completion: completion
+            )
+        } else {
+            // In case we have single provider, ramp screen is pushed on navigation stack
+            CATransaction.begin()
+            CATransaction.setCompletionBlock { completion() }
+
+            controller.navigationController?.popToViewController(
+                controller,
+                animated: true
+            )
+
+            CATransaction.commit()
+        }
+    }
 }

--- a/novawallet/en.lproj/Localizable.strings
+++ b/novawallet/en.lproj/Localizable.strings
@@ -1839,3 +1839,7 @@
 "asset.operation.sell.title" = "Sell";
 "ramp.not.supported.alert.title" = "This token is not supported by the buy/sell feature";
 "ramp.not.supported.alert.message" = "None of our providers currently support the buying or selling of this token. Please choose a different token, a different network, or check back later.";
+"onRamp.not.supported.alert.title" = "This token is not supported by the buy feature";
+"onRamp.not.supported.alert.message" = "None of our providers currently support the buying of this token. Please choose a different token, a different network, or check back later.";
+"offRamp.not.supported.alert.title" = "This token is not supported by the sell feature";
+"offRamp.not.supported.alert.message" = "None of our providers currently support the selling of this token. Please choose a different token, a different network, or check back later.";


### PR DESCRIPTION
### SUMMARY

The PR addresses the following issues:

- Previously, the ramp actions sheet wasn't triggered when the ramp flow started from the `AssetDetails` module. Now the flow begins with the sheet.
- `ActionManageTableViewCell` now supports content styling with options for `.available`, `.unavailable`, or `.destructive` types. The `.unavailable` style doesn't disable the action, but instead provides flexibility to handle interactions with unavailable actions.
- The alert for unsupported tokens can now be displayed for all three types of ramp actions: Buy, Sell, or Buy/Sell. Alert content and presentation logic depends on the available options set and is encapsulated within the `RampActionsPresentable` protocol.
- The "Continue in browser" dialog is now mandatory.