### PR TITLE
Forbid insufficient assets for non single paths &8699cj7mb

### DIFF
--- a/novawallet/Common/Services/AssetExchange/AssetExchangePathFilter.swift
+++ b/novawallet/Common/Services/AssetExchange/AssetExchangePathFilter.swift
@@ -41,7 +41,13 @@ extension AssetExchangePathFilter: GraphEdgeFiltering {
             return true
         }
 
-        if !sufficiencyProvider.isSufficient(chainAsset: chainAssetOut) {
+        let isAssetInSufficient = sufficiencyProvider.isSufficient(chainAsset: chainAssetIn)
+        let isAssetOutSufficient = sufficiencyProvider.isSufficient(chainAsset: chainAssetOut)
+
+        let anyInsufficientAsset = !isAssetInSufficient || !isAssetOutSufficient
+
+        // reject any path with len > 1 that includes insufficient asset
+        if anyInsufficientAsset {
             return false
         }
 


### PR DESCRIPTION
## Purpose

The PR fixes an issue where non sufficient assets can be transfered via xcm as first swap segment. As the result assets might be trapped. The PR introduces constraints that forbid any non single segment paths containing insufficient asset