### PR TITLE
Allow only one segment swaps for wallets for multisigs

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -315,6 +315,8 @@
 		0C21D7802AB432B100EB2DBD /* MainTabBarIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C21D77F2AB432B100EB2DBD /* MainTabBarIndex.swift */; };
 		0C2200692ACA80BB0067BA61 /* AssetHubSwapQuoteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2200682ACA80BB0067BA61 /* AssetHubSwapQuoteBuilder.swift */; };
 		0C22006E2ACAAC2F0067BA61 /* AssetConversionPallet+Call.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C22006D2ACAAC2F0067BA61 /* AssetConversionPallet+Call.swift */; };
+		0C2285CD2E20F5720093FD44 /* Staking+Hold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2285CC2E20F5720093FD44 /* Staking+Hold.swift */; };
+		0C2285D12E21060B0093FD44 /* Staking+Amount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2285D02E21060B0093FD44 /* Staking+Amount.swift */; };
 		0C2285D32E2110420093FD44 /* MultisigFeeValidationViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2285D22E2110420093FD44 /* MultisigFeeValidationViewFactory.swift */; };
 		0C2285D52E2110C60093FD44 /* DelegatedSignFeeValidationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2285D42E2110C60093FD44 /* DelegatedSignFeeValidationFactory.swift */; };
 		0C2285D72E2111FF0093FD44 /* MultisigSignValidationWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2285D62E2111FF0093FD44 /* MultisigSignValidationWireframe.swift */; };
@@ -324,8 +326,6 @@
 		0C2285E02E23E0140093FD44 /* DelegationResolutionPathResult+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2285DF2E23E0140093FD44 /* DelegationResolutionPathResult+Search.swift */; };
 		0C2285E22E23E14E0093FD44 /* ProxyResolutionCallWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2285E12E23E14E0093FD44 /* ProxyResolutionCallWrapper.swift */; };
 		0C2285E42E244D1E0093FD44 /* DelegationCallWrapperFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2285E32E244D1E0093FD44 /* DelegationCallWrapperFactory.swift */; };
-		0C2285CD2E20F5720093FD44 /* Staking+Hold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2285CC2E20F5720093FD44 /* Staking+Hold.swift */; };
-		0C2285D12E21060B0093FD44 /* Staking+Amount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2285D02E21060B0093FD44 /* Staking+Amount.swift */; };
 		0C23529E2BCCDFC2004D2548 /* CloudBackupFileModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C23529D2BCCDFC2004D2548 /* CloudBackupFileModel.swift */; };
 		0C2352A02BCCEAC0004D2548 /* CloudBackupFileModelConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C23529F2BCCEAC0004D2548 /* CloudBackupFileModelConverter.swift */; };
 		0C252BBF2B3D3CEB0047308F /* TypeRegistry+Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C252BBE2B3D3CEB0047308F /* TypeRegistry+Node.swift */; };
@@ -1078,6 +1078,8 @@
 		0CD8463F2BE20CF20026B5CA /* AvailSignedExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD8463E2BE20CF20026B5CA /* AvailSignedExtension.swift */; };
 		0CD846412BE25ECA0026B5CA /* ExtrinsicSignedExtensionFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD846402BE25ECA0026B5CA /* ExtrinsicSignedExtensionFacade.swift */; };
 		0CD846432BE352D10026B5CA /* PreferredValidatorsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD846422BE352D10026B5CA /* PreferredValidatorsProvider.swift */; };
+		0CD9801F2E268ED0005251E1 /* WalletDelayedExecutionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD9801E2E268ED0005251E1 /* WalletDelayedExecutionRepository.swift */; };
+		0CD980212E268F35005251E1 /* WalletDelayedExecution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD980202E268F35005251E1 /* WalletDelayedExecution.swift */; };
 		0CDEF1642C27E578003878F2 /* ExtrinsicProofOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEF1632C27E578003878F2 /* ExtrinsicProofOperationFactory.swift */; };
 		0CDEF1662C27EC83003878F2 /* RuntimeMetadataRepositoryFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEF1652C27EC83003878F2 /* RuntimeMetadataRepositoryFactory.swift */; };
 		0CE150502A6FAC1200B61CC1 /* NominationPoolsPoolSubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE1504F2A6FAC1200B61CC1 /* NominationPoolsPoolSubscriptionService.swift */; };
@@ -6343,6 +6345,8 @@
 		0C21D77F2AB432B100EB2DBD /* MainTabBarIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarIndex.swift; sourceTree = "<group>"; };
 		0C2200682ACA80BB0067BA61 /* AssetHubSwapQuoteBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetHubSwapQuoteBuilder.swift; sourceTree = "<group>"; };
 		0C22006D2ACAAC2F0067BA61 /* AssetConversionPallet+Call.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssetConversionPallet+Call.swift"; sourceTree = "<group>"; };
+		0C2285CC2E20F5720093FD44 /* Staking+Hold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Staking+Hold.swift"; sourceTree = "<group>"; };
+		0C2285D02E21060B0093FD44 /* Staking+Amount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Staking+Amount.swift"; sourceTree = "<group>"; };
 		0C2285D22E2110420093FD44 /* MultisigFeeValidationViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultisigFeeValidationViewFactory.swift; sourceTree = "<group>"; };
 		0C2285D42E2110C60093FD44 /* DelegatedSignFeeValidationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegatedSignFeeValidationFactory.swift; sourceTree = "<group>"; };
 		0C2285D62E2111FF0093FD44 /* MultisigSignValidationWireframe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultisigSignValidationWireframe.swift; sourceTree = "<group>"; };
@@ -6352,8 +6356,6 @@
 		0C2285DF2E23E0140093FD44 /* DelegationResolutionPathResult+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DelegationResolutionPathResult+Search.swift"; sourceTree = "<group>"; };
 		0C2285E12E23E14E0093FD44 /* ProxyResolutionCallWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyResolutionCallWrapper.swift; sourceTree = "<group>"; };
 		0C2285E32E244D1E0093FD44 /* DelegationCallWrapperFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegationCallWrapperFactory.swift; sourceTree = "<group>"; };
-		0C2285CC2E20F5720093FD44 /* Staking+Hold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Staking+Hold.swift"; sourceTree = "<group>"; };
-		0C2285D02E21060B0093FD44 /* Staking+Amount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Staking+Amount.swift"; sourceTree = "<group>"; };
 		0C23529D2BCCDFC2004D2548 /* CloudBackupFileModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupFileModel.swift; sourceTree = "<group>"; };
 		0C23529F2BCCEAC0004D2548 /* CloudBackupFileModelConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupFileModelConverter.swift; sourceTree = "<group>"; };
 		0C2437D345C3D9B12AEE1E28 /* ParaStkYieldBoostSetupProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParaStkYieldBoostSetupProtocols.swift; sourceTree = "<group>"; };
@@ -7144,6 +7146,8 @@
 		0CD8463E2BE20CF20026B5CA /* AvailSignedExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailSignedExtension.swift; sourceTree = "<group>"; };
 		0CD846402BE25ECA0026B5CA /* ExtrinsicSignedExtensionFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrinsicSignedExtensionFacade.swift; sourceTree = "<group>"; };
 		0CD846422BE352D10026B5CA /* PreferredValidatorsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferredValidatorsProvider.swift; sourceTree = "<group>"; };
+		0CD9801E2E268ED0005251E1 /* WalletDelayedExecutionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletDelayedExecutionRepository.swift; sourceTree = "<group>"; };
+		0CD980202E268F35005251E1 /* WalletDelayedExecution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletDelayedExecution.swift; sourceTree = "<group>"; };
 		0CDEF1632C27E578003878F2 /* ExtrinsicProofOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrinsicProofOperationFactory.swift; sourceTree = "<group>"; };
 		0CDEF1652C27EC83003878F2 /* RuntimeMetadataRepositoryFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeMetadataRepositoryFactory.swift; sourceTree = "<group>"; };
 		0CDFFCC54A504417F4ACE7AA /* NftListInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NftListInteractor.swift; sourceTree = "<group>"; };
@@ -14801,6 +14805,15 @@
 			path = Onboarding;
 			sourceTree = "<group>";
 		};
+		0CD9801D2E268EA4005251E1 /* WalletDelayedExecution */ = {
+			isa = PBXGroup;
+			children = (
+				0CD9801E2E268ED0005251E1 /* WalletDelayedExecutionRepository.swift */,
+				0CD980202E268F35005251E1 /* WalletDelayedExecution.swift */,
+			);
+			path = WalletDelayedExecution;
+			sourceTree = "<group>";
+		};
 		0CE1A0502BE9E97C008206ED /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -19085,6 +19098,7 @@
 		84155DE8253980D700A27058 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				0CD9801D2E268EA4005251E1 /* WalletDelayedExecution */,
 				0C521C0E2E1728C500ABAC97 /* CallFormatting */,
 				2D32D7322DCBBF490016354C /* DelegatedAccounts */,
 				0C0CB37C2AC5408000EAC516 /* AssetConversion */,
@@ -33314,6 +33328,7 @@
 				C32B85D65D0290A577BFC85F /* ParaStkRebondViewFactory.swift in Sources */,
 				8490110F29E5A4F4005D688B /* URIQRMatcher.swift in Sources */,
 				912ECC319A48CAD09FB694AC /* AssetsSearchProtocols.swift in Sources */,
+				0CD9801F2E268ED0005251E1 /* WalletDelayedExecutionRepository.swift in Sources */,
 				77895CA12A8F7360006870FB /* NominationPoolSearchOperationFactory.swift in Sources */,
 				8456D2C12993EE9F00D159A7 /* GovernanceDelegateStackCell.swift in Sources */,
 				8582395FEF296771447439FF /* AssetsSearchWireframe.swift in Sources */,
@@ -33762,6 +33777,7 @@
 				2DF95D2D2D785DA2001D8785 /* HapticPlayer.swift in Sources */,
 				7796C7032A17846B00D56094 /* EmptyCellContentView.swift in Sources */,
 				B8349266F061AEFFA9802237 /* TokenManageSingleViewController.swift in Sources */,
+				0CD980212E268F35005251E1 /* WalletDelayedExecution.swift in Sources */,
 				D9746967761B1B4772A562B2 /* TokenManageSingleViewLayout.swift in Sources */,
 				0C7C88662A95030800DD96A1 /* SubqueryStakingType.swift in Sources */,
 				0C85F5C12E140D12003789DC /* MultisigSignatoryRepository.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1084,6 +1084,7 @@
 		0CD980242E26AE76005251E1 /* MetaAccountModel+Extrinsic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD980222E26AE76005251E1 /* MetaAccountModel+Extrinsic.swift */; };
 		0CD980262E26D2C5005251E1 /* NotDelegatedCallDelayedExecVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD980252E26D2C5005251E1 /* NotDelegatedCallDelayedExecVerifier.swift */; };
 		0CD980282E26D462005251E1 /* WalletDelayedExecutionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD980272E26D462005251E1 /* WalletDelayedExecutionProvider.swift */; };
+		0CD9802A2E27883A005251E1 /* AssetExchangeFee+InitialAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD980292E27883A005251E1 /* AssetExchangeFee+InitialAmount.swift */; };
 		0CDEF1642C27E578003878F2 /* ExtrinsicProofOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEF1632C27E578003878F2 /* ExtrinsicProofOperationFactory.swift */; };
 		0CDEF1662C27EC83003878F2 /* RuntimeMetadataRepositoryFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEF1652C27EC83003878F2 /* RuntimeMetadataRepositoryFactory.swift */; };
 		0CE150502A6FAC1200B61CC1 /* NominationPoolsPoolSubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE1504F2A6FAC1200B61CC1 /* NominationPoolsPoolSubscriptionService.swift */; };
@@ -7155,6 +7156,7 @@
 		0CD980222E26AE76005251E1 /* MetaAccountModel+Extrinsic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MetaAccountModel+Extrinsic.swift"; sourceTree = "<group>"; };
 		0CD980252E26D2C5005251E1 /* NotDelegatedCallDelayedExecVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotDelegatedCallDelayedExecVerifier.swift; sourceTree = "<group>"; };
 		0CD980272E26D462005251E1 /* WalletDelayedExecutionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletDelayedExecutionProvider.swift; sourceTree = "<group>"; };
+		0CD980292E27883A005251E1 /* AssetExchangeFee+InitialAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssetExchangeFee+InitialAmount.swift"; sourceTree = "<group>"; };
 		0CDEF1632C27E578003878F2 /* ExtrinsicProofOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrinsicProofOperationFactory.swift; sourceTree = "<group>"; };
 		0CDEF1652C27EC83003878F2 /* RuntimeMetadataRepositoryFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeMetadataRepositoryFactory.swift; sourceTree = "<group>"; };
 		0CDFFCC54A504417F4ACE7AA /* NftListInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NftListInteractor.swift; sourceTree = "<group>"; };
@@ -14053,6 +14055,7 @@
 				0C2DA8A72CC2679E001F79C8 /* AssetsExchangeGraph.swift */,
 				0C11D85D2CCA470D003EC46D /* AssetsExchangeRouteManager.swift */,
 				0C746DBB2CCE5E9900E9178B /* AssetExchangeExecutionManager.swift */,
+				0CD980292E27883A005251E1 /* AssetExchangeFee+InitialAmount.swift */,
 				0C6108482CD889A000909928 /* AssetsExchange.swift */,
 				0C61084A2CD88F9B00909928 /* AssetsExchangeService.swift */,
 				0C2A3C922CDC813B00A0E2B3 /* AssetsExchangeOperationFactory.swift */,
@@ -33415,6 +33418,7 @@
 				1812D5012A1765CB38D32A4A /* WalletsListPresenter.swift in Sources */,
 				A265CC9857E951EB71E5E831 /* WalletsListInteractor.swift in Sources */,
 				28B4C94DBAF461CBF18B1B63 /* WalletsListViewController.swift in Sources */,
+				0CD9802A2E27883A005251E1 /* AssetExchangeFee+InitialAmount.swift in Sources */,
 				0C27F3822DA6C74100191FFF /* SystePallet+ConstantPath.swift in Sources */,
 				77C9BCC42ACD570100022EA2 /* SwapAssetsOperationInteractor.swift in Sources */,
 				233CB11F486DE1953D977295 /* WalletsListViewLayout.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1080,6 +1080,10 @@
 		0CD846432BE352D10026B5CA /* PreferredValidatorsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD846422BE352D10026B5CA /* PreferredValidatorsProvider.swift */; };
 		0CD9801F2E268ED0005251E1 /* WalletDelayedExecutionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD9801E2E268ED0005251E1 /* WalletDelayedExecutionRepository.swift */; };
 		0CD980212E268F35005251E1 /* WalletDelayedExecution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD980202E268F35005251E1 /* WalletDelayedExecution.swift */; };
+		0CD980232E26AE76005251E1 /* MetaAccountModel+Extrinsic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD980222E26AE76005251E1 /* MetaAccountModel+Extrinsic.swift */; };
+		0CD980242E26AE76005251E1 /* MetaAccountModel+Extrinsic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD980222E26AE76005251E1 /* MetaAccountModel+Extrinsic.swift */; };
+		0CD980262E26D2C5005251E1 /* NotDelegatedCallDelayedExecVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD980252E26D2C5005251E1 /* NotDelegatedCallDelayedExecVerifier.swift */; };
+		0CD980282E26D462005251E1 /* WalletDelayedExecutionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD980272E26D462005251E1 /* WalletDelayedExecutionProvider.swift */; };
 		0CDEF1642C27E578003878F2 /* ExtrinsicProofOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEF1632C27E578003878F2 /* ExtrinsicProofOperationFactory.swift */; };
 		0CDEF1662C27EC83003878F2 /* RuntimeMetadataRepositoryFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEF1652C27EC83003878F2 /* RuntimeMetadataRepositoryFactory.swift */; };
 		0CE150502A6FAC1200B61CC1 /* NominationPoolsPoolSubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE1504F2A6FAC1200B61CC1 /* NominationPoolsPoolSubscriptionService.swift */; };
@@ -7148,6 +7152,9 @@
 		0CD846422BE352D10026B5CA /* PreferredValidatorsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferredValidatorsProvider.swift; sourceTree = "<group>"; };
 		0CD9801E2E268ED0005251E1 /* WalletDelayedExecutionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletDelayedExecutionRepository.swift; sourceTree = "<group>"; };
 		0CD980202E268F35005251E1 /* WalletDelayedExecution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletDelayedExecution.swift; sourceTree = "<group>"; };
+		0CD980222E26AE76005251E1 /* MetaAccountModel+Extrinsic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MetaAccountModel+Extrinsic.swift"; sourceTree = "<group>"; };
+		0CD980252E26D2C5005251E1 /* NotDelegatedCallDelayedExecVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotDelegatedCallDelayedExecVerifier.swift; sourceTree = "<group>"; };
+		0CD980272E26D462005251E1 /* WalletDelayedExecutionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletDelayedExecutionProvider.swift; sourceTree = "<group>"; };
 		0CDEF1632C27E578003878F2 /* ExtrinsicProofOperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrinsicProofOperationFactory.swift; sourceTree = "<group>"; };
 		0CDEF1652C27EC83003878F2 /* RuntimeMetadataRepositoryFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeMetadataRepositoryFactory.swift; sourceTree = "<group>"; };
 		0CDFFCC54A504417F4ACE7AA /* NftListInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NftListInteractor.swift; sourceTree = "<group>"; };
@@ -14810,6 +14817,8 @@
 			children = (
 				0CD9801E2E268ED0005251E1 /* WalletDelayedExecutionRepository.swift */,
 				0CD980202E268F35005251E1 /* WalletDelayedExecution.swift */,
+				0CD980252E26D2C5005251E1 /* NotDelegatedCallDelayedExecVerifier.swift */,
+				0CD980272E26D462005251E1 /* WalletDelayedExecutionProvider.swift */,
 			);
 			path = WalletDelayedExecution;
 			sourceTree = "<group>";
@@ -24134,6 +24143,7 @@
 				0C37AFC72B59815500009ECA /* ProxiedSettings.swift */,
 				0CE9338D2C019998000F3EFE /* MetaAccountModelType+ExtrinsicLimit.swift */,
 				0CCA70742CD0B2860082A9C8 /* MetaAccountModel+Async.swift */,
+				0CD980222E26AE76005251E1 /* MetaAccountModel+Extrinsic.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -29062,6 +29072,7 @@
 				0CCD18AF2BA175540068D73A /* NotificationContentResult+UserContent.swift in Sources */,
 				77AE4F972B905B4D00426519 /* ChainModel.swift in Sources */,
 				2D6CC26B2DD2836600FF5FA8 /* MetaAccountModel+Delegated.swift in Sources */,
+				0CD980242E26AE76005251E1 /* MetaAccountModel+Extrinsic.swift in Sources */,
 				2DC694482DF2EEC7004F4584 /* AccountId+Dummy.swift in Sources */,
 				0CEBAD512D5C7433000EBA45 /* Decimal+Conversion.swift in Sources */,
 				778215DD2B95AD8F006C7D13 /* NewReferendumHandler.swift in Sources */,
@@ -30280,6 +30291,7 @@
 				849014DC24AA8F60008F705E /* MainTabBarPresenter.swift in Sources */,
 				8467F4C526B1E4E200C5B6F4 /* StakingDurationFetching.swift in Sources */,
 				2D6C5FA32CF30C25000D106C /* PersistentTabLocalSubscriptionFactory.swift in Sources */,
+				0CD980282E26D462005251E1 /* WalletDelayedExecutionProvider.swift in Sources */,
 				F4A6C9E4265283EB00FABF98 /* StakingStateViewModelFactory+Alerts.swift in Sources */,
 				844ADE8028CB35EC00EE29F7 /* AutomationTimeCancelTask.swift in Sources */,
 				8422F2F02888193F00C7B840 /* UsernameViewModel+Handler.swift in Sources */,
@@ -33621,6 +33633,7 @@
 				2D65F6C92CCED77200CC6F72 /* SwapOperationNetworkListPresenter.swift in Sources */,
 				8F131D86B269B7FAB96CF3B5 /* ParaStkYieldBoostStartWireframe.swift in Sources */,
 				84C1DBBE29C2615F00F295A5 /* InflationCurveRewardConfig.swift in Sources */,
+				0CD980262E26D2C5005251E1 /* NotDelegatedCallDelayedExecVerifier.swift in Sources */,
 				EEDDE41F8445C0CB2E99AFE4 /* ParaStkYieldBoostStartPresenter.swift in Sources */,
 				0C1E331C2D955D0D0070D772 /* ParitySignerTxQrSetupModel.swift in Sources */,
 				84A1742728ED607B0096F943 /* GovernanceOperationProtocols.swift in Sources */,
@@ -34343,6 +34356,7 @@
 				EC606EEBC39CF643AB753ACD /* NotificationsSetupWireframe.swift in Sources */,
 				1A07FDE443FBF49FFEB451FD /* NotificationsSetupPresenter.swift in Sources */,
 				2327570CCE0B64B88A65F121 /* NotificationsSetupInteractor.swift in Sources */,
+				0CD980232E26AE76005251E1 /* MetaAccountModel+Extrinsic.swift in Sources */,
 				ADB55B4083B049CD7ED51F8A /* NotificationsSetupViewController.swift in Sources */,
 				91E4653DFEDBE6605E241144 /* NotificationsSetupViewLayout.swift in Sources */,
 				6688EC06E774363AA868498F /* NotificationsSetupViewFactory.swift in Sources */,

--- a/novawallet/Common/Helpers/ChainAccountFetching.swift
+++ b/novawallet/Common/Helpers/ChainAccountFetching.swift
@@ -5,6 +5,7 @@ struct ChainAccountRequest {
     let addressPrefix: ChainModel.AddressPrefix
     let isEthereumBased: Bool
     let supportsGenericLedger: Bool
+    let supportsMultisigs: Bool
 }
 
 struct ChainAccountResponse {
@@ -178,8 +179,14 @@ extension MetaAccountModel {
             } else {
                 return nil
             }
-        case .secrets, .ledger, .paritySigner, .polkadotVault, .proxied, .watchOnly, .multisig:
+        case .secrets, .ledger, .paritySigner, .polkadotVault, .proxied, .watchOnly:
             return executeFetch(request: request)
+        case .multisig:
+            if request.supportsMultisigs {
+                return executeFetch(request: request)
+            } else {
+                return nil
+            }
         }
     }
 
@@ -336,7 +343,8 @@ extension ChainModel {
             chainId: chainId,
             addressPrefix: addressPrefix,
             isEthereumBased: isEthereumBased,
-            supportsGenericLedger: supportsGenericLedgerApp
+            supportsGenericLedger: supportsGenericLedgerApp,
+            supportsMultisigs: hasMultisig
         )
     }
 

--- a/novawallet/Common/Helpers/ChainAccountFetching.swift
+++ b/novawallet/Common/Helpers/ChainAccountFetching.swift
@@ -44,6 +44,10 @@ struct MetaAccountDelegationId: Hashable {
     let delegatorId: AccountId
     let chainId: ChainModel.Id?
     let delegationType: DelegationType
+
+    func existsInChainWithId(_ identifier: ChainModel.Id) -> Bool {
+        chainId == nil || chainId == identifier
+    }
 }
 
 enum ChainAccountFetchingError: Error {

--- a/novawallet/Common/Helpers/MetaAccountModel+Delegated.swift
+++ b/novawallet/Common/Helpers/MetaAccountModel+Delegated.swift
@@ -12,6 +12,22 @@ extension MetaAccountModel {
         }
     }
 
+    func getMultisig(for chain: ChainModel) -> DelegatedAccount.MultisigAccountModel? {
+        guard let multisig else {
+            return chainAccounts.first {
+                $0.multisig != nil && $0.chainId == chain.chainId
+            }?.multisig
+        }
+
+        if !chain.isEthereumBased, substrateAccountId != nil {
+            return multisig
+        } else if chain.isEthereumBased, ethereumAddress != nil {
+            return multisig
+        } else {
+            return nil
+        }
+    }
+
     var proxy: DelegatedAccount.ProxyAccountModel? {
         guard type == .proxied,
               let chainAccount = chainAccounts.first(where: { $0.proxy != nil }) else {
@@ -95,7 +111,7 @@ extension MetaAccountModel {
     func delegatedAccountStatus() -> DelegatedAccount.Status? {
         if let proxyAccount = proxy {
             proxyAccount.status
-        } else if let multisigAccount = multisigAccount?.multisig {
+        } else if let multisigAccount = multisigAccount?.anyChainMultisig {
             multisigAccount.status
         } else {
             nil
@@ -108,8 +124,7 @@ extension MetaAccountModel {
         case universal(multisig: DelegatedAccount.MultisigAccountModel)
         case singleChain(chainAccount: ChainAccountModel)
 
-        // TODO: Should depend on chain otherwise there might be misuse across multiple chains
-        var multisig: DelegatedAccount.MultisigAccountModel? {
+        var anyChainMultisig: DelegatedAccount.MultisigAccountModel? {
             switch self {
             case let .universal(multisig):
                 multisig

--- a/novawallet/Common/Model/ChainRegistry/Account/MetaAccountModel+Extrinsic.swift
+++ b/novawallet/Common/Model/ChainRegistry/Account/MetaAccountModel+Extrinsic.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension MetaAccountModel {
+    func delaysCallExecution(in chain: ChainModel) -> Bool {
+        guard let multisig = getMultisig(for: chain) else { return false }
+
+        return multisig.threshold > 1
+    }
+}

--- a/novawallet/Common/Model/ChainRegistry/Account/MetaAccountModelType+ExtrinsicLimit.swift
+++ b/novawallet/Common/Model/ChainRegistry/Account/MetaAccountModelType+ExtrinsicLimit.swift
@@ -10,4 +10,13 @@ extension MetaAccountModelType {
             return nil
         }
     }
+
+    var delaysExtrinsicCallExecution: Bool {
+        switch self {
+        case .secrets, .watchOnly, .paritySigner, .ledger, .polkadotVault, .genericLedger, .proxied:
+            false
+        case .multisig:
+            true
+        }
+    }
 }

--- a/novawallet/Common/Services/AssetExchange/AssetExchangeExecutionManager.swift
+++ b/novawallet/Common/Services/AssetExchange/AssetExchangeExecutionManager.swift
@@ -47,19 +47,9 @@ final class AssetExchangeExecutionManager {
 
     private func startFirstSegmentExecution() {
         do {
-            guard
-                let firstSegment = fee.route.items.first,
-                let firstFees = fee.operationFees.first else {
-                throw AssetExchangeExecutionManagerError.invalidRouteDetails
-            }
+            let initialAmount = try fee.getInitialAmountIn()
 
-            let amountIn = firstSegment.amountIn(for: fee.route.direction)
-            let amountInWithFee = amountIn + fee.intermediateFeesInAssetIn
-
-            let holdingFee = try firstFees.totalToPayFromAmountEnsuring(asset: firstSegment.edge.origin)
-            let amountInWithHolding = amountInWithFee + holdingFee
-
-            executeSegment(at: 0, amountIn: amountInWithHolding)
+            executeSegment(at: 0, amountIn: initialAmount)
         } catch {
             logger.error("Failed first segment processing: \(error)")
             complete(with: .failure(error))

--- a/novawallet/Common/Services/AssetExchange/AssetExchangeFee+InitialAmount.swift
+++ b/novawallet/Common/Services/AssetExchange/AssetExchangeFee+InitialAmount.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension AssetExchangeFee {
+    func getInitialAmountIn() throws -> Balance {
+        guard
+            let firstSegment = route.items.first,
+            let firstFees = operationFees.first else {
+            throw AssetExchangeFeeError.mismatchBetweenFeeAndRoute
+        }
+
+        let amountIn = firstSegment.amountIn(for: route.direction)
+        let amountInWithFee = amountIn + intermediateFeesInAssetIn
+
+        let holdingFee = try firstFees.totalToPayFromAmountEnsuring(asset: firstSegment.edge.origin)
+        return amountInWithFee + holdingFee
+    }
+}

--- a/novawallet/Common/Services/AssetExchange/AssetExchangePathFilter.swift
+++ b/novawallet/Common/Services/AssetExchange/AssetExchangePathFilter.swift
@@ -7,17 +7,20 @@ final class AssetExchangePathFilter {
     let chainRegistry: ChainRegistryProtocol
     let sufficiencyProvider: AssetExchangeSufficiencyProviding
     let feeSupport: AssetExchangeFeeSupporting
+    let delayedCallExecVerifier: WalletDelayedExecVerifing
 
     init(
         selectedWallet: MetaAccountModel,
         chainRegistry: ChainRegistryProtocol,
         sufficiencyProvider: AssetExchangeSufficiencyProviding,
-        feeSupport: AssetExchangeFeeSupporting
+        feeSupport: AssetExchangeFeeSupporting,
+        delayedCallExecVerifier: WalletDelayedExecVerifing
     ) {
         self.selectedWallet = selectedWallet
         self.chainRegistry = chainRegistry
         self.sufficiencyProvider = sufficiencyProvider
         self.feeSupport = feeSupport
+        self.delayedCallExecVerifier = delayedCallExecVerifier
     }
 }
 
@@ -39,6 +42,14 @@ extension AssetExchangePathFilter: GraphEdgeFiltering {
         // first segment always allowed
         guard let predecessor else {
             return true
+        }
+
+        // if call execution is delayed then allow only one segmented paths
+        guard !delayedCallExecVerifier.executesCallWithDelay(
+            selectedWallet,
+            chain: chainIn
+        ) else {
+            return false
         }
 
         let isAssetInSufficient = sufficiencyProvider.isSufficient(chainAsset: chainAssetIn)

--- a/novawallet/Common/Services/AssetExchange/AssetsExchangeService.swift
+++ b/novawallet/Common/Services/AssetExchange/AssetsExchangeService.swift
@@ -16,6 +16,10 @@ protocol AssetsExchangeServiceProtocol: ApplicationServiceProtocol {
         operationStartClosure: @escaping (Int) -> Void
     ) -> CompoundOperationWrapper<Balance>
 
+    func submitSingleOperationWrapper(
+        using estimation: AssetExchangeFee
+    ) -> CompoundOperationWrapper<Void>
+
     func subscribeRequoteService(
         for target: AnyObject,
         ignoreIfAlreadyAdded: Bool,
@@ -139,6 +143,14 @@ extension AssetsExchangeService: AssetsExchangeServiceProtocol {
                 notifyingIn: queue,
                 operationStartClosure: operationStartClosure
             )
+        }
+    }
+
+    func submitSingleOperationWrapper(
+        using estimation: AssetExchangeFee
+    ) -> CompoundOperationWrapper<Void> {
+        prepareWrapper {
+            $0.createSingleOperationSubmitWrapper(for: estimation)
         }
     }
 

--- a/novawallet/Common/Services/AssetExchange/Common/AssetExchangeAtomicOperation.swift
+++ b/novawallet/Common/Services/AssetExchange/Common/AssetExchangeAtomicOperation.swift
@@ -5,6 +5,7 @@ protocol AssetExchangeAtomicOperationProtocol {
     var swapLimit: AssetExchangeSwapLimit { get }
 
     func executeWrapper(for swapLimit: AssetExchangeSwapLimit) -> CompoundOperationWrapper<Balance>
+    func submitWrapper(for swapLimit: AssetExchangeSwapLimit) -> CompoundOperationWrapper<Void>
     func estimateFee() -> CompoundOperationWrapper<AssetExchangeOperationFee>
 
     func requiredAmountToGetAmountOut(

--- a/novawallet/Common/Services/AssetExchange/Facade/AssetExchangeFacade.swift
+++ b/novawallet/Common/Services/AssetExchange/Facade/AssetExchangeFacade.swift
@@ -5,7 +5,8 @@ final class AssetExchangeFacade {
         for params: AssetExchangeGraphProvidingParams,
         feeSupportProvider: AssetsExchangeFeeSupportProviding,
         exchangesStateMediator: AssetsExchangeStateMediating,
-        pathCostEstimator: AssetsExchangePathCostEstimating
+        pathCostEstimator: AssetsExchangePathCostEstimating,
+        delayedCallExecProvider: WalletDelayedExecutionProviding
     ) -> AssetsExchangeGraphProviding {
         let suffiencyProvider = AssetExchangeSufficiencyProvider()
 
@@ -55,12 +56,7 @@ final class AssetExchangeFacade {
             ],
             feeSupportProvider: feeSupportProvider,
             suffiencyProvider: suffiencyProvider,
-            delayedCallExecProvider: WalletDelayedExecutionProvider(
-                selectedWallet: params.wallet,
-                repository: WalletDelayedExecutionRepository(userStorageFacade: params.userDataStorageFacade),
-                operationQueue: params.operationQueue,
-                logger: Logger.shared
-            ),
+            delayedCallExecProvider: delayedCallExecProvider,
             operationQueue: params.operationQueue,
             logger: params.logger
         )

--- a/novawallet/Common/Services/AssetExchange/Facade/AssetExchangeFacade.swift
+++ b/novawallet/Common/Services/AssetExchange/Facade/AssetExchangeFacade.swift
@@ -55,6 +55,12 @@ final class AssetExchangeFacade {
             ],
             feeSupportProvider: feeSupportProvider,
             suffiencyProvider: suffiencyProvider,
+            delayedCallExecProvider: WalletDelayedExecutionProvider(
+                selectedWallet: params.wallet,
+                repository: WalletDelayedExecutionRepository(userStorageFacade: params.userDataStorageFacade),
+                operationQueue: params.operationQueue,
+                logger: Logger.shared
+            ),
             operationQueue: params.operationQueue,
             logger: params.logger
         )

--- a/novawallet/Common/Services/DelegatedAccounts/SyncService/DelegatedAccountChangesCalculator/DelegatedMetaAccountFactory/MultisigMetaAccountFactory.swift
+++ b/novawallet/Common/Services/DelegatedAccounts/SyncService/DelegatedAccountChangesCalculator/DelegatedMetaAccountFactory/MultisigMetaAccountFactory.swift
@@ -130,7 +130,7 @@ extension MultisigMetaAccountFactory: DelegatedMetaAccountFactoryProtocol {
     func renew(_ metaAccount: ManagedMetaAccountModel) -> ManagedMetaAccountModel {
         guard
             let multisigAccountType = metaAccount.info.multisigAccount,
-            multisigAccountType.multisig?.status == .revoked
+            multisigAccountType.anyChainMultisig?.status == .revoked
         else {
             return metaAccount
         }
@@ -143,7 +143,7 @@ extension MultisigMetaAccountFactory: DelegatedMetaAccountFactoryProtocol {
     func markAsRevoked(_ metaAccount: ManagedMetaAccountModel) -> ManagedMetaAccountModel {
         guard
             let multisigType = metaAccount.info.multisigAccount,
-            let oldStatus = multisigType.multisig?.status
+            let oldStatus = multisigType.anyChainMultisig?.status
         else { return metaAccount }
 
         let info = metaAccount.info
@@ -171,7 +171,9 @@ extension MultisigMetaAccountFactory: DelegatedMetaAccountFactoryProtocol {
     }
 
     func extractDelegateIdentifier(from metaAccount: ManagedMetaAccountModel) -> DelegateIdentifier? {
-        guard let multisig = metaAccount.info.multisigAccount?.multisig else {
+        guard let multisig = metaAccount.info.getMultisig(
+            for: chainModel
+        ) else {
             return nil
         }
 
@@ -188,7 +190,7 @@ extension MultisigMetaAccountFactory: DelegatedMetaAccountFactoryProtocol {
         return switch localMultisigAccountType {
         case let .singleChain(chainAccount):
             chainAccount.chainId == chainModel.chainId
-        case let .universal(localMultisig):
+        case .universal:
             true
         }
     }

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicSenderResolution/DelegationResolution/DelegationResolutionNode.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicSenderResolution/DelegationResolution/DelegationResolutionNode.swift
@@ -121,7 +121,7 @@ extension MetaAccountModel: DelegationResolutionNodeSourceProtocol {
             return (key, value)
         } else if
             type == .multisig,
-            let multisig = multisigAccount?.multisig {
+            let multisig = getMultisig(for: chain) {
             let allSignatories = multisig.otherSignatories + [multisig.signatory]
 
             let key = DelegationResolution.DelegationKey(

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransactService.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmTransactService.swift
@@ -8,6 +8,11 @@ protocol XcmTransactServiceProtocol {
         destinationChainAsset: ChainAsset,
         signer: SigningWrapperProtocol
     ) -> CompoundOperationWrapper<Balance>
+
+    func submitTransferWrapper(
+        _ transferRequest: XcmTransferRequest,
+        signer: SigningWrapperProtocol
+    ) -> CompoundOperationWrapper<Void>
 }
 
 final class XcmTransactService {
@@ -38,51 +43,69 @@ extension XcmTransactService: XcmTransactServiceProtocol {
         destinationChainAsset: ChainAsset,
         signer: SigningWrapperProtocol
     ) -> CompoundOperationWrapper<Balance> {
-        do {
-            let monitoringService = XcmDepositMonitoringService(
-                accountId: transferRequest.unweighted.destination.accountId,
-                chainAsset: destinationChainAsset,
-                chainRegistry: chainRegistry,
-                operationQueue: operationQueue,
-                workingQueue: workingQueue,
-                logger: logger
-            )
+        let monitoringService = XcmDepositMonitoringService(
+            accountId: transferRequest.unweighted.destination.accountId,
+            chainAsset: destinationChainAsset,
+            chainRegistry: chainRegistry,
+            operationQueue: operationQueue,
+            workingQueue: workingQueue,
+            logger: logger
+        )
 
-            let monitoringWrapper = monitoringService.useMonitoringWrapper()
+        let monitoringWrapper = monitoringService.useMonitoringWrapper()
 
-            let submittionOperation = AsyncClosureOperation<XcmSubmitExtrinsic> { completion in
-                self.transferService.submit(
-                    request: transferRequest,
-                    signer: signer,
-                    runningIn: self.workingQueue
-                ) { result in
-                    // cancel monitoring in case transaction submission failed
-                    if case .failure = result {
-                        monitoringWrapper.cancel()
-                    }
+        let submittionOperation = AsyncClosureOperation<XcmSubmitExtrinsic> { completion in
+            self.transferService.submit(
+                request: transferRequest,
+                signer: signer,
+                runningIn: self.workingQueue
+            ) { result in
+                // cancel monitoring in case transaction submission failed
+                if case .failure = result {
+                    monitoringWrapper.cancel()
+                }
 
-                    completion(result)
+                completion(result)
+            }
+        }
+
+        let mappingOperation = ClosureOperation<Balance> {
+            _ = try submittionOperation.extractNoCancellableResultData()
+
+            let arrivedAmount = try monitoringWrapper.targetOperation.extractNoCancellableResultData()
+
+            self.logger.debug("Arrived amount: \(String(arrivedAmount))")
+
+            return arrivedAmount
+        }
+
+        mappingOperation.addDependency(monitoringWrapper.targetOperation)
+        mappingOperation.addDependency(submittionOperation)
+
+        let dependencies = monitoringWrapper.allOperations + [submittionOperation]
+
+        return CompoundOperationWrapper(targetOperation: mappingOperation, dependencies: dependencies)
+    }
+
+    func submitTransferWrapper(
+        _ transferRequest: XcmTransferRequest,
+        signer: SigningWrapperProtocol
+    ) -> CompoundOperationWrapper<Void> {
+        let submitOperation = AsyncClosureOperation<Void> { completion in
+            self.transferService.submit(
+                request: transferRequest,
+                signer: signer,
+                runningIn: self.workingQueue
+            ) { result in
+                switch result {
+                case .success:
+                    completion(.success(()))
+                case let .failure(error):
+                    completion(.failure(error))
                 }
             }
-
-            let mappingOperation = ClosureOperation<Balance> {
-                _ = try submittionOperation.extractNoCancellableResultData()
-
-                let arrivedAmount = try monitoringWrapper.targetOperation.extractNoCancellableResultData()
-
-                self.logger.debug("Arrived amount: \(String(arrivedAmount))")
-
-                return arrivedAmount
-            }
-
-            mappingOperation.addDependency(monitoringWrapper.targetOperation)
-            mappingOperation.addDependency(submittionOperation)
-
-            let dependencies = monitoringWrapper.allOperations + [submittionOperation]
-
-            return CompoundOperationWrapper(targetOperation: mappingOperation, dependencies: dependencies)
-        } catch {
-            return .createWithError(error)
         }
+
+        return CompoundOperationWrapper(targetOperation: submitOperation)
     }
 }

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/Multisig/CallDataSync/MultisigCallDataSyncService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/Multisig/CallDataSync/MultisigCallDataSyncService.swift
@@ -240,7 +240,7 @@ extension MultisigCallDataSyncService: MultisigEventsSubscriber {
         mutex.lock()
         defer { mutex.unlock() }
 
-        let availableAccountIds = Set(availableMetaAccounts.compactMap { $0.multisigAccount?.multisig?.accountId })
+        let availableAccountIds = Set(availableMetaAccounts.compactMap { $0.multisigAccount?.anyChainMultisig?.accountId })
         let relevantEvents = events.filter { availableAccountIds.contains($0.accountId) }
 
         guard !relevantEvents.isEmpty else { return }

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/Multisig/MultisigPendingOperationsSyncService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/Multisig/MultisigPendingOperationsSyncService.swift
@@ -92,7 +92,7 @@ private extension MultisigPendingOperationsService {
 
     func setupChainSyncService(for chain: ChainModel) {
         guard
-            let multisigAccount = selectedMetaAccount.multisigAccount?.multisig,
+            let multisigAccount = selectedMetaAccount.getMultisig(for: chain),
             pendingOperationsChainSyncServices[chain.chainId] == nil
         else { return }
 

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/Multisig/PendingOperationChainSync/PendingMultisigChainSyncService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/Multisig/PendingOperationChainSync/PendingMultisigChainSyncService.swift
@@ -166,6 +166,8 @@ extension PendingMultisigChainSyncService: MultisigPendingOperationsSubscriber {
         callHash: Substrate.CallHash,
         multisigDefinition: MultisigDefinitionWithTime?
     ) {
+        logger.debug("Update definition: \(String(describing: multisigDefinition))")
+
         let updateDefinitionWrapper = localSyncFactory.createUpdateDefinitionWrapper(
             for: callHash,
             multisigDefinition

--- a/novawallet/Common/Services/WalletDelayedExecution/NotDelegatedCallDelayedExecVerifier.swift
+++ b/novawallet/Common/Services/WalletDelayedExecution/NotDelegatedCallDelayedExecVerifier.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+final class NotDelegatedCallDelayedExecVerifier {
+    let selectedWallet: MetaAccountModel
+
+    init(selectedWallet: MetaAccountModel) {
+        self.selectedWallet = selectedWallet
+    }
+}
+
+extension NotDelegatedCallDelayedExecVerifier: WalletDelayedExecVerifing {
+    func executesCallWithDelay(
+        _ wallet: MetaAccountModel,
+        chain: ChainModel
+    ) -> Bool {
+        guard wallet.isDelegated() else {
+            return false
+        }
+
+        return wallet.delaysCallExecution(in: chain)
+    }
+}

--- a/novawallet/Common/Services/WalletDelayedExecution/WalletDelayedExecution.swift
+++ b/novawallet/Common/Services/WalletDelayedExecution/WalletDelayedExecution.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+protocol WalletDelayedExecuting {
+    func executesCallWithDelay(_ wallet: MetaAccountModel, chain: ChainModel) -> Bool
+}
+
+final class WalletDelayedExecution {
+    let allWallet: [MetaAccountModel.Id: MetaAccountModel]
+
+    init(allWallet: [MetaAccountModel.Id: MetaAccountModel]) {
+        self.allWallet = allWallet
+    }
+}
+
+extension WalletDelayedExecution: WalletDelayedExecuting {
+    func executesCallWithDelay(_: MetaAccountModel, chain _: ChainModel) -> Bool {
+        false
+    }
+}

--- a/novawallet/Common/Services/WalletDelayedExecution/WalletDelayedExecution.swift
+++ b/novawallet/Common/Services/WalletDelayedExecution/WalletDelayedExecution.swift
@@ -1,19 +1,76 @@
 import Foundation
 
-protocol WalletDelayedExecuting {
+protocol WalletDelayedExecVerifing {
     func executesCallWithDelay(_ wallet: MetaAccountModel, chain: ChainModel) -> Bool
 }
 
-final class WalletDelayedExecution {
-    let allWallet: [MetaAccountModel.Id: MetaAccountModel]
+/**
+ *     The implemetation checks for a given wallet whethere there is reachable delegate wallet that delays call
+ *     execution
+ */
+final class WalletDelayedExecVerifier {
+    let allWallets: [MetaAccountModel.Id: MetaAccountModel]
 
-    init(allWallet: [MetaAccountModel.Id: MetaAccountModel]) {
-        self.allWallet = allWallet
+    init(allWallets: [MetaAccountModel.Id: MetaAccountModel]) {
+        self.allWallets = allWallets
     }
 }
 
-extension WalletDelayedExecution: WalletDelayedExecuting {
-    func executesCallWithDelay(_: MetaAccountModel, chain _: ChainModel) -> Bool {
-        false
+extension WalletDelayedExecVerifier: WalletDelayedExecVerifing {
+    func executesCallWithDelay(_ wallet: MetaAccountModel, chain: ChainModel) -> Bool {
+        guard wallet.isDelegated() else {
+            return false
+        }
+
+        guard !wallet.delaysCallExecution(in: chain) else {
+            return true
+        }
+
+        let metaIdsByDelegateId: [AccountId: [MetaAccountModel.Id]] = allWallets.values.reduce(
+            into: [:]
+        ) { accum, wallet in
+            guard
+                let accountId = wallet.fetch(for: chain.accountRequest())?.accountId else {
+                return
+            }
+
+            let prevList = accum[accountId] ?? []
+            accum[accountId] = prevList + [wallet.metaId]
+        }
+
+        var prevMetaIds: Set<MetaAccountModel.Id> = [wallet.metaId]
+        var currentMetaIds = prevMetaIds
+
+        repeat {
+            let newMetaIds: [MetaAccountModel.Id] = currentMetaIds.flatMap { metaId in
+                guard
+                    let wallet = allWallets[metaId],
+                    let delegation = wallet.delegationId,
+                    delegation.existsInChainWithId(chain.chainId) else {
+                    return [MetaAccountModel.Id]()
+                }
+
+                return metaIdsByDelegateId[delegation.delegateAccountId] ?? []
+            }
+
+            let nextMetaIds = Set(newMetaIds).union(currentMetaIds)
+
+            let hasDelayedExecWallets = nextMetaIds.subtracting(currentMetaIds).contains { metaId in
+                guard let wallet = allWallets[metaId] else {
+                    return false
+                }
+
+                return wallet.delaysCallExecution(in: chain)
+            }
+
+            if hasDelayedExecWallets {
+                return true
+            }
+
+            prevMetaIds = currentMetaIds
+            currentMetaIds = Set(nextMetaIds)
+        } while prevMetaIds != currentMetaIds
+
+        return false
     }
 }

--- a/novawallet/Common/Services/WalletDelayedExecution/WalletDelayedExecutionProvider.swift
+++ b/novawallet/Common/Services/WalletDelayedExecution/WalletDelayedExecutionProvider.swift
@@ -22,6 +22,7 @@ final class WalletDelayedExecutionProvider {
     let logger: LoggerProtocol
 
     private let mutex = NSLock()
+    private var isActive: Bool = false
 
     private let callStore = CancellableCallStore()
 
@@ -78,6 +79,12 @@ extension WalletDelayedExecutionProvider: WalletDelayedExecutionProviding {
             self.mutex.unlock()
         }
 
+        guard !isActive else {
+            return
+        }
+
+        isActive = true
+
         fetchAndSetupVerifier()
     }
 
@@ -87,6 +94,12 @@ extension WalletDelayedExecutionProvider: WalletDelayedExecutionProviding {
         defer {
             mutex.unlock()
         }
+
+        guard isActive else {
+            return
+        }
+
+        isActive = false
 
         callStore.cancel()
     }

--- a/novawallet/Common/Services/WalletDelayedExecution/WalletDelayedExecutionProvider.swift
+++ b/novawallet/Common/Services/WalletDelayedExecution/WalletDelayedExecutionProvider.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+protocol WalletDelayedExecutionProviding {
+    func setup()
+    func throttle()
+
+    func subscribeDelayedExecVerifier(
+        _ target: AnyObject,
+        notifyingIn queue: DispatchQueue,
+        onChange: @escaping (WalletDelayedExecVerifing) -> Void
+    )
+
+    func unsubscribe(_ target: AnyObject)
+
+    func getCurrentState() -> WalletDelayedExecVerifing
+}
+
+final class WalletDelayedExecutionProvider {
+    let repository: WalletDelayedExecutionRepositoryProtocol
+    let workQueue: DispatchQueue
+    let operationQueue: OperationQueue
+    let logger: LoggerProtocol
+
+    private let mutex = NSLock()
+
+    private let callStore = CancellableCallStore()
+
+    private var observableState: Observable<NotEqualWrapper<WalletDelayedExecVerifing>>
+
+    init(
+        selectedWallet: MetaAccountModel,
+        repository: WalletDelayedExecutionRepositoryProtocol,
+        operationQueue: OperationQueue,
+        workQueue: DispatchQueue = .global(),
+        logger: LoggerProtocol
+    ) {
+        self.repository = repository
+        self.operationQueue = operationQueue
+        self.workQueue = workQueue
+        self.logger = logger
+
+        observableState = .init(
+            state: .init(
+                value: NotDelegatedCallDelayedExecVerifier(
+                    selectedWallet: selectedWallet
+                )
+            )
+        )
+    }
+}
+
+private extension WalletDelayedExecutionProvider {
+    func fetchAndSetupVerifier() {
+        let wrapper = repository.createVerifier()
+
+        executeCancellable(
+            wrapper: wrapper,
+            inOperationQueue: operationQueue,
+            backingCallIn: callStore,
+            runningCallbackIn: workQueue,
+            mutex: mutex
+        ) { [weak self] result in
+            switch result {
+            case let .success(verifier):
+                self?.observableState.state = .init(value: verifier)
+            case let .failure(error):
+                self?.logger.error("Unexpected error: \(error)")
+            }
+        }
+    }
+}
+
+extension WalletDelayedExecutionProvider: WalletDelayedExecutionProviding {
+    func setup() {
+        mutex.lock()
+
+        defer {
+            self.mutex.unlock()
+        }
+
+        fetchAndSetupVerifier()
+    }
+
+    func throttle() {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        callStore.cancel()
+    }
+
+    func subscribeDelayedExecVerifier(
+        _ target: AnyObject,
+        notifyingIn queue: DispatchQueue,
+        onChange: @escaping (WalletDelayedExecVerifing) -> Void
+    ) {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        observableState.addObserver(
+            with: target,
+            sendStateOnSubscription: true,
+            queue: queue
+        ) { _, newState in
+            onChange(newState.value)
+        }
+    }
+
+    func unsubscribe(_ target: AnyObject) {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        observableState.removeObserver(by: target)
+    }
+
+    func getCurrentState() -> WalletDelayedExecVerifing {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        return observableState.state.value
+    }
+}

--- a/novawallet/Common/Services/WalletDelayedExecution/WalletDelayedExecutionRepository.swift
+++ b/novawallet/Common/Services/WalletDelayedExecution/WalletDelayedExecutionRepository.swift
@@ -1,3 +1,40 @@
 import Foundation
+import Operation_iOS
 
-protocol WalletDelayedExecutionRepositoryProtocol {}
+protocol WalletDelayedExecutionRepositoryProtocol {
+    func createVerifier() -> CompoundOperationWrapper<WalletDelayedExecVerifing>
+}
+
+final class WalletDelayedExecutionRepository {
+    let walletRepository: AnyDataProviderRepository<MetaAccountModel>
+
+    init(walletRepository: AnyDataProviderRepository<MetaAccountModel>) {
+        self.walletRepository = walletRepository
+    }
+
+    init(userStorageFacade: StorageFacadeProtocol) {
+        walletRepository = AccountRepositoryFactory(storageFacade: userStorageFacade).createMetaAccountRepository(
+            for: nil,
+            sortDescriptors: []
+        )
+    }
+}
+
+extension WalletDelayedExecutionRepository: WalletDelayedExecutionRepositoryProtocol {
+    func createVerifier() -> CompoundOperationWrapper<WalletDelayedExecVerifing> {
+        let allWalletsOperation = walletRepository.fetchAllOperation(with: RepositoryFetchOptions())
+
+        let mapOperation = ClosureOperation<WalletDelayedExecVerifing> {
+            let allWallets = try allWalletsOperation.extractNoCancellableResultData().reduceToDict()
+
+            return WalletDelayedExecVerifier(allWallets: allWallets)
+        }
+
+        mapOperation.addDependency(allWalletsOperation)
+
+        return CompoundOperationWrapper(
+            targetOperation: mapOperation,
+            dependencies: [allWalletsOperation]
+        )
+    }
+}

--- a/novawallet/Common/Services/WalletDelayedExecution/WalletDelayedExecutionRepository.swift
+++ b/novawallet/Common/Services/WalletDelayedExecution/WalletDelayedExecutionRepository.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+protocol WalletDelayedExecutionRepositoryProtocol {}

--- a/novawallet/Modules/AssetList/AssetListInteractor.swift
+++ b/novawallet/Modules/AssetList/AssetListInteractor.swift
@@ -181,7 +181,7 @@ private extension AssetListInteractor {
 
         guard
             selectedWalletSettings.value.type == .multisig,
-            let multisigAccount = selectedWalletSettings.value.multisigAccount?.multisig
+            let multisigAccount = selectedWalletSettings.value.multisigAccount?.anyChainMultisig
         else { return }
 
         multisigOperationsSubscription = subscribePendingOperations(for: multisigAccount.accountId)

--- a/novawallet/Modules/DelegatedAccounts/Multisig/Models/Multisig+Signatory.swift
+++ b/novawallet/Modules/DelegatedAccounts/Multisig/Models/Multisig+Signatory.swift
@@ -42,8 +42,8 @@ extension Multisig.LocalSignatory {
 }
 
 extension Array where Element == Multisig.Signatory {
-    func findSignatory(for wallet: MetaAccountModel) -> Multisig.Signatory? {
-        guard let multisig = wallet.multisigAccount?.multisig else {
+    func findSignatory(for wallet: MetaAccountModel, chain: ChainModel) -> Multisig.Signatory? {
+        guard let multisig = wallet.getMultisig(for: chain) else {
             return nil
         }
 

--- a/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/Approve/MultisigOperationApproveInteractor.swift
+++ b/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/Approve/MultisigOperationApproveInteractor.swift
@@ -65,7 +65,7 @@ final class MultisigOperationApproveInteractor: MultisigOperationConfirmInteract
     override func doEstimateFee() {
         guard
             let call,
-            let multisig = multisigWallet.multisigAccount?.multisig,
+            let multisig = multisigWallet.getMultisig(for: chain),
             let definition = operation.operation.multisigDefinition,
             let operationFactory = extrinsicOperationFactory else {
             return
@@ -108,7 +108,7 @@ final class MultisigOperationApproveInteractor: MultisigOperationConfirmInteract
     override func doConfirm() {
         guard
             let call,
-            let multisig = multisigWallet.multisigAccount?.multisig,
+            let multisig = multisigWallet.getMultisig(for: chain),
             let definition = operation.operation.multisigDefinition,
             let extrinsicSubmissionMonitor,
             let signer else {

--- a/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/Factory/MultisigOperationConfirmViewFactory.swift
+++ b/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/Factory/MultisigOperationConfirmViewFactory.swift
@@ -81,7 +81,9 @@ struct MultisigOperationConfirmViewFactory {
         let chainRegistry = ChainRegistryFacade.sharedRegistry
 
         guard
-            let multisig = multisigWallet.multisigAccount?.multisig,
+            let multisig = multisigWallet.getMultisig(
+                for: chain
+            ),
             let runtimeProvider = chainRegistry.getRuntimeProvider(for: chain.chainId),
             let connection = chainRegistry.getConnection(for: chain.chainId) else {
             return nil

--- a/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/Factory/MultisigOperationConfirmViewModelFactory.swift
+++ b/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/Factory/MultisigOperationConfirmViewModelFactory.swift
@@ -399,12 +399,13 @@ private extension MultisigOperationConfirmViewModelFactory {
     func createActions(
         for pendingOperation: Multisig.PendingOperationProxyModel,
         multisigWallet: MetaAccountModel,
+        chain: ChainModel,
         locale: Locale,
         confirmClosure: @escaping () -> Void,
         callDataAddClosure: @escaping () -> Void
     ) -> [MultisigOperationConfirmViewModel.Action] {
         guard
-            let multisigContext = multisigWallet.multisigAccount?.anyChainMultisig,
+            let multisigContext = multisigWallet.getMultisig(for: chain),
             let definition = pendingOperation.operation.multisigDefinition
         else { return [] }
 
@@ -512,6 +513,7 @@ extension MultisigOperationConfirmViewModelFactory: MultisigOperationConfirmView
         let actions = createActions(
             for: params.pendingOperation,
             multisigWallet: params.multisigWallet,
+            chain: params.chain,
             locale: locale,
             confirmClosure: params.confirmClosure,
             callDataAddClosure: params.callDataAddClosure

--- a/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/Factory/MultisigOperationConfirmViewModelFactory.swift
+++ b/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/Factory/MultisigOperationConfirmViewModelFactory.swift
@@ -156,7 +156,9 @@ private extension MultisigOperationConfirmViewModelFactory {
         locale: Locale
     ) -> MultisigOperationConfirmViewModel.Section? {
         guard
-            let multisigContext = multisigWallet.multisigAccount?.multisig,
+            let multisigContext = multisigWallet.getMultisig(
+                for: feeAsset.chain
+            ),
             let definition = pendingOperation.multisigDefinition,
             let signatory = signatories.first(
                 where: { $0.localAccount?.chainAccount.accountId == multisigContext.signatory }
@@ -236,7 +238,9 @@ private extension MultisigOperationConfirmViewModelFactory {
         locale: Locale
     ) -> MultisigOperationConfirmViewModel.Section? {
         guard
-            let multisigContext = multisigWallet.multisigAccount?.multisig,
+            let multisigContext = multisigWallet.getMultisig(
+                for: chain
+            ),
             let definition = pendingOperation.multisigDefinition
         else { return nil }
 
@@ -400,7 +404,7 @@ private extension MultisigOperationConfirmViewModelFactory {
         callDataAddClosure: @escaping () -> Void
     ) -> [MultisigOperationConfirmViewModel.Action] {
         guard
-            let multisigContext = multisigWallet.multisigAccount?.multisig,
+            let multisigContext = multisigWallet.multisigAccount?.anyChainMultisig,
             let definition = pendingOperation.operation.multisigDefinition
         else { return [] }
 

--- a/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/MultisigOperationConfirmInteractor.swift
+++ b/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/MultisigOperationConfirmInteractor.swift
@@ -98,7 +98,7 @@ class MultisigOperationConfirmInteractor: AnyProviderAutoCleaning {
 
 private extension MultisigOperationConfirmInteractor {
     func setupSignatories() {
-        guard let multisig = multisigWallet.multisigAccount?.multisig else {
+        guard let multisig = multisigWallet.getMultisig(for: chain) else {
             logger.error("Multisig expected here")
             return
         }
@@ -125,7 +125,8 @@ private extension MultisigOperationConfirmInteractor {
 
     func setupCurrentSignatory(from signatories: [Multisig.Signatory]) {
         guard let signatoryAccount = signatories.findSignatory(
-            for: multisigWallet
+            for: multisigWallet,
+            chain: chain
         )?.localAccount else {
             logger.error("No local signatory found")
             return
@@ -292,7 +293,9 @@ private extension MultisigOperationConfirmInteractor {
         clear(streamableProvider: &balanceProvider)
 
         guard
-            let multisig = multisigWallet.multisigAccount?.multisig,
+            let multisig = multisigWallet.getMultisig(
+                for: chain
+            ),
             let asset = chain.utilityAsset() else {
             logger.error("Multisig and asset expected")
             return
@@ -307,7 +310,7 @@ private extension MultisigOperationConfirmInteractor {
 
     func setupSignatoryRemoteBalanceSubsription() {
         guard
-            let multisig = multisigWallet.multisigAccount?.multisig,
+            let multisig = multisigWallet.getMultisig(for: chain),
             let asset = chain.utilityChainAsset(),
             let assetInfo else {
             logger.error("Multisig, asset and info expected here")
@@ -326,7 +329,7 @@ private extension MultisigOperationConfirmInteractor {
         guard
             let assetInfo,
             let assetRemoteSubscriptionId,
-            let multisig = multisigWallet.multisigAccount?.multisig,
+            let multisig = multisigWallet.getMultisig(for: chain),
             let asset = chain.utilityChainAsset() else {
             return
         }

--- a/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/MultisigOperationConfirmPresenter.swift
+++ b/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/MultisigOperationConfirmPresenter.swift
@@ -21,7 +21,7 @@ final class MultisigOperationConfirmPresenter {
     var transferAssetPriceData: PriceData?
 
     var multisigContext: DelegatedAccount.MultisigAccountModel? {
-        multisigWallet.multisigAccount?.multisig
+        multisigWallet.getMultisig(for: chain)
     }
 
     init(
@@ -172,7 +172,8 @@ private extension MultisigOperationConfirmPresenter {
         }
 
         let signatoryName = signatories?.findSignatory(
-            for: multisigWallet
+            for: multisigWallet,
+            chain: chain
         )?.localAccount?.chainAccount.name
 
         DataValidationRunner(validators: [
@@ -209,7 +210,7 @@ private extension MultisigOperationConfirmPresenter {
 
 extension MultisigOperationConfirmPresenter: MultisigOperationConfirmPresenterProtocol {
     func actionShowSender() {
-        guard let multisigContext = multisigWallet.multisigAccount?.multisig else {
+        guard let multisigContext else {
             return
         }
 
@@ -242,7 +243,7 @@ extension MultisigOperationConfirmPresenter: MultisigOperationConfirmPresenterPr
     }
 
     func actionShowCurrentSignatory() {
-        guard let multisigContext = multisigWallet.multisigAccount?.multisig else {
+        guard let multisigContext else {
             return
         }
 

--- a/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/Reject/MultisigOperationRejectInteractor.swift
+++ b/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/Reject/MultisigOperationRejectInteractor.swift
@@ -22,7 +22,7 @@ final class MultisigOperationRejectInteractor: MultisigOperationConfirmInteracto
 
     override func doConfirm() {
         guard
-            let multisig = multisigWallet.multisigAccount?.multisig,
+            let multisig = multisigWallet.getMultisig(for: chain),
             let definition = operation.operation.multisigDefinition,
             let extrinsicSubmissionMonitor,
             let signer else {
@@ -56,7 +56,7 @@ final class MultisigOperationRejectInteractor: MultisigOperationConfirmInteracto
 
     override func doEstimateFee() {
         guard
-            let multisig = multisigWallet.multisigAccount?.multisig,
+            let multisig = multisigWallet.getMultisig(for: chain),
             let definition = operation.operation.multisigDefinition,
             let operationFactory = extrinsicOperationFactory else {
             return

--- a/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperations/Factory/MultisigOperationsViewModelFactory.swift
+++ b/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperations/Factory/MultisigOperationsViewModelFactory.swift
@@ -190,7 +190,7 @@ private extension MultisigOperationsViewModelFactory {
         for locale: Locale
     ) -> MultisigOperationViewModel? {
         guard
-            let multisigContext = wallet.multisigAccount?.multisig,
+            let multisigContext = wallet.getMultisig(for: chain),
             let definition = operationModel.operation.multisigDefinition
         else { return nil }
 

--- a/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperations/MultisigOperationsInteractor.swift
+++ b/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperations/MultisigOperationsInteractor.swift
@@ -29,7 +29,7 @@ final class MultisigOperationsInteractor: AnyProviderAutoCleaning {
 
 private extension MultisigOperationsInteractor {
     func subscribeToOperations() {
-        guard let multisigAccount = wallet.multisigAccount?.multisig else {
+        guard let multisigAccount = wallet.multisigAccount?.anyChainMultisig else {
             presenter?.didReceive(error: MultisigOperationsInteractorError.walletUnavailable)
             return
         }

--- a/novawallet/Modules/ManageWallets/AccountManagement/Model/AccountManagementFilter.swift
+++ b/novawallet/Modules/ManageWallets/AccountManagement/Model/AccountManagementFilter.swift
@@ -15,9 +15,7 @@ final class AccountManagementFilter: AccountManagementFilterProtocol {
         switch wallet.type {
         case .watchOnly, .paritySigner, .polkadotVault, .secrets:
             true
-        case .multisig:
-            wallet.chainAccounts.contains { $0.chainId == chain.chainId }
-        case .proxied:
+        case .proxied, .multisig:
             wallet.fetch(for: chain.accountRequest()) != nil
         case .ledger:
             supportedLedgerChains.contains(chain.chainId)

--- a/novawallet/Modules/Swaps/Confirm/SwapConfirmInteractor.swift
+++ b/novawallet/Modules/Swaps/Confirm/SwapConfirmInteractor.swift
@@ -5,6 +5,17 @@ import BigInt
 
 final class SwapConfirmInteractor: SwapBaseInteractor {
     let initState: SwapConfirmInitState
+    let delayedExecutionProvider: WalletDelayedExecutionProviding
+
+    var presenter: SwapConfirmInteractorOutProtocol? {
+        get {
+            basePresenter as? SwapConfirmInteractorOutProtocol
+        }
+
+        set {
+            basePresenter = newValue
+        }
+    }
 
     init(
         state: SwapTokensFlowStateProtocol,
@@ -18,6 +29,7 @@ final class SwapConfirmInteractor: SwapBaseInteractor {
         logger: LoggerProtocol
     ) {
         self.initState = initState
+        delayedExecutionProvider = state.setupWalletDelayedCallExecProvider()
 
         super.init(
             state: state,
@@ -40,4 +52,24 @@ final class SwapConfirmInteractor: SwapBaseInteractor {
     }
 }
 
-extension SwapConfirmInteractor: SwapConfirmInteractorInputProtocol {}
+extension SwapConfirmInteractor: SwapConfirmInteractorInputProtocol {
+    func initiateSwapSubmission(of model: SwapExecutionModel) {
+        guard delayedExecutionProvider.getCurrentState().executesCallWithDelay(
+            selectedWallet,
+            chain: model.chainAssetIn.chain
+        ) else {
+            presenter?.didDecideMonitoredExecution(for: model)
+            return
+        }
+
+        let wrapper = assetsExchangeService.submitSingleOperationWrapper(using: model.fee)
+
+        execute(
+            wrapper: wrapper,
+            inOperationQueue: operationQueue,
+            runningCallbackIn: .main
+        ) { [weak self] result in
+            self?.presenter?.didCompleteSwapSubmission(with: result)
+        }
+    }
+}

--- a/novawallet/Modules/Swaps/Confirm/SwapConfirmPresenter.swift
+++ b/novawallet/Modules/Swaps/Confirm/SwapConfirmPresenter.swift
@@ -322,7 +322,9 @@ extension SwapConfirmPresenter {
             fee: fee
         )
 
-        wireframe.showSwapExecution(from: view, model: executionModel)
+        view?.didReceiveStartLoading()
+
+        interactor.initiateSwapSubmission(of: executionModel)
     }
 }
 
@@ -422,6 +424,30 @@ extension SwapConfirmPresenter: SwapConfirmPresenterProtocol {
                 self?.view?.didReceiveStartLoading()
             }
         )
+    }
+}
+
+extension SwapConfirmPresenter: SwapConfirmInteractorOutProtocol {
+    func didCompleteSwapSubmission(with result: Result<Void, Error>) {
+        switch result {
+        case .success:
+            wireframe.complete(on: view)
+        case let .failure(error):
+            view?.didReceiveStopLoading()
+
+            logger.error("Swap failed: \(error)")
+
+            _ = wireframe.handleExtrinsicSigningErrorPresentation(
+                error,
+                view: view,
+                closeAction: .dismissAllModals,
+                completionClosure: nil
+            )
+        }
+    }
+
+    func didDecideMonitoredExecution(for model: SwapExecutionModel) {
+        wireframe.showSwapExecution(from: view, model: model)
     }
 }
 

--- a/novawallet/Modules/Swaps/Confirm/SwapConfirmProtocols.swift
+++ b/novawallet/Modules/Swaps/Confirm/SwapConfirmProtocols.swift
@@ -27,7 +27,14 @@ protocol SwapConfirmPresenterProtocol: AnyObject {
     func confirm()
 }
 
-protocol SwapConfirmInteractorInputProtocol: SwapBaseInteractorInputProtocol {}
+protocol SwapConfirmInteractorInputProtocol: SwapBaseInteractorInputProtocol {
+    func initiateSwapSubmission(of model: SwapExecutionModel)
+}
+
+protocol SwapConfirmInteractorOutProtocol: SwapBaseInteractorOutputProtocol {
+    func didCompleteSwapSubmission(with result: Result<Void, Error>)
+    func didDecideMonitoredExecution(for model: SwapExecutionModel)
+}
 
 protocol SwapConfirmWireframeProtocol: SwapBaseWireframeProtocol, AddressOptionsPresentable,
     ShortTextInfoPresentable, MessageSheetPresentable, ExtrinsicSigningErrorHandling {
@@ -47,4 +54,6 @@ protocol SwapConfirmWireframeProtocol: SwapBaseWireframeProtocol, AddressOptions
         operations: [AssetExchangeMetaOperationProtocol],
         fee: AssetExchangeFee
     )
+
+    func complete(on view: SwapConfirmViewProtocol?)
 }

--- a/novawallet/Modules/Swaps/Confirm/SwapConfirmViewFactory.swift
+++ b/novawallet/Modules/Swaps/Confirm/SwapConfirmViewFactory.swift
@@ -66,7 +66,7 @@ struct SwapConfirmViewFactory {
 
         presenter.view = view
         dataValidatingFactory.view = view
-        interactor.basePresenter = presenter
+        interactor.presenter = presenter
 
         return view
     }

--- a/novawallet/Modules/Swaps/Confirm/SwapConfirmWireframe.swift
+++ b/novawallet/Modules/Swaps/Confirm/SwapConfirmWireframe.swift
@@ -69,4 +69,11 @@ final class SwapConfirmWireframe: SwapConfirmWireframeProtocol {
 
         view?.controller.present(navigationController, animated: true)
     }
+
+    func complete(on view: SwapConfirmViewProtocol?) {
+        // TODO: Figure out actual navigation
+        let presenter = view?.controller.presentingViewController
+
+        presenter?.dismiss(animated: true)
+    }
 }

--- a/novawallet/Modules/WalletsList/Common/WalletsListViewModelFactory.swift
+++ b/novawallet/Modules/WalletsList/Common/WalletsListViewModelFactory.swift
@@ -268,7 +268,7 @@ extension WalletsListViewModelFactory: WalletsListViewModelFactoryProtocol {
     ) -> WalletsListViewModel? {
         guard
             let multisigAccountType = wallet.info.multisigAccount,
-            let multisig = multisigAccountType.multisig,
+            let multisig = multisigAccountType.anyChainMultisig,
             let signatoryWallet = wallets.first(where: { $0.info.isSignatory(for: multisigAccountType) })
         else { return nil }
 

--- a/novawalletIntegrationTests/AssetsExchange/AssetsExchangeTests.swift
+++ b/novawalletIntegrationTests/AssetsExchange/AssetsExchangeTests.swift
@@ -225,6 +225,13 @@ final class AssetsExchangeTests: XCTestCase {
             logger: params.logger
         )
         
+        let delayedCallExecProvider = WalletDelayedExecutionProvider(
+            selectedWallet: params.wallet,
+            repository: WalletDelayedExecutionRepository(userStorageFacade: params.userDataStorageFacade),
+            operationQueue: params.operationQueue,
+            logger: params.logger
+        )
+        
         let pathCostEstimator = MockAssetsExchangePathCostEstimator()
         
         let graphProvider = AssetsExchangeGraphProvider(
@@ -272,12 +279,14 @@ final class AssetsExchangeTests: XCTestCase {
             ],
             feeSupportProvider: feeSupportProvider,
             suffiencyProvider: AssetExchangeSufficiencyProvider(),
+            delayedCallExecProvider: delayedCallExecProvider,
             operationQueue: params.operationQueue,
             logger: params.logger
         )
 
         graphProvider.setup()
         feeSupportProvider.setup()
+        delayedCallExecProvider.setup()
         
         var actualGraph: AssetsExchangeGraphProtocol?
         


### PR DESCRIPTION
## Purpose

The PR introduces additional logic for swaps that allows only one segment swaps for wallets with delayed execution (currently, that contains a multisig in the signer resolution route). That works using `WalletDelayedExecutionProvider`  that supplies an object to the AssetExchange provider allowing to check in the edge filter whether a given wallet in the given chain executes the call with a delay.

Additionaly:

- hide assets and networks in the chains without multisig support
- refactor multisig fetch logic to depend on chain