### PR TITLE
[CU-86983uh2z] Fallback to default custom fee calculation when swaps not available

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -484,7 +484,6 @@
 		0C6108342CD5F77E00909928 /* ExtrinsicFeeEstimatorHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6108332CD5F77E00909928 /* ExtrinsicFeeEstimatorHost.swift */; };
 		0C6108382CD7333100909928 /* ExtrinsicFeeInstallingFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6108372CD7333100909928 /* ExtrinsicFeeInstallingFactory.swift */; };
 		0C61083E2CD7382E00909928 /* AssetConversionFeeInstallingFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C61083D2CD7382E00909928 /* AssetConversionFeeInstallingFactory.swift */; };
-		0C6108412CD74DD200909928 /* AssetExchangeFeeEstimatingFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6108402CD74DD200909928 /* AssetExchangeFeeEstimatingFactory.swift */; };
 		0C6108432CD755A300909928 /* AssetExchangeGraphProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6108422CD755A300909928 /* AssetExchangeGraphProxy.swift */; };
 		0C6108452CD8827200909928 /* HydraSwapFeeCurrencyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6108442CD8827200909928 /* HydraSwapFeeCurrencyService.swift */; };
 		0C6108472CD882F900909928 /* SwapFeeCurrencyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6108462CD882F900909928 /* SwapFeeCurrencyState.swift */; };
@@ -1113,6 +1112,9 @@
 		0CFA161C2B0CE851007AF885 /* Utility+Calls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA161B2B0CE851007AF885 /* Utility+Calls.swift */; };
 		0CFA161E2B0CED07007AF885 /* GovTreasurySpentLocalHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA161D2B0CED07007AF885 /* GovTreasurySpentLocalHandler.swift */; };
 		0CFA16202B0CEF31007AF885 /* GovTreasuryApproveHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA161F2B0CEF31007AF885 /* GovTreasuryApproveHandler.swift */; };
+		0CFF73EC2DA91633009889FC /* AssetExchangeFeeEstimatingRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF73EB2DA91633009889FC /* AssetExchangeFeeEstimatingRouter.swift */; };
+		0CFF73F02DA96A79009889FC /* AssetExchangeFeeEstimatingFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF73EF2DA96A79009889FC /* AssetExchangeFeeEstimatingFactory.swift */; };
+		0CFF73F22DA96D04009889FC /* AssetExchangeFeeConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF73F12DA96D04009889FC /* AssetExchangeFeeConstants.swift */; };
 		0CFF821B2D8AF98F00DB17A4 /* XcmDynamicCrosschainFeeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF821A2D8AF98F00DB17A4 /* XcmDynamicCrosschainFeeCalculator.swift */; };
 		0CFF821D2D8B150D00DB17A4 /* XcmDeliveryFeeMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF821C2D8B150D00DB17A4 /* XcmDeliveryFeeMatcher.swift */; };
 		0CFF821F2D8B580E00DB17A4 /* Xcm+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF821E2D8B580E00DB17A4 /* Xcm+Event.swift */; };
@@ -6239,7 +6241,6 @@
 		0C6108332CD5F77E00909928 /* ExtrinsicFeeEstimatorHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrinsicFeeEstimatorHost.swift; sourceTree = "<group>"; };
 		0C6108372CD7333100909928 /* ExtrinsicFeeInstallingFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrinsicFeeInstallingFactory.swift; sourceTree = "<group>"; };
 		0C61083D2CD7382E00909928 /* AssetConversionFeeInstallingFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetConversionFeeInstallingFactory.swift; sourceTree = "<group>"; };
-		0C6108402CD74DD200909928 /* AssetExchangeFeeEstimatingFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetExchangeFeeEstimatingFactory.swift; sourceTree = "<group>"; };
 		0C6108422CD755A300909928 /* AssetExchangeGraphProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetExchangeGraphProxy.swift; sourceTree = "<group>"; };
 		0C6108442CD8827200909928 /* HydraSwapFeeCurrencyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraSwapFeeCurrencyService.swift; sourceTree = "<group>"; };
 		0C6108462CD882F900909928 /* SwapFeeCurrencyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapFeeCurrencyState.swift; sourceTree = "<group>"; };
@@ -6898,6 +6899,9 @@
 		0CFA161B2B0CE851007AF885 /* Utility+Calls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Utility+Calls.swift"; sourceTree = "<group>"; };
 		0CFA161D2B0CED07007AF885 /* GovTreasurySpentLocalHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GovTreasurySpentLocalHandler.swift; sourceTree = "<group>"; };
 		0CFA161F2B0CEF31007AF885 /* GovTreasuryApproveHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GovTreasuryApproveHandler.swift; sourceTree = "<group>"; };
+		0CFF73EB2DA91633009889FC /* AssetExchangeFeeEstimatingRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetExchangeFeeEstimatingRouter.swift; sourceTree = "<group>"; };
+		0CFF73EF2DA96A79009889FC /* AssetExchangeFeeEstimatingFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetExchangeFeeEstimatingFactory.swift; sourceTree = "<group>"; };
+		0CFF73F12DA96D04009889FC /* AssetExchangeFeeConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetExchangeFeeConstants.swift; sourceTree = "<group>"; };
 		0CFF821A2D8AF98F00DB17A4 /* XcmDynamicCrosschainFeeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmDynamicCrosschainFeeCalculator.swift; sourceTree = "<group>"; };
 		0CFF821C2D8B150D00DB17A4 /* XcmDeliveryFeeMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmDeliveryFeeMatcher.swift; sourceTree = "<group>"; };
 		0CFF821E2D8B580E00DB17A4 /* Xcm+Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Xcm+Event.swift"; sourceTree = "<group>"; };
@@ -12827,8 +12831,10 @@
 		0C61083F2CD74D5600909928 /* FeeEstimating */ = {
 			isa = PBXGroup;
 			children = (
-				0C6108402CD74DD200909928 /* AssetExchangeFeeEstimatingFactory.swift */,
+				0CFF73EF2DA96A79009889FC /* AssetExchangeFeeEstimatingFactory.swift */,
 				0C6108422CD755A300909928 /* AssetExchangeGraphProxy.swift */,
+				0CFF73EB2DA91633009889FC /* AssetExchangeFeeEstimatingRouter.swift */,
+				0CFF73F12DA96D04009889FC /* AssetExchangeFeeConstants.swift */,
 			);
 			path = FeeEstimating;
 			sourceTree = "<group>";
@@ -27221,9 +27227,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-novawalletTests/Pods-novawalletTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-novawalletTests/Pods-novawalletTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -27277,9 +27287,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-novawalletAll-novawalletIntegrationTests/Pods-novawalletAll-novawalletIntegrationTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-novawalletAll-novawalletIntegrationTests/Pods-novawalletAll-novawalletIntegrationTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -27316,9 +27330,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-novawalletAll-novawallet/Pods-novawalletAll-novawallet-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-novawalletAll-novawallet/Pods-novawalletAll-novawallet-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -30109,6 +30127,7 @@
 				2D1C5D162C24553200E2DBDD /* NetworkNodeAddPresenter.swift in Sources */,
 				0CE8621B2D64E86700245992 /* StakingRewardsLocalSubscriber.swift in Sources */,
 				849E17F02791909C002D1744 /* DAppSettings.swift in Sources */,
+				0CFF73EC2DA91633009889FC /* AssetExchangeFeeEstimatingRouter.swift in Sources */,
 				0C893E6A2A65591C00781503 /* PoolsMultistakingUpdateService.swift in Sources */,
 				0CCDB2EB2B74DA55007BC5D6 /* GraphModel.swift in Sources */,
 				84DBEA7729DAF5EC00A504A7 /* ConnectionNodeSwitchCode.swift in Sources */,
@@ -30225,6 +30244,7 @@
 				84A70D9F29CCEDA800C648AD /* GovV1SubsquareOperationFactory.swift in Sources */,
 				844DBC742750F12C009F8351 /* AdvancedWalletSettings.swift in Sources */,
 				77DAFF6F2B298FFF00D4220C /* WalletView.swift in Sources */,
+				0CFF73F22DA96D04009889FC /* AssetExchangeFeeConstants.swift in Sources */,
 				8443CA4A289D04E900FA4A95 /* TransactionSigningPresenting.swift in Sources */,
 				8475B47B289870A4009B90BC /* ProcessStepView.swift in Sources */,
 				0C0F6D772D3A5C9500943A7C /* StartStakingInfoMythosInteractor.swift in Sources */,
@@ -31267,7 +31287,6 @@
 				0CCCDF802B64BE7C00473D42 /* HydraDx+Constants.swift in Sources */,
 				716F0819BAB14322E34E416C /* CrowdloanYourContributionsPresenter.swift in Sources */,
 				F0675F495766D07473B065F7 /* CrowdloanYourContributionsInteractor.swift in Sources */,
-				0C6108412CD74DD200909928 /* AssetExchangeFeeEstimatingFactory.swift in Sources */,
 				0C0F6D652D3807D200943A7C /* BalancesPallet+Freezes.swift in Sources */,
 				845B080D2918D4F8005785D3 /* Democracy+Call.swift in Sources */,
 				8425D0EE28FE9BF1003B782A /* ReferendumVoteAction.swift in Sources */,
@@ -32439,6 +32458,7 @@
 				E5528BE6A0BD2D2C53C6F5F8 /* DAppWalletAuthPresenter.swift in Sources */,
 				0D8213272889988B78188D9A /* DAppWalletAuthInteractor.swift in Sources */,
 				A5153C322938579FA145742A /* DAppWalletAuthViewController.swift in Sources */,
+				0CFF73F02DA96A79009889FC /* AssetExchangeFeeEstimatingFactory.swift in Sources */,
 				D7D91A2CACE6FE12AE634BEF /* DAppWalletAuthViewLayout.swift in Sources */,
 				3F3AE7490C59A0CE0BF2D7A7 /* DAppWalletAuthViewFactory.swift in Sources */,
 				0C0F6DA42D3E8EB500943A7C /* MythosCollatorService.swift in Sources */,

--- a/novawallet/Common/Helpers/Scheduler.swift
+++ b/novawallet/Common/Helpers/Scheduler.swift
@@ -48,7 +48,7 @@ final class Scheduler: NSObject, SchedulerProtocol {
         }
 
         clearTimer()
-        
+
         let milliseconds = Int(min(Double(Int.max), 1000.0 * seconds))
 
         timer = DispatchSource.makeTimerSource()

--- a/novawallet/Common/Services/AssetExchange/AssetHubExchange/AssetsHubExchangeProvider.swift
+++ b/novawallet/Common/Services/AssetExchange/AssetHubExchange/AssetsHubExchangeProvider.swift
@@ -59,7 +59,8 @@ final class AssetsHubExchangeProvider: AssetsExchangeBaseProvider {
 
             let customFeeEstimatingFactory = AssetExchangeFeeEstimatingFactory(
                 graphProxy: graphProxy,
-                operationQueue: operationQueue
+                operationQueue: operationQueue,
+                feeBufferInPercentage: AssetExchangeFeeConstants.feeBufferInPercentage
             )
 
             let extrinsicOperationFactory = serviceFactory.createOperationFactory(

--- a/novawallet/Common/Services/AssetExchange/CrosschainExchange/CrosschainAssetsExchangeProvider.swift
+++ b/novawallet/Common/Services/AssetExchange/CrosschainExchange/CrosschainAssetsExchangeProvider.swift
@@ -75,9 +75,16 @@ final class CrosschainAssetsExchangeProvider: AssetsExchangeBaseProvider {
                 userStorageFacade: userStorageFacade,
                 substrateStorageFacade: substrateStorageFacade,
                 operationQueue: operationQueue,
-                customFeeEstimatingFactory: AssetExchangeFeeEstimatingFactory(
+                customFeeEstimatingFactory: AssetExchangeFeeEstimatingRouter(
                     graphProxy: graphProxy,
-                    operationQueue: operationQueue
+                    dependencies: .init(
+                        wallet: wallet,
+                        userStorageFacade: userStorageFacade,
+                        substrateStorageFacade: substrateStorageFacade,
+                        chainRegistry: chainRegistry,
+                        operationQueue: operationQueue,
+                        logger: logger
+                    )
                 ),
                 logger: logger
             ),

--- a/novawallet/Common/Services/AssetExchange/FeeEstimating/AssetExchangeFeeConstants.swift
+++ b/novawallet/Common/Services/AssetExchange/FeeEstimating/AssetExchangeFeeConstants.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum AssetExchangeFeeConstants {
+    // we keep 10% buffer for fee since swaps to native asset especially volatile
+    static let feeBufferInPercentage = BigRational.percent(of: 10)
+}

--- a/novawallet/Common/Services/AssetExchange/FeeEstimating/AssetExchangeFeeEstimatingFactory.swift
+++ b/novawallet/Common/Services/AssetExchange/FeeEstimating/AssetExchangeFeeEstimatingFactory.swift
@@ -3,13 +3,16 @@ import Foundation
 final class AssetExchangeFeeEstimatingFactory {
     let graphProxy: AssetQuoteFactoryProtocol
     let operationQueue: OperationQueue
+    let feeBufferInPercentage: BigRational
 
-    // we 10% buffer for fee since swaps to native asset especially volatile
-    let feeBuffer = BigRational.percent(of: 10)
-
-    init(graphProxy: AssetQuoteFactoryProtocol, operationQueue: OperationQueue) {
+    init(
+        graphProxy: AssetQuoteFactoryProtocol,
+        operationQueue: OperationQueue,
+        feeBufferInPercentage: BigRational
+    ) {
         self.graphProxy = graphProxy
         self.operationQueue = operationQueue
+        self.feeBufferInPercentage = feeBufferInPercentage
     }
 }
 
@@ -19,7 +22,7 @@ extension AssetExchangeFeeEstimatingFactory: ExtrinsicCustomFeeEstimatingFactory
             chainAsset: chainAsset,
             operationQueue: operationQueue,
             quoteFactory: graphProxy,
-            feeBufferInPercentage: feeBuffer
+            feeBufferInPercentage: feeBufferInPercentage
         )
     }
 }

--- a/novawallet/Common/Services/AssetExchange/FeeEstimating/AssetExchangeFeeEstimatingRouter.swift
+++ b/novawallet/Common/Services/AssetExchange/FeeEstimating/AssetExchangeFeeEstimatingRouter.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+final class AssetExchangeFeeEstimatingRouter {
+    let graphBasedFactory: ExtrinsicCustomFeeEstimatingFactoryProtocol
+    let dependencies: AssetExchangeFeeEstimatingRouter.Dependencies
+    let feeBufferInPercentage: BigRational
+
+    // cache factories to optimize fee calc for multi attempts
+    private let conversionCache: InMemoryCache<ChainModel.Id, ExtrinsicCustomFeeEstimatingFactoryProtocol> = .init()
+
+    init(
+        graphProxy: AssetQuoteFactoryProtocol,
+        dependencies: AssetExchangeFeeEstimatingRouter.Dependencies,
+        feeBufferInPercentage: BigRational = AssetExchangeFeeConstants.feeBufferInPercentage
+    ) {
+        graphBasedFactory = AssetExchangeFeeEstimatingFactory(
+            graphProxy: graphProxy,
+            operationQueue: dependencies.operationQueue,
+            feeBufferInPercentage: feeBufferInPercentage
+        )
+
+        self.dependencies = dependencies
+        self.feeBufferInPercentage = feeBufferInPercentage
+    }
+}
+
+private extension AssetExchangeFeeEstimatingRouter {
+    func canSwapViaGraph(chainAsset: ChainAsset) -> Bool {
+        switch AssetType(rawType: chainAsset.asset.type) {
+        case .orml:
+            chainAsset.chain.hasSwapHydra
+        case .statemine:
+            chainAsset.chain.hasSwapHub
+        case .none, .equilibrium, .evmNative, .evmAsset:
+            false
+        }
+    }
+
+    func routeViaGraph(chainAsset: ChainAsset) -> ExtrinsicFeeEstimating? {
+        dependencies.logger.debug("Using graph factory for chain \(chainAsset.chain.name)")
+
+        return graphBasedFactory.createCustomFeeEstimator(for: chainAsset)
+    }
+
+    func routeViaConversion(chainAsset: ChainAsset) -> ExtrinsicFeeEstimating? {
+        do {
+            let factory: ExtrinsicCustomFeeEstimatingFactoryProtocol
+            let chain = chainAsset.chain
+            let chainId = chain.chainId
+
+            if let estimatorFactory = conversionCache.fetchValue(for: chainId) {
+                factory = estimatorFactory
+
+                dependencies.logger.debug("Using conversion cache for chain \(chain.name)")
+
+            } else {
+                let account = try dependencies.wallet.fetchOrError(for: chain.accountRequest())
+                let connection = try dependencies.chainRegistry.getConnectionOrError(for: chainId)
+                let runtimeProvider = try dependencies.chainRegistry.getRuntimeProviderOrError(for: chainId)
+
+                factory = AssetConversionFeeEstimatingFactory(
+                    host: ExtrinsicFeeEstimatorHost(
+                        account: account,
+                        chain: chain,
+                        connection: connection,
+                        runtimeProvider: runtimeProvider,
+                        userStorageFacade: dependencies.userStorageFacade,
+                        substrateStorageFacade: dependencies.substrateStorageFacade,
+                        operationQueue: dependencies.operationQueue
+                    ),
+                    feeBufferInPercentage: feeBufferInPercentage
+                )
+
+                conversionCache.store(value: factory, for: chainId)
+
+                dependencies.logger.debug("New factory for chain \(chain.name)")
+            }
+
+            return factory.createCustomFeeEstimator(for: chainAsset)
+        } catch {
+            dependencies.logger.error("Unexpected error: \(error)")
+
+            return nil
+        }
+    }
+}
+
+extension AssetExchangeFeeEstimatingRouter: ExtrinsicCustomFeeEstimatingFactoryProtocol {
+    func createCustomFeeEstimator(for chainAsset: ChainAsset) -> ExtrinsicFeeEstimating? {
+        // swaps might be turned off on the chain
+        if canSwapViaGraph(chainAsset: chainAsset) {
+            routeViaGraph(chainAsset: chainAsset)
+        } else {
+            routeViaConversion(chainAsset: chainAsset)
+        }
+    }
+}
+
+extension AssetExchangeFeeEstimatingRouter {
+    struct Dependencies {
+        let wallet: MetaAccountModel
+        let userStorageFacade: StorageFacadeProtocol
+        let substrateStorageFacade: StorageFacadeProtocol
+        let chainRegistry: ChainRegistryProtocol
+        let operationQueue: OperationQueue
+        let logger: LoggerProtocol
+    }
+}

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/AssetsHydraExchangeProvider.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/AssetsHydraExchangeProvider.swift
@@ -140,7 +140,8 @@ final class AssetsHydraExchangeProvider: AssetsExchangeBaseProvider {
 
         let customFeeEstimatingFactory = AssetExchangeFeeEstimatingFactory(
             graphProxy: graphProxy,
-            operationQueue: operationQueue
+            operationQueue: operationQueue,
+            feeBufferInPercentage: AssetExchangeFeeConstants.feeBufferInPercentage
         )
 
         let extrinsicOperationFactory = serviceFactory.createOperationFactory(

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/FeeManaging/FeeViaSwap/AssetConversionFeeEstimatingFactory.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/FeeManaging/FeeViaSwap/AssetConversionFeeEstimatingFactory.swift
@@ -4,11 +4,16 @@ import SubstrateSdk
 
 final class AssetConversionFeeEstimatingFactory {
     let host: ExtrinsicFeeEstimatorHostProtocol
+    let feeBufferInPercentage: BigRational
 
     private var hydraFlowState: HydraFlowState?
 
-    init(host: ExtrinsicFeeEstimatorHostProtocol) {
+    init(
+        host: ExtrinsicFeeEstimatorHostProtocol,
+        feeBufferInPercentage: BigRational = BigRational.percent(of: 0) // no overestimation by default
+    ) {
         self.host = host
+        self.feeBufferInPercentage = feeBufferInPercentage
     }
 
     private func setupHydraFlowState() -> HydraFlowState {
@@ -41,7 +46,8 @@ extension AssetConversionFeeEstimatingFactory: ExtrinsicCustomFeeEstimatingFacto
             return ExtrinsicAssetConversionFeeEstimator(
                 chainAsset: chainAsset,
                 operationQueue: host.operationQueue,
-                quoteFactory: quoteFactory
+                quoteFactory: quoteFactory,
+                feeBufferInPercentage: feeBufferInPercentage
             )
         case .statemine where chainAsset.chain.hasAssetHubFees:
             let assetHubQuoteFactory = AssetHubSwapOperationFactory(
@@ -54,7 +60,8 @@ extension AssetConversionFeeEstimatingFactory: ExtrinsicCustomFeeEstimatingFacto
             return ExtrinsicAssetConversionFeeEstimator(
                 chainAsset: chainAsset,
                 operationQueue: host.operationQueue,
-                quoteFactory: assetHubQuoteFactory
+                quoteFactory: assetHubQuoteFactory,
+                feeBufferInPercentage: feeBufferInPercentage
             )
         case .none, .equilibrium, .evmNative, .evmAsset, .orml, .statemine:
             return nil

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/FeeManaging/FeeViaSwap/ExtrinsicAssetConversionFeeEstimator.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/FeeManaging/FeeViaSwap/ExtrinsicAssetConversionFeeEstimator.swift
@@ -12,7 +12,7 @@ final class ExtrinsicAssetConversionFeeEstimator {
         chainAsset: ChainAsset,
         operationQueue: OperationQueue,
         quoteFactory: AssetQuoteFactoryProtocol,
-        feeBufferInPercentage: BigRational = BigRational.percent(of: 0) // no overestimation by default
+        feeBufferInPercentage: BigRational
     ) {
         self.chainAsset = chainAsset
         self.operationQueue = operationQueue


### PR DESCRIPTION
## Purpose

Currently, if swaps on the PAH are not available the attempt to calculate fee in the custom asset for cross chain transfer on PAH during the swap leads to the error. The PR introduces AssetExchangeFeeEstimatingRouter that fallbacks to the default fee calculation method if swaps are not available in the graph.