### PR TITLE
Fix signatory matching

### DIFF
--- a/novawallet/Common/Helpers/MetaAccountModel+Delegated.swift
+++ b/novawallet/Common/Helpers/MetaAccountModel+Delegated.swift
@@ -69,9 +69,11 @@ extension MetaAccountModel {
     func isSignatory(for multisig: MultisigAccountType) -> Bool {
         switch multisig {
         case let .universal(multisig):
-            multisig.signatory == substrateAccountId || multisig.signatory == ethereumAddress
+            return multisig.signatory == substrateAccountId || multisig.signatory == ethereumAddress
         case let .singleChain(chainAccount):
-            has(accountId: chainAccount.accountId, chainId: chainAccount.chainId)
+            guard let multisig = chainAccount.multisig else { return false }
+
+            return has(accountId: multisig.signatory, chainId: chainAccount.chainId)
         }
     }
 


### PR DESCRIPTION
### SUMMARY

The PR fixes the typo when passing an accountId to match the signatory meta account for multisig.