### PR TITLE
Fee calculation for EVM multisig approval

### DIFF
--- a/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicServiceFactory.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/ExtrinsicServiceFactory.swift
@@ -47,7 +47,7 @@ extension ExtrinsicServiceFactoryProtocol {
             accountId: accountId,
             publicKey: accountId,
             name: "",
-            cryptoType: .sr25519,
+            cryptoType: chain.isEthereumBased ? .ethereumEcdsa : .sr25519,
             addressPrefix: chain.addressPrefix,
             isEthereumBased: chain.isEthereumBased,
             isChainAccount: false,


### PR DESCRIPTION
### SUMMARY
Fee calculation is currently broken for multisig approval on EVM networks. This PR fixes the issue.

### SOLUTION
The issue is caused by the dummy account response used for call weight estimation. The response has its crypto type manually set to `sr25519`. This crypto type is later used to generate the extrinsic signature, but EVM networks expect an ethereum's `ecdsa` signature instead. The fix adds a check for chain type to select the correct crypto type either for EVM or Substrate networks.

### SCREEN RECORDINGS

The recording shows there are fee calculated for multisig operations in both EVM and Substrate networks

https://github.com/user-attachments/assets/8fe9d512-a394-4893-88c4-9a1d368f199f
