### PR TITLE
Add support delegate_with_autocompound for Parachain Staking [CU-8698ghttz]

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -2439,6 +2439,7 @@
 		77FFB2B12B0D392A00C7C879 /* OpenStakingUrlParsingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77FFB2B02B0D392A00C7C879 /* OpenStakingUrlParsingService.swift */; };
 		77FFB2B32B0D394700C7C879 /* OpenGovernanceUrlParsingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77FFB2B22B0D394700C7C879 /* OpenGovernanceUrlParsingService.swift */; };
 		782C073E35DE4CEA38B610E0 /* NetworksListViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C890ABA28180F1F93B7865C /* NetworksListViewFactory.swift */; };
+		78A20523CF046A96E52F4218 /* Pods_NovaPushNotificationServiceExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16B3C516E748F09D1A316E1D /* Pods_NovaPushNotificationServiceExtension.framework */; };
 		78D63EC7EC5F7427335A025E /* StakingClaimRewardsViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7302440137F083F7AEC64E /* StakingClaimRewardsViewLayout.swift */; };
 		78D94A761EFECED60F38232D /* CustomValidatorListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270B309EC85D8897A4ADD98A /* CustomValidatorListViewController.swift */; };
 		78E0B6963A8D0A07E742232C /* GovernanceEditDelegationTracksWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3B84FA1F22CC12B16C79AE /* GovernanceEditDelegationTracksWireframe.swift */; };
@@ -11571,6 +11572,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A20523CF046A96E52F4218 /* Pods_NovaPushNotificationServiceExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -27463,13 +27465,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-novawalletTests/Pods-novawalletTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-novawalletTests/Pods-novawalletTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -27509,7 +27507,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				$PROJECT_DIR/NovaPushNotificationServiceExtension/R.generated.swift,
+				"$PROJECT_DIR/NovaPushNotificationServiceExtension/R.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -27523,13 +27521,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-novawalletAll-novawalletIntegrationTests/Pods-novawalletAll-novawalletIntegrationTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-novawalletAll-novawalletIntegrationTests/Pods-novawalletAll-novawalletIntegrationTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -27566,13 +27560,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-novawalletAll-novawallet/Pods-novawalletAll-novawallet-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-novawalletAll-novawallet/Pods-novawalletAll-novawallet-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -27665,7 +27655,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				$PROJECT_DIR/R.generated.swift,
+				"$PROJECT_DIR/R.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -27730,7 +27720,7 @@
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/CIKeys.generated.swift",
-				$PROJECT_DIR/CIKeys.generated.swift,
+				"$PROJECT_DIR/CIKeys.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/novawallet/Common/Substrate/Calls/ParachainStaking/ParaStkCalls.swift
+++ b/novawallet/Common/Substrate/Calls/ParachainStaking/ParaStkCalls.swift
@@ -2,7 +2,6 @@ import Foundation
 import SubstrateSdk
 import BigInt
 
-// swiftlint:disable nesting
 extension ParachainStaking {
     struct DelegateCall: Codable {
         enum CodingKeys: String, CodingKey {
@@ -15,6 +14,24 @@ extension ParachainStaking {
         @BytesCodable var candidate: AccountId
         @StringCodable var amount: BigUInt
         @StringCodable var candidateDelegationCount: UInt32
+        @StringCodable var delegationCount: UInt32
+    }
+
+    struct DelegateWithAutocompoundCall: Codable {
+        enum CodingKeys: String, CodingKey {
+            case candidate
+            case amount
+            case autoCompound = "auto_compound"
+            case candidateDelegationCount = "candidate_delegation_count"
+            case candidateAutoCompoundingDelegationCount = "candidate_auto_compounding_delegation_count"
+            case delegationCount = "delegation_count"
+        }
+
+        @BytesCodable var candidate: AccountId
+        @StringCodable var amount: BigUInt
+        @StringCodable var autoCompound: BigUInt
+        @StringCodable var candidateDelegationCount: UInt32
+        @StringCodable var candidateAutoCompoundingDelegationCount: UInt32
         @StringCodable var delegationCount: UInt32
     }
 
@@ -81,18 +98,31 @@ extension ParachainStaking {
     }
 }
 
-// swiftlint:enable nesting
-
 extension ParachainStaking.DelegateCall {
-    var extrinsicIdentifier: String {
-        candidate.toHex() + "-"
-            + String(amount) + "-"
-            + String(candidateDelegationCount) + "-"
-            + String(delegationCount)
+    static var callCodingPath: CallCodingPath {
+        CallCodingPath(moduleName: "ParachainStaking", callName: "delegate")
     }
 
-    var runtimeCall: RuntimeCall<ParachainStaking.DelegateCall> {
-        RuntimeCall(moduleName: "ParachainStaking", callName: "delegate", args: self)
+    var runtimeCall: RuntimeCall<Self> {
+        RuntimeCall(
+            moduleName: Self.callCodingPath.moduleName,
+            callName: Self.callCodingPath.callName,
+            args: self
+        )
+    }
+}
+
+extension ParachainStaking.DelegateWithAutocompoundCall {
+    static var callCodingPath: CallCodingPath {
+        CallCodingPath(moduleName: "ParachainStaking", callName: "delegate_with_auto_compound")
+    }
+
+    var runtimeCall: RuntimeCall<Self> {
+        RuntimeCall(
+            moduleName: Self.callCodingPath.moduleName,
+            callName: Self.callCodingPath.callName,
+            args: self
+        )
     }
 }
 


### PR DESCRIPTION
## Purpose

The deprecated `delegate` call has been removed from [Parachain Staking pallet](https://github.com/moonbeam-foundation/moonbeam/pull/3215). The PR introduces support for `delegate_with_autocompound_call`. Since UI doesn't support autocompound yet the values are set to zero correspondingly. Also PR ensures backward compatability for chains which haven't upgrade yet.

##

![Simulator Screenshot - iPhone 16 Pro - 2025-04-25 at 11 54 31](https://github.com/user-attachments/assets/cb86873a-4333-44d2-b877-36b0d1f43930)

![Simulator Screenshot - iPhone 16 Pro - 2025-04-25 at 11 54 53](https://github.com/user-attachments/assets/d718c01a-337d-4ee6-b928-a388ef183a9b)

![Simulator Screenshot - iPhone 16 Pro - 2025-04-25 at 11 55 18](https://github.com/user-attachments/assets/9b799966-c950-4295-9648-2c71da50dc6c)

