### PR TITLE
Unblock bytes signing with Polkadot Vault

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1035,6 +1035,7 @@
 		0CDEF1662C27EC83003878F2 /* RuntimeMetadataRepositoryFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEF1652C27EC83003878F2 /* RuntimeMetadataRepositoryFactory.swift */; };
 		0CE150502A6FAC1200B61CC1 /* NominationPoolsPoolSubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE1504F2A6FAC1200B61CC1 /* NominationPoolsPoolSubscriptionService.swift */; };
 		0CE150542A70EA2200B61CC1 /* NominationPoolsSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE150532A70EA2200B61CC1 /* NominationPoolsSyncTests.swift */; };
+		0CE164F82DEF1BFB0099FC28 /* DAppBrowserSigningChainResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE164F72DEF1BFB0099FC28 /* DAppBrowserSigningChainResolver.swift */; };
 		0CE1A0522BE9E995008206ED /* CloudBackupSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE1A0512BE9E995008206ED /* CloudBackupSettingsView.swift */; };
 		0CE1A0572BEBCC46008206ED /* CloudBackupSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE1A0562BEBCC46008206ED /* CloudBackupSettingsViewModel.swift */; };
 		0CE360212C33F398006A6CE4 /* GraphModel+Dijkstra.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE360202C33F398006A6CE4 /* GraphModel+Dijkstra.swift */; };
@@ -6914,6 +6915,7 @@
 		0CDFFCC54A504417F4ACE7AA /* NftListInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NftListInteractor.swift; sourceTree = "<group>"; };
 		0CE1504F2A6FAC1200B61CC1 /* NominationPoolsPoolSubscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NominationPoolsPoolSubscriptionService.swift; sourceTree = "<group>"; };
 		0CE150532A70EA2200B61CC1 /* NominationPoolsSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NominationPoolsSyncTests.swift; sourceTree = "<group>"; };
+		0CE164F72DEF1BFB0099FC28 /* DAppBrowserSigningChainResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppBrowserSigningChainResolver.swift; sourceTree = "<group>"; };
 		0CE1A0512BE9E995008206ED /* CloudBackupSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupSettingsView.swift; sourceTree = "<group>"; };
 		0CE1A0562BEBCC46008206ED /* CloudBackupSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupSettingsViewModel.swift; sourceTree = "<group>"; };
 		0CE360202C33F398006A6CE4 /* GraphModel+Dijkstra.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphModel+Dijkstra.swift"; sourceTree = "<group>"; };
@@ -18539,6 +18541,7 @@
 				842BDB26278C46EE00AB4B5A /* PolkadotExtensionStates */,
 				842BDB22278C229D00AB4B5A /* DAppBrowserStateDataSource.swift */,
 				840D92A0278D8D6F0007B979 /* DAppBrowserStateError.swift */,
+				0CE164F72DEF1BFB0099FC28 /* DAppBrowserSigningChainResolver.swift */,
 			);
 			path = StateMachine;
 			sourceTree = "<group>";
@@ -32855,6 +32858,7 @@
 				4C4142B4CB2DBCA1F06DC046 /* GovernanceDelegateSetupViewLayout.swift in Sources */,
 				6789ED94EFF73E5B47956462 /* GovernanceDelegateSetupViewFactory.swift in Sources */,
 				4F406ED92AAE2C77E358F49C /* GovernanceDelegateConfirmProtocols.swift in Sources */,
+				0CE164F82DEF1BFB0099FC28 /* DAppBrowserSigningChainResolver.swift in Sources */,
 				0CA7CEF62CE0D35B004328F2 /* PalletAssets+Events.swift in Sources */,
 				0C3205C42A877172002EB914 /* EthereumReducedBlockObject.swift in Sources */,
 				1C9EA26D4E4BA6BAE147B374 /* GovernanceDelegateConfirmWireframe.swift in Sources */,

--- a/novawallet/Common/Crypto/MetaAccountModelType+SignatureFormat.swift
+++ b/novawallet/Common/Crypto/MetaAccountModelType+SignatureFormat.swift
@@ -15,12 +15,10 @@ extension MetaAccountModelType {
 
     var notSupportedRawBytesSigner: NoSigningSupportType? {
         switch self {
-        case .secrets, .watchOnly, .proxied:
+        case .secrets, .watchOnly, .proxied, .polkadotVault:
             return nil
         case .paritySigner:
             return .paritySigner
-        case .polkadotVault:
-            return .polkadotVault
         case .ledger, .genericLedger:
             return .ledger
         }

--- a/novawallet/Modules/DApp/DAppBrowser/StateMachine/DAppBrowserSigningChainResolver.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/StateMachine/DAppBrowserSigningChainResolver.swift
@@ -1,0 +1,85 @@
+import Foundation
+import NovaCrypto
+
+protocol DAppSignBytesChainResolving {
+    func resolveChainForBytesSigning(
+        for address: AccountAddress,
+        wallet: MetaAccountModel,
+        chains: [ChainModel]
+    ) throws -> ChainModel
+}
+
+enum DAppBrowserSigningChainResolverError: Error {
+    case noChainFound
+}
+
+final class DAppSignBytesChainResolver {}
+
+private extension DAppSignBytesChainResolver {
+    func deriveChainForPolkadotVaultWallet(
+        for addressPrefix: UInt16,
+        chains: [ChainModel]
+    ) -> ChainModel? {
+        let prefixMatchingChains = chains.filter { $0.addressPrefix == addressPrefix }
+
+        // there is only one possible chain
+        if let chain = prefixMatchingChains.first, prefixMatchingChains.count == 1 {
+            return chain
+        }
+
+        if addressPrefix == UInt16(SNAddressType.kusamaMain.rawValue) {
+            return chains.first { $0.chainId == KnowChainId.kusama }
+        }
+
+        // either unsupported prefix or more then one chain detected then fallback to polkadot
+        return chains.first { $0.chainId == KnowChainId.polkadot }
+    }
+
+    func deriveChainForWallet(
+        for address: AccountAddress,
+        wallet: MetaAccountModel,
+        chains: [ChainModel]
+    ) throws -> ChainModel? {
+        let accountId = try address.toAccountId()
+        let addressPrefix = try SS58AddressFactory().type(fromAddress: address).uint16Value
+
+        switch wallet.type {
+        case .secrets,
+             .watchOnly,
+             .paritySigner,
+             .ledger,
+             .genericLedger,
+             .proxied:
+            let prefixMatchingChains = chains.filter { $0.addressPrefix == addressPrefix }
+
+            return prefixMatchingChains
+                .sorted { $0.order < $1.order }
+                .first { wallet.fetch(for: $0.accountRequest())?.accountId == accountId }
+        case .polkadotVault:
+            let walletMatchingChains = chains.filter {
+                wallet.fetch(for: $0.accountRequest())?.accountId == accountId
+            }
+
+            return deriveChainForPolkadotVaultWallet(for: addressPrefix, chains: walletMatchingChains)
+        }
+    }
+}
+
+extension DAppSignBytesChainResolver: DAppSignBytesChainResolving {
+    func resolveChainForBytesSigning(
+        for address: AccountAddress,
+        wallet: MetaAccountModel,
+        chains: [ChainModel]
+    ) throws -> ChainModel {
+        guard
+            let chain = try deriveChainForWallet(
+                for: address,
+                wallet: wallet,
+                chains: chains
+            ) else {
+            throw DAppBrowserSigningChainResolverError.noChainFound
+        }
+
+        return chain
+    }
+}

--- a/novawallet/Modules/DApp/DAppBrowser/StateMachine/DAppBrowserStateDataSource.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/StateMachine/DAppBrowserStateDataSource.swift
@@ -5,6 +5,8 @@ import BigInt
 final class DAppBrowserStateDataSource {
     private(set) var chainStore: [String: ChainModel] = [:]
     private(set) var metadataStore: [String: PolkadotExtensionMetadata] = [:]
+    let signBytesChainResolver = DAppSignBytesChainResolver()
+
     let wallet: MetaAccountModel
     let chainRegistry: ChainRegistryProtocol
     let dAppSettingsRepository: AnyDataProviderRepository<DAppSettings>
@@ -132,6 +134,14 @@ final class DAppBrowserStateDataSource {
         addresses.append(contentsOf: chainAddresses)
 
         return addresses
+    }
+
+    func resolveSignBytesChain(for address: AccountAddress) throws -> ChainModel {
+        try signBytesChainResolver.resolveChainForBytesSigning(
+            for: address,
+            wallet: wallet,
+            chains: Array(chainStore.values)
+        )
     }
 
     private func createExtensionAccount(

--- a/novawallet/Modules/DApp/DAppBrowser/StateMachine/PolkadotExtensionStates/DAppBrowserSigningState.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/StateMachine/PolkadotExtensionStates/DAppBrowserSigningState.swift
@@ -20,10 +20,6 @@ final class DAppBrowserSigningState: DAppBrowserBaseState {
         modifiedTransaction: Data?,
         nextState: DAppBrowserStateProtocol
     ) throws {
-        guard let msgType = signingType.msgType else {
-            return
-        }
-
         let identifier = (0 ... UInt32.max).randomElement() ?? 0
         let result = PolkadotExtensionSignerResult(
             identifier: UInt(identifier),
@@ -38,10 +34,6 @@ final class DAppBrowserSigningState: DAppBrowserBaseState {
         _ error: PolkadotExtensionError,
         nextState: DAppBrowserStateProtocol
     ) {
-        guard let msgType = signingType.msgType else {
-            return
-        }
-
         provideError(for: requestId, errorMessage: error.rawValue, nextState: nextState)
     }
 }

--- a/novawallet/Modules/ParitySigner/TransactionQr/ParitySignerTxQrPresenter.swift
+++ b/novawallet/Modules/ParitySigner/TransactionQr/ParitySignerTxQrPresenter.swift
@@ -84,7 +84,7 @@ final class ParitySignerTxQrPresenter {
                 view?.didReceiveQrFormat(viewModel: .new)
             case .extrinsicWithoutProof:
                 view?.didReceiveQrFormat(viewModel: .legacy)
-            case nil, .rawBytes:
+            case .rawBytes:
                 view?.didReceiveQrFormat(viewModel: .none)
             }
         } else {


### PR DESCRIPTION
## Purpose

The PR introduces support for byte signing with Polkadot Vault wallet. As we don't store information about the chain the wallet created for we try to derive it from address prefix in the `DAppSignBytesChainResolver`


https://github.com/user-attachments/assets/c2fc07c5-3700-4a19-a9a8-b2a6290ef3d2

