### PR TITLE
handle delegated account formatting

### DIFF
--- a/NovaPushNotificationServiceExtension/Handlers/Multisig/CommonMultisigHandler.swift
+++ b/NovaPushNotificationServiceExtension/Handlers/Multisig/CommonMultisigHandler.swift
@@ -187,25 +187,42 @@ private extension CommonMultisigHandler {
         adding operationSpecificPart: String,
         chain: ChainModel
     ) -> String {
-        let commonBodyPart: String
+        let commonPart: String
 
         switch formattedCall.definition {
         case let .transfer(transfer):
-            commonBodyPart = createTransferBodyContent(for: transfer)
+            commonPart = createTransferBodyContent(for: transfer)
         case let .batch(batch):
-            commonBodyPart = createBatchBodyContent(for: batch, chain: chain)
+            commonPart = createBatchBodyContent(for: batch, chain: chain)
         case let .general(general):
-            commonBodyPart = createGeneralBodyContent(for: general, chain: chain)
+            commonPart = createGeneralBodyContent(for: general, chain: chain)
         }
 
-        return createBody(using: commonBodyPart, adding: operationSpecificPart)
+        guard
+            let delegatedAccount = formattedCall.delegatedAccount,
+            let delegatedAddress = try? delegatedAccount.accountId.toAddress(using: chain.chainFormat).mediumTruncated
+        else {
+            return createBody(using: commonPart, adding: operationSpecificPart)
+        }
+
+        let delegatedAccountPart = [
+            R.string.localizable.pushNotificationOnBehalfOf(preferredLanguages: locale.rLanguages),
+            delegatedAddress
+        ].joined(with: .space)
+
+        let delegatedCommonPart = [
+            commonPart,
+            delegatedAccountPart
+        ].joined(with: .newLine)
+
+        return createBody(using: delegatedCommonPart, adding: operationSpecificPart)
     }
 
     func createBody(
         using commonBodyPart: String,
         adding operationSpecificPart: String
     ) -> String {
-        [commonBodyPart, operationSpecificPart].joined(with: .space)
+        [commonBodyPart, operationSpecificPart].joined(with: .newLine)
     }
 
     func createCallFormattingOperationFactory(

--- a/NovaPushNotificationServiceExtension/Handlers/Multisig/CommonMultisigHandler.swift
+++ b/NovaPushNotificationServiceExtension/Handlers/Multisig/CommonMultisigHandler.swift
@@ -200,14 +200,14 @@ private extension CommonMultisigHandler {
 
         guard
             let delegatedAccount = formattedCall.delegatedAccount,
-            let delegatedAddress = try? delegatedAccount.accountId.toAddress(using: chain.chainFormat).mediumTruncated
+            let delegatedAddress = try? delegatedAccount.accountId.toAddress(using: chain.chainFormat)
         else {
             return createBody(using: commonPart, adding: operationSpecificPart)
         }
 
         let delegatedAccountPart = [
             R.string.localizable.pushNotificationOnBehalfOf(preferredLanguages: locale.rLanguages),
-            delegatedAddress
+            delegatedAddress.mediumTruncated
         ].joined(with: .space)
 
         let delegatedCommonPart = [

--- a/NovaPushNotificationServiceExtension/en.lproj/Localizable.strings
+++ b/NovaPushNotificationServiceExtension/en.lproj/Localizable.strings
@@ -41,3 +41,4 @@
 "push.notification.multisig.cancelled.title" = "❌ Multisig transaction rejected";
 "push.notification.multisig.cancelled.body" = "Rejected by %@.";
 "push.notification.multisig.unknown.body" = "Unknown operation on %@.";
+"push.notification.on.behalf.of" = "On behalf of";

--- a/novawallet/Common/Extension/Foundation/String+Split.swift
+++ b/novawallet/Common/Extension/Foundation/String+Split.swift
@@ -12,6 +12,7 @@ extension String {
     enum CompoundSeparator: String {
         case commaSpace = ", "
         case colonSpace = ": "
+        case newLine = "\n"
     }
 
     func split(by separator: Separator, maxSplits: Int = .max) -> [String] {


### PR DESCRIPTION
### SUMMARY

The PR extends common notification body construction logic with delegated account formatting. Also changed part separators to `.newLine` according to mockups.