### PR TITLE
Fix long WC request time after WiFi/LTE change

### DIFF
--- a/novawallet/Common/Services/WalletConnect/WalletConnectService.swift
+++ b/novawallet/Common/Services/WalletConnect/WalletConnectService.swift
@@ -407,7 +407,7 @@ private final class DefaultWebSocket: WebSocketConnecting {
             markDisconnectedAndNotify(error: nil)
         case let .reconnectSuggested(isBetter):
             if isBetter {
-                restart()
+                protectedForceRestart()
             }
         case let .viabilityChanged(isViable):
             if isViable {
@@ -459,7 +459,7 @@ private final class DefaultWebSocket: WebSocketConnecting {
         startWebsocket()
     }
 
-    private func restart() {
+    private func protectedForceRestart() {
         mutex.lock()
 
         defer {
@@ -468,6 +468,7 @@ private final class DefaultWebSocket: WebSocketConnecting {
 
         connectionState = .connecting
 
+        stopWebsocket()
         startWebsocket()
     }
 

--- a/novawallet/Common/Services/WalletConnect/WalletConnectService.swift
+++ b/novawallet/Common/Services/WalletConnect/WalletConnectService.swift
@@ -407,7 +407,7 @@ private final class DefaultWebSocket: WebSocketConnecting {
             markDisconnectedAndNotify(error: nil)
         case let .reconnectSuggested(isBetter):
             if isBetter {
-                protectedRestartIfDisconnected()
+                restart()
             }
         case let .viabilityChanged(isViable):
             if isViable {
@@ -452,6 +452,18 @@ private final class DefaultWebSocket: WebSocketConnecting {
 
         guard connectionState == .notConnected else {
             return
+        }
+
+        connectionState = .connecting
+
+        startWebsocket()
+    }
+
+    private func restart() {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
         }
 
         connectionState = .connecting


### PR DESCRIPTION
### SUMMARY
The PR fixes long WC request time after WiFi/LTE change by calling forced connection restart if reconnection suggested by WS engine.