### PR TITLE
[8699byy4q] Not adding discovered ms wallet after Cloud backup import

### DIFF
--- a/novawallet/Common/Helpers/ChainAccountFetching.swift
+++ b/novawallet/Common/Helpers/ChainAccountFetching.swift
@@ -321,9 +321,9 @@ extension MetaAccountModel {
 
     func has(accountId: AccountId, chainId: ChainModel.Id) -> Bool {
         if let chainAccount = chainAccounts.first(where: { $0.chainId == chainId }) {
-            return chainAccount.accountId == accountId
+            chainAccount.accountId == accountId
         } else {
-            return substrateAccountId == accountId || ethereumAddress == accountId
+            substrateAccountId == accountId || ethereumAddress == accountId
         }
     }
 }

--- a/novawallet/Common/Helpers/MetaAccountModel+Delegated.swift
+++ b/novawallet/Common/Helpers/MetaAccountModel+Delegated.swift
@@ -71,9 +71,7 @@ extension MetaAccountModel {
         case let .universal(multisig):
             multisig.signatory == substrateAccountId || multisig.signatory == ethereumAddress
         case let .singleChain(chainAccount):
-            chainAccounts.contains {
-                $0.chainId == chainAccount.chainId && $0.accountId == chainAccount.multisig?.signatory
-            }
+            has(accountId: chainAccount.accountId, chainId: chainAccount.chainId)
         }
     }
 


### PR DESCRIPTION
### SUMMARY

Since we can have a signatory account both as a meta account and as a chain account in another meta account at the same time, it will be discovered as a single chain multisig. In this case, the isSignatory method should check for both even if the multisig is single chain.