### PR TITLE
Add delegated accounts chain filter strategy

### DIFF
--- a/novawallet/Common/Services/ServiceCoordinator.swift
+++ b/novawallet/Common/Services/ServiceCoordinator.swift
@@ -222,7 +222,7 @@ extension ServiceCoordinator {
             chainRegistry: chainRegistry,
             metaAccountsRepository: metaAccountsRepository,
             walletUpdateMediator: walletUpdateMediator,
-            chainFilter: .allSatisfies([.enabledChains, .hasProxy]),
+            chainFilter: .allSatisfies([.enabledChains, .hasDelegatedAccounts]),
             chainWalletFilter: { wallet in
                 #if F_RELEASE
                     return wallet.type != .watchOnly

--- a/novawalletTests/Helper/ChainModelGenerator.swift
+++ b/novawalletTests/Helper/ChainModelGenerator.swift
@@ -188,6 +188,7 @@ enum ChainModelGenerator {
         hasCrowdloans: Bool = false,
         hasSubstrateRuntime: Bool = true,
         hasProxy: Bool = true,
+        hasMultisig: Bool = true,
         enabled: Bool = true
     ) -> ChainModel {
         let assets = (0..<count).map { index in
@@ -207,6 +208,7 @@ enum ChainModelGenerator {
             hasCrowdloans: hasCrowdloans,
             hasSubstrateRuntime: hasSubstrateRuntime,
             hasProxy: hasProxy,
+            hasMultisig: hasMultisig,
             enabled: enabled
         )
     }
@@ -220,6 +222,7 @@ enum ChainModelGenerator {
         hasCrowdloans: Bool = false,
         hasSubstrateRuntime: Bool = true,
         hasProxy: Bool = true,
+        hasMultisig: Bool = true,
         enabled: Bool = true
     ) -> ChainModel {
         let chainId = defaultChainId ?? Data.random(of: 32)!.toHex()
@@ -246,6 +249,10 @@ enum ChainModelGenerator {
         
         if hasProxy {
             options.append(.proxy)
+        }
+        
+        if hasMultisig {
+            options.append(.multisig)
         }
 
         let externalApis = generateExternaApis(


### PR DESCRIPTION
### SUMMARY

The PR adds `hasDelegatedAccounts` filter strategy and integrates it for `DelegatedAccountSyncService`.