### PR TITLE
Fix controller check for redeem operation

### DIFF
--- a/novawallet/Common/DataProvider/Subscription/AccountLocalStorageSubscriber.swift
+++ b/novawallet/Common/DataProvider/Subscription/AccountLocalStorageSubscriber.swift
@@ -16,7 +16,10 @@ extension AccountLocalStorageSubscriber {
         _ accountId: AccountId,
         chain: ChainModel
     ) -> StreamableProvider<MetaAccountModel> {
-        let provider = accountProviderFactory.createStreambleProvider(for: accountId)
+        let provider = accountProviderFactory.createStreambleProvider(
+            for: accountId,
+            chainId: chain.chainId
+        )
 
         let updateClosure = { [weak self] (changes: [DataProviderChange<MetaAccountModel>]) in
             let maybeAccount: MetaChainAccountResponse? = changes.compactMap { change in

--- a/novawallet/Common/Extension/Foundation/Predicate/NSPredicate+Filter.swift
+++ b/novawallet/Common/Extension/Foundation/Predicate/NSPredicate+Filter.swift
@@ -55,6 +55,36 @@ extension NSPredicate {
         ])
     }
 
+    static func filterMetaAccount(
+        accountId: AccountId,
+        chainId: ChainModel.Id
+    ) -> NSPredicate {
+        let hexAccountId = accountId.toHex()
+
+        let substrateAccountFilter = NSPredicate(
+            format: "%K == %@",
+            #keyPath(CDMetaAccount.substrateAccountId), hexAccountId
+        )
+
+        let ethereumAccountFilter = NSPredicate(
+            format: "%K == %@",
+            #keyPath(CDMetaAccount.ethereumAddress), hexAccountId
+        )
+
+        let chainAccountFilter = NSPredicate(
+            format: "SUBQUERY(%K, $account, $account.%K == %@ AND $account.%K == %@).@count > 0",
+            #keyPath(CDMetaAccount.chainAccounts),
+            #keyPath(CDChainAccount.accountId), hexAccountId,
+            #keyPath(CDChainAccount.chainId), chainId
+        )
+
+        return NSCompoundPredicate(orPredicateWithSubpredicates: [
+            substrateAccountFilter,
+            ethereumAccountFilter,
+            chainAccountFilter
+        ])
+    }
+
     static func metaAccountById(_ identifier: String) -> NSPredicate {
         NSPredicate(format: "%K == %@", #keyPath(CDMetaAccount.metaId), identifier)
     }

--- a/novawallet/Common/Helpers/AccountProviderFactory.swift
+++ b/novawallet/Common/Helpers/AccountProviderFactory.swift
@@ -6,7 +6,8 @@ protocol AccountProviderFactoryProtocol {
     var operationManager: OperationManagerProtocol { get }
 
     func createStreambleProvider(
-        for accountId: AccountId
+        for accountId: AccountId,
+        chainId: ChainModel.Id
     ) -> StreamableProvider<MetaAccountModel>
 }
 
@@ -26,11 +27,16 @@ final class AccountProviderFactory: AccountProviderFactoryProtocol {
     }
 
     func createStreambleProvider(
-        for accountId: AccountId
+        for accountId: AccountId,
+        chainId: ChainModel.Id
     ) -> StreamableProvider<MetaAccountModel> {
         let mapper = MetaAccountMapper()
 
-        let filter = NSPredicate.filterMetaAccountByAccountId(accountId)
+        let filter = NSPredicate.filterMetaAccount(
+            accountId: accountId,
+            chainId: chainId
+        )
+
         let repository: CoreDataRepository<MetaAccountModel, CDMetaAccount> = storageFacade
             .createRepository(
                 filter: filter,
@@ -51,7 +57,7 @@ final class AccountProviderFactory: AccountProviderFactoryProtocol {
                                 return false
                             }
 
-                            return chainAccount.accountId == hexAccountId
+                            return chainAccount.accountId == hexAccountId && chainAccount.chainId == chainId
                         }
                     ) ?? false
             }


### PR DESCRIPTION
## Purpose

When there are wallet changes after staking details opened then accounts discovered for controller and stash might be getting cleared. For example, when there are discovered proxies on Kusama the for Polkadot staking AccountProvider might report changes not in the Polkadot.

## Solution

The issue is fixed by providing more strict filters for AccountProvider to not notify about non actual wallets