### PR TITLE
Restore asset receive when retrying the swap

### DIFF
--- a/novawallet/Modules/Swaps/Setup/SwapSetupPresenter.swift
+++ b/novawallet/Modules/Swaps/Setup/SwapSetupPresenter.swift
@@ -644,6 +644,7 @@ extension SwapSetupPresenter: SwapSetupPresenterProtocol {
         interactor.setup()
         interactor.update(payChainAsset: payChainAsset)
         interactor.update(feeChainAsset: feeChainAsset)
+        interactor.update(receiveChainAsset: receiveChainAsset)
 
         if let amount = initState.amount, let direction = initState.direction {
             switch direction {


### PR DESCRIPTION
## Purpose

The PR fixes the issue when the receive token is not set after swap retry