### PR TITLE
Show correct address and options for EVM signatories

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1786,10 +1786,10 @@
 		2D86845E2BFF9DA000A663D2 /* BackupAttentionInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D86845D2BFF9DA000A663D2 /* BackupAttentionInteractor.swift */; };
 		2D8684602C0086A500A663D2 /* ManualBackupKeyListViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D86845F2C0086A500A663D2 /* ManualBackupKeyListViewModelFactory.swift */; };
 		2D87C1992E1A6C3500396A3B /* String+Truncation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDF94D42E19BC0D009B7F19 /* String+Truncation.swift */; };
-		2D87C1A62E1C698A00396A3B /* MultisigProviderProxySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D87C1A52E1C698A00396A3B /* MultisigProviderProxySnapshot.swift */; };
-		2D87C1A82E1C752200396A3B /* MultisigOperationsFlowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D87C1A72E1C752200396A3B /* MultisigOperationsFlowState.swift */; };
 		2D87C1A02E1BE37200396A3B /* AccountManageWalletTypeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D87C19F2E1BE37200396A3B /* AccountManageWalletTypeViewModel.swift */; };
 		2D87C1A22E1BE95300396A3B /* AccountManagementViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D87C1A12E1BE95300396A3B /* AccountManagementViewModelFactory.swift */; };
+		2D87C1A62E1C698A00396A3B /* MultisigProviderProxySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D87C1A52E1C698A00396A3B /* MultisigProviderProxySnapshot.swift */; };
+		2D87C1A82E1C752200396A3B /* MultisigOperationsFlowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D87C1A72E1C752200396A3B /* MultisigOperationsFlowState.swift */; };
 		2D8851DE2D0888690099B078 /* UIViewController+PresentCardLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8851D92D0888690099B078 /* UIViewController+PresentCardLayout.swift */; };
 		2D8A52A72DF942CB00DD47F9 /* MultisigPendingOperationsUpdatingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8A52A62DF942CB00DD47F9 /* MultisigPendingOperationsUpdatingService.swift */; };
 		2D8BA36F2C99A6ED002ED440 /* SwipeGovDetailsInteractorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8BA36E2C99A6ED002ED440 /* SwipeGovDetailsInteractorError.swift */; };
@@ -7910,10 +7910,10 @@
 		2D86845D2BFF9DA000A663D2 /* BackupAttentionInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupAttentionInteractor.swift; sourceTree = "<group>"; };
 		2D86845F2C0086A500A663D2 /* ManualBackupKeyListViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualBackupKeyListViewModelFactory.swift; sourceTree = "<group>"; };
 		2D86FBE32DBA49E600E55B9F /* MultiassetUserDataModel15.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MultiassetUserDataModel15.xcdatamodel; sourceTree = "<group>"; };
-		2D87C1A52E1C698A00396A3B /* MultisigProviderProxySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultisigProviderProxySnapshot.swift; sourceTree = "<group>"; };
-		2D87C1A72E1C752200396A3B /* MultisigOperationsFlowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultisigOperationsFlowState.swift; sourceTree = "<group>"; };
 		2D87C19F2E1BE37200396A3B /* AccountManageWalletTypeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManageWalletTypeViewModel.swift; sourceTree = "<group>"; };
 		2D87C1A12E1BE95300396A3B /* AccountManagementViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManagementViewModelFactory.swift; sourceTree = "<group>"; };
+		2D87C1A52E1C698A00396A3B /* MultisigProviderProxySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultisigProviderProxySnapshot.swift; sourceTree = "<group>"; };
+		2D87C1A72E1C752200396A3B /* MultisigOperationsFlowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultisigOperationsFlowState.swift; sourceTree = "<group>"; };
 		2D8851D92D0888690099B078 /* UIViewController+PresentCardLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+PresentCardLayout.swift"; sourceTree = "<group>"; };
 		2D8A52A62DF942CB00DD47F9 /* MultisigPendingOperationsUpdatingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultisigPendingOperationsUpdatingService.swift; sourceTree = "<group>"; };
 		2D8BA36E2C99A6ED002ED440 /* SwipeGovDetailsInteractorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeGovDetailsInteractorError.swift; sourceTree = "<group>"; };

--- a/novawallet/Common/Model/ChainRegistry/Account/MetaAccountModel.swift
+++ b/novawallet/Common/Model/ChainRegistry/Account/MetaAccountModel.swift
@@ -149,7 +149,7 @@ extension MetaAccountModel {
 
     func replacingMultisig(with multisigType: MultisigAccountType) -> MetaAccountModel? {
         switch multisigType {
-        case let .universal(multisig):
+        case let .universalSubstrate(multisig), let .universalEvm(multisig):
             MetaAccountModel(
                 metaId: metaId,
                 name: name,

--- a/novawallet/Common/Protocols/AddressOptionsPresentable.swift
+++ b/novawallet/Common/Protocols/AddressOptionsPresentable.swift
@@ -146,6 +146,32 @@ extension AddressOptionsPresentable {
             completion: nil
         )
     }
+
+    func presentSubstrateAddressOptions(
+        from view: ControllerBackedProtocol,
+        address: String,
+        locale: Locale
+    ) {
+        presentHardwareAddressOptions(
+            from: view,
+            address: address,
+            scheme: .substrate,
+            locale: locale
+        )
+    }
+
+    func presentEvmAddressOptions(
+        from view: ControllerBackedProtocol,
+        address: String,
+        locale: Locale
+    ) {
+        presentHardwareAddressOptions(
+            from: view,
+            address: address,
+            scheme: .evm,
+            locale: locale
+        )
+    }
 }
 
 enum AddressOptionsPresentableFactory {
@@ -218,7 +244,7 @@ enum AddressOptionsPresentableFactory {
             R.string.localizable.commonCopyAddress(preferredLanguages: locale.rLanguages)
         }
 
-        var builder = ChainAddressDetailsModelBuilder(
+        let builder = ChainAddressDetailsModelBuilder(
             address: address,
             titleText: title
         ).addAction(

--- a/novawallet/Common/Services/DelegatedAccounts/SyncService/DelegatedAccountChangesCalculator/DelegatedMetaAccountFactory/MultisigMetaAccountFactory.swift
+++ b/novawallet/Common/Services/DelegatedAccounts/SyncService/DelegatedAccountChangesCalculator/DelegatedMetaAccountFactory/MultisigMetaAccountFactory.swift
@@ -9,18 +9,10 @@ final class MultisigMetaAccountFactory {
 }
 
 private extension MultisigMetaAccountFactory {
-    enum MultisigMetaAccountType {
-        case singleChain(ChainAccountModel)
-        case universalSubstrate(DelegatedAccount.MultisigAccountModel)
-        case universalEvm(DelegatedAccount.MultisigAccountModel)
-    }
-}
-
-private extension MultisigMetaAccountFactory {
     func createMultisigType(
         discoveredMultisig: DiscoveredMultisig,
         metaAccounts: [ManagedMetaAccountModel]
-    ) -> MultisigMetaAccountType? {
+    ) -> MetaAccountModel.MultisigAccountType? {
         let signatoryAccountId = discoveredMultisig.signatory
 
         let signatoryWallets: [MetaAccountModel] = metaAccounts.compactMap { wallet in
@@ -168,7 +160,7 @@ extension MultisigMetaAccountFactory: DelegatedMetaAccountFactoryProtocol {
             return chainAccount.chainId == chainModel.chainId &&
                 delegatedAccount.delegateAccountId == localMultisig.signatory &&
                 delegatedAccount.accountId == localMultisig.accountId
-        case let .universal(localMultisig):
+        case let .universalSubstrate(localMultisig), let .universalEvm(localMultisig):
             return localMultisig.accountId == delegatedAccount.accountId &&
                 localMultisig.signatory == delegatedAccount.delegateAccountId
         }
@@ -194,7 +186,7 @@ extension MultisigMetaAccountFactory: DelegatedMetaAccountFactoryProtocol {
         return switch localMultisigAccountType {
         case let .singleChain(chainAccount):
             chainAccount.chainId == chainModel.chainId
-        case .universal:
+        case .universalEvm, .universalSubstrate:
             true
         }
     }

--- a/novawallet/Modules/ManageWallets/AccountManagement/AccountManagementPresenter.swift
+++ b/novawallet/Modules/ManageWallets/AccountManagement/AccountManagementPresenter.swift
@@ -115,21 +115,29 @@ private extension AccountManagementPresenter {
             let multisigAccount = wallet?.multisigAccount
         else { return }
 
-        let chain: ChainModel? = switch multisigAccount {
+        switch multisigAccount {
         case let .singleChain(chainAccount):
-            chains[chainAccount.chainId]
-        case .universal:
-            chains[KnowChainId.polkadot]
+            guard let chain = chains[chainAccount.chainId] else { return }
+
+            wireframe.presentAccountOptions(
+                from: view,
+                address: address,
+                chain: chain,
+                locale: selectedLocale
+            )
+        case .universalSubstrate:
+            wireframe.presentSubstrateAddressOptions(
+                from: view,
+                address: address,
+                locale: selectedLocale
+            )
+        case .universalEvm:
+            wireframe.presentEvmAddressOptions(
+                from: view,
+                address: address,
+                locale: selectedLocale
+            )
         }
-
-        guard let chain else { return }
-
-        wireframe.presentAccountOptions(
-            from: view,
-            address: address,
-            chain: chain,
-            locale: selectedLocale
-        )
     }
 
     // MARK: Common bottom sheet

--- a/novawallet/Modules/ManageWallets/AccountManagement/ViewModel/AccountManagementViewModelFactory.swift
+++ b/novawallet/Modules/ManageWallets/AccountManagement/ViewModel/AccountManagementViewModelFactory.swift
@@ -165,8 +165,10 @@ private extension AccountManagementViewModelFactory {
             } else {
                 .multichainDisplayFormat
             }
-        case .universal:
+        case .universalSubstrate:
             .multichainDisplayFormat
+        case .universalEvm:
+            .ethereum
         }
 
         let signatoryViewModel = createDelegateViewModel(


### PR DESCRIPTION
### SUMMARY

This PR fixes an incorrect address format used for displaying signatory addresses in the `AccountManagement` module.

### SOLUTION

We are modifying `MultisigAccountType` to support both universal substrate and evm msigs for improved flexibility. Additionally, for universal multisig accounts, we now utilize the ledger's address options sheet, ensuring consistency with the Android implementation.

### SCREENSHOTS

<img width=45% height=45% alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-08-13 at 15 43 30" src="https://github.com/user-attachments/assets/15c18664-b64d-4f27-9a9c-ff4be824f77d" />
<img width=45% height=45% alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-08-13 at 15 43 19" src="https://github.com/user-attachments/assets/f491ec6e-22a3-4ce4-9ff1-7e47f17f3a53" />

