### PR TITLE
Fix approval button for multisig operation

### DIFF
--- a/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/Factory/MultisigOperationConfirmViewModelFactory.swift
+++ b/novawallet/Modules/DelegatedAccounts/Multisig/MultisigOperationConfirm/Factory/MultisigOperationConfirmViewModelFactory.swift
@@ -491,12 +491,14 @@ private extension MultisigOperationConfirmViewModelFactory {
         let hasCall = pendingOperation.operation.call != nil
             || pendingOperation.formattedModel?.decoded != nil
         let createdBySignatory = pendingOperation.operation.isCreator(accountId: multisigContext.signatory)
+        let approvedBySignatory = definition.approvals.contains(multisigContext.signatory)
         let approved = definition.approvals.count >= multisigContext.threshold
         let willExecute = (multisigContext.threshold - definition.approvals.count) == 1
 
         return OperationProperties(
             hasCall: hasCall,
             createdBySignatory: createdBySignatory,
+            approvedBySignatory: approvedBySignatory,
             approved: approved,
             willExecute: willExecute
         )
@@ -610,6 +612,7 @@ extension MultisigOperationConfirmViewModelFactory: MultisigOperationConfirmView
 private struct OperationProperties {
     let hasCall: Bool
     let createdBySignatory: Bool
+    let approvedBySignatory: Bool
     let approved: Bool
     let willExecute: Bool
 
@@ -618,7 +621,7 @@ private struct OperationProperties {
     }
 
     var canApprove: Bool {
-        !createdBySignatory && hasCall
+        !approvedBySignatory && hasCall
     }
 
     var canReject: Bool {


### PR DESCRIPTION
### SUMMARY
This PR fixes the approval button presentation logic for the multisig operation confirmation screen.

### SOLUTION
Previously, we were adding the approval button depending on the multisig depositor. The result was that the button was shown even if the transaction was signed from another client.

The solution is to check if the current signatory is contained in the approvals.