### PR TITLE
[AH-Migration] Aggregate staking rewards APIs

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -987,17 +987,17 @@
 		0CB261F52A9E188300287305 /* NominationPoolsBondExtraCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB261F42A9E188300287305 /* NominationPoolsBondExtraCall.swift */; };
 		0CB261F72A9E2D8400287305 /* StackSwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB261F62A9E2D8400287305 /* StackSwitchCell.swift */; };
 		0CB261F92A9F1F2200287305 /* NPoolsRedeemError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB261F82A9F1F2200287305 /* NPoolsRedeemError.swift */; };
+		0CB2E88E2E5DC3100067DE12 /* NominationPools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C893E6C2A6562B400781503 /* NominationPools.swift */; };
+		0CB2E88F2E5DC3170067DE12 /* NominationPools+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C893E6E2A65702A00781503 /* NominationPools+CodingPath.swift */; };
+		0CB2E8902E5DC3200067DE12 /* NominationPools+Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB06E722A6800F500C7EC99 /* NominationPools+Functions.swift */; };
+		0CB2E8912E5DC34B0067DE12 /* Staking+Era.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CBF19FE2E435EE8009EE38D /* Staking+Era.swift */; };
+		0CB2E8932E5DC3B20067DE12 /* AssetStorageInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB2E8922E5DC3B20067DE12 /* AssetStorageInfo.swift */; };
 		0CB2E8972E5EF9EB0067DE12 /* DiscoverProxiesAccountsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB2E8962E5EF9EB0067DE12 /* DiscoverProxiesAccountsRepository.swift */; };
 		0CB2E8992E5EFC2D0067DE12 /* DelegatedAccountsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB2E8982E5EFC2D0067DE12 /* DelegatedAccountsRepository.swift */; };
 		0CB2E89B2E5EFE250067DE12 /* AccountIdKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB2E89A2E5EFE250067DE12 /* AccountIdKey.swift */; };
 		0CB2E89D2E5EFE6F0067DE12 /* ProxyFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB2E89C2E5EFE6F0067DE12 /* ProxyFilter.swift */; };
 		0CB2E8A02E5EFEC20067DE12 /* ProxyDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB2E89F2E5EFEC20067DE12 /* ProxyDefinitions.swift */; };
 		0CB2E8A32E5F0CA80067DE12 /* Proxy+Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB2E8A22E5F0CA80067DE12 /* Proxy+Account.swift */; };
-		0CB2E88E2E5DC3100067DE12 /* NominationPools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C893E6C2A6562B400781503 /* NominationPools.swift */; };
-		0CB2E88F2E5DC3170067DE12 /* NominationPools+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C893E6E2A65702A00781503 /* NominationPools+CodingPath.swift */; };
-		0CB2E8902E5DC3200067DE12 /* NominationPools+Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB06E722A6800F500C7EC99 /* NominationPools+Functions.swift */; };
-		0CB2E8912E5DC34B0067DE12 /* Staking+Era.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CBF19FE2E435EE8009EE38D /* Staking+Era.swift */; };
-		0CB2E8932E5DC3B20067DE12 /* AssetStorageInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB2E8922E5DC3B20067DE12 /* AssetStorageInfo.swift */; };
 		0CB3135F2C0F051700353724 /* EnterCloudPasswordFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB3135E2C0F051700353724 /* EnterCloudPasswordFlow.swift */; };
 		0CB313622C0F09B800353724 /* BaseBackupEnterPasswordInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB313612C0F09B800353724 /* BaseBackupEnterPasswordInteractor.swift */; };
 		0CB313652C0F0D0900353724 /* CloudBackupEnterPasswordSetInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB313642C0F0D0900353724 /* CloudBackupEnterPasswordSetInteractor.swift */; };
@@ -1582,6 +1582,7 @@
 		2D0A82F12CB573BB0043B330 /* PayCardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0A82EF2CB5722C0043B330 /* PayCardStatus.swift */; };
 		2D0B77F72D14392500654497 /* UIApplication+TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0B77F62D14392500654497 /* UIApplication+TabBarController.swift */; };
 		2D0C3B5D2D1E95650094AF20 /* DAppSearchingByQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0C3B5C2D1E95650094AF20 /* DAppSearchingByQuery.swift */; };
+		2D1210002E6EB54C00330920 /* SubqueryRewardAggregatingWrapperFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D120FFF2E6EB54C00330920 /* SubqueryRewardAggregatingWrapperFactory.swift */; };
 		2D141FDC2C5AE4230013D952 /* EndedReferendumProgressViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D141FDB2C5AE4230013D952 /* EndedReferendumProgressViewModelFactory.swift */; };
 		2D15850F2D3AA5FC00E86DA8 /* UpdatedWalletBrowserStateCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D15850E2D3AA5FC00E86DA8 /* UpdatedWalletBrowserStateCleaner.swift */; };
 		2D1A5F552C358E280073773D /* CustomNetworkSetupFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1A5F542C358E280073773D /* CustomNetworkSetupFactory.swift */; };
@@ -7473,13 +7474,13 @@
 		0CB261F42A9E188300287305 /* NominationPoolsBondExtraCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NominationPoolsBondExtraCall.swift; sourceTree = "<group>"; };
 		0CB261F62A9E2D8400287305 /* StackSwitchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackSwitchCell.swift; sourceTree = "<group>"; };
 		0CB261F82A9F1F2200287305 /* NPoolsRedeemError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NPoolsRedeemError.swift; sourceTree = "<group>"; };
+		0CB2E8922E5DC3B20067DE12 /* AssetStorageInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetStorageInfo.swift; sourceTree = "<group>"; };
 		0CB2E8962E5EF9EB0067DE12 /* DiscoverProxiesAccountsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverProxiesAccountsRepository.swift; sourceTree = "<group>"; };
 		0CB2E8982E5EFC2D0067DE12 /* DelegatedAccountsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegatedAccountsRepository.swift; sourceTree = "<group>"; };
 		0CB2E89A2E5EFE250067DE12 /* AccountIdKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountIdKey.swift; sourceTree = "<group>"; };
 		0CB2E89C2E5EFE6F0067DE12 /* ProxyFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyFilter.swift; sourceTree = "<group>"; };
 		0CB2E89F2E5EFEC20067DE12 /* ProxyDefinitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyDefinitions.swift; sourceTree = "<group>"; };
 		0CB2E8A22E5F0CA80067DE12 /* Proxy+Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Proxy+Account.swift"; sourceTree = "<group>"; };
-		0CB2E8922E5DC3B20067DE12 /* AssetStorageInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetStorageInfo.swift; sourceTree = "<group>"; };
 		0CB3135E2C0F051700353724 /* EnterCloudPasswordFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterCloudPasswordFlow.swift; sourceTree = "<group>"; };
 		0CB313612C0F09B800353724 /* BaseBackupEnterPasswordInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBackupEnterPasswordInteractor.swift; sourceTree = "<group>"; };
 		0CB313642C0F0D0900353724 /* CloudBackupEnterPasswordSetInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupEnterPasswordSetInteractor.swift; sourceTree = "<group>"; };
@@ -8073,6 +8074,7 @@
 		2D0A82EF2CB5722C0043B330 /* PayCardStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayCardStatus.swift; sourceTree = "<group>"; };
 		2D0B77F62D14392500654497 /* UIApplication+TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+TabBarController.swift"; sourceTree = "<group>"; };
 		2D0C3B5C2D1E95650094AF20 /* DAppSearchingByQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppSearchingByQuery.swift; sourceTree = "<group>"; };
+		2D120FFF2E6EB54C00330920 /* SubqueryRewardAggregatingWrapperFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubqueryRewardAggregatingWrapperFactory.swift; sourceTree = "<group>"; };
 		2D141FDB2C5AE4230013D952 /* EndedReferendumProgressViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndedReferendumProgressViewModelFactory.swift; sourceTree = "<group>"; };
 		2D15850E2D3AA5FC00E86DA8 /* UpdatedWalletBrowserStateCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatedWalletBrowserStateCleaner.swift; sourceTree = "<group>"; };
 		2D1A5F542C358E280073773D /* CustomNetworkSetupFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNetworkSetupFactory.swift; sourceTree = "<group>"; };
@@ -24070,6 +24072,7 @@
 				8455F1942A1DD6BD003F072D /* Filter */,
 				849AFEBB26DCCDDD00B65924 /* Models */,
 				84412EE026DAC3300049577A /* SubqueryHistoryOperationFactory.swift */,
+				2D120FFF2E6EB54C00330920 /* SubqueryRewardAggregatingWrapperFactory.swift */,
 				843461D026E2641500DCE0CD /* SubqueryRewardOperationFactory.swift */,
 				84DC3CE22795E0340038E2ED /* SubqueryHistoryOperationFactory+RemoteHistory.swift */,
 				84DC3CE42796768A0038E2ED /* SubqueryHistoryContext.swift */,
@@ -33815,6 +33818,7 @@
 				0CEB6B4F2CA6AC9700609DC2 /* UIEdgeInsets+Init.swift in Sources */,
 				0C13DFD12AF8AE3E00E5F355 /* SwapBasePresenter.swift in Sources */,
 				88FB7DD12950720800784E08 /* ContainerProtocols.swift in Sources */,
+				2D1210002E6EB54C00330920 /* SubqueryRewardAggregatingWrapperFactory.swift in Sources */,
 				840AE2E529C9AF9C008FF665 /* EtherscanWalletHistoryDecodable.swift in Sources */,
 				772B1C7D2A93837800A19061 /* StartStakingCustomValidatorListWireframe.swift in Sources */,
 				0CD846432BE352D10026B5CA /* PreferredValidatorsProvider.swift in Sources */,

--- a/novawallet/Common/DataProvider/NPoolsLocalSubscriptionFactory.swift
+++ b/novawallet/Common/DataProvider/NPoolsLocalSubscriptionFactory.swift
@@ -82,8 +82,14 @@ private extension NPoolsLocalSubscriptionFactory {
         var hasher = Hasher()
 
         hasher.combine(address)
-        hasher.combine(startTimestamp ?? 0)
-        hasher.combine(endTimestamp ?? 0)
+
+        if let startTimestamp {
+            hasher.combine(startTimestamp)
+        }
+
+        if let endTimestamp {
+            hasher.combine(endTimestamp)
+        }
 
         api
             .map(\.url.absoluteString)

--- a/novawallet/Common/DataProvider/StakingAnalyticsLocalSubscriptionFactory.swift
+++ b/novawallet/Common/DataProvider/StakingAnalyticsLocalSubscriptionFactory.swift
@@ -28,6 +28,24 @@ final class StakingAnalyticsLocalSubscriptionFactory {
     }
 }
 
+private extension StakingAnalyticsLocalSubscriptionFactory {
+    func createHash(
+        for address: AccountAddress,
+        urls: [URL]
+    ) -> Int {
+        var hasher = Hasher()
+
+        hasher.combine(address)
+
+        urls
+            .map(\.absoluteString)
+            .sorted()
+            .forEach { hasher.combine($0) }
+
+        return hasher.finalize()
+    }
+}
+
 extension StakingAnalyticsLocalSubscriptionFactory: StakingAnalyticsLocalSubscriptionFactoryProtocol {
     func getWeaklyAnalyticsProvider(
         for address: AccountAddress,
@@ -35,7 +53,8 @@ extension StakingAnalyticsLocalSubscriptionFactory: StakingAnalyticsLocalSubscri
     ) -> AnySingleValueProvider<[SubqueryRewardItemData]> {
         clearIfNeeded()
 
-        let identifier = "weaklyAnalytics" + address + urls.map(\.absoluteString).joined(with: .dash)
+        let hash = createHash(for: address, urls: urls)
+        let identifier = "weaklyAnalytics_\(hash)"
 
         if let provider = getProvider(for: identifier) as? SingleValueProvider<[SubqueryRewardItemData]> {
             return AnySingleValueProvider(provider)

--- a/novawallet/Common/DataProvider/StakingRewardsLocalSubscriptionFactory.swift
+++ b/novawallet/Common/DataProvider/StakingRewardsLocalSubscriptionFactory.swift
@@ -25,7 +25,7 @@ final class StakingRewardsLocalSubscriptionFactory: SubstrateLocalSubscriptionFa
         let timeIdentifier = [
             startTimestamp.map { "\($0)" } ?? "nil",
             endTimestamp.map { "\($0)" } ?? "nil"
-        ].joined(separator: "-")
+        ].joined(with: .dash)
 
         let identifier = ("reward" + api.map(\.url.absoluteString).joined(with: .dash))
             + address

--- a/novawallet/Common/DataProvider/Subscription/NPoolsLocalStorageHandler.swift
+++ b/novawallet/Common/DataProvider/Subscription/NPoolsLocalStorageHandler.swift
@@ -60,7 +60,7 @@ protocol NPoolsLocalSubscriptionHandler {
         for _: AccountAddress,
         startTimestamp: Int64?,
         endTimestamp: Int64?,
-        api _: LocalChainExternalApi
+        api _: Set<LocalChainExternalApi>
     )
 }
 
@@ -123,6 +123,6 @@ extension NPoolsLocalSubscriptionHandler {
         for _: AccountAddress,
         startTimestamp _: Int64?,
         endTimestamp _: Int64?,
-        api _: LocalChainExternalApi
+        api _: Set<LocalChainExternalApi>
     ) {}
 }

--- a/novawallet/Common/DataProvider/Subscription/NPoolsLocalStorageSubscriber.swift
+++ b/novawallet/Common/DataProvider/Subscription/NPoolsLocalStorageSubscriber.swift
@@ -65,7 +65,7 @@ protocol NPoolsLocalStorageSubscriber: LocalStorageProviderObserving where Self:
         for address: AccountAddress,
         startTimestamp: Int64?,
         endTimestamp: Int64?,
-        api: LocalChainExternalApi,
+        api: Set<LocalChainExternalApi>,
         assetPrecision: Int16
     ) -> AnySingleValueProvider<TotalRewardItem>?
 }
@@ -452,7 +452,7 @@ extension NPoolsLocalStorageSubscriber where Self: NPoolsLocalSubscriptionHandle
         for address: AccountAddress,
         startTimestamp: Int64?,
         endTimestamp: Int64?,
-        api: LocalChainExternalApi,
+        api: Set<LocalChainExternalApi>,
         assetPrecision: Int16
     ) -> AnySingleValueProvider<TotalRewardItem>? {
         guard let provider = try? npoolsLocalSubscriptionFactory.getTotalReward(

--- a/novawallet/Common/DataProvider/Subscription/StakingAnalyticsLocalStorageSubscriber.swift
+++ b/novawallet/Common/DataProvider/Subscription/StakingAnalyticsLocalStorageSubscriber.swift
@@ -8,24 +8,24 @@ protocol StakingAnalyticsLocalStorageSubscriber where Self: AnyObject {
 
     func subscribeWeaklyRewardAnalytics(
         for address: AccountAddress,
-        url: URL
+        urls: [URL]
     ) -> AnySingleValueProvider<[SubqueryRewardItemData]>?
 }
 
 extension StakingAnalyticsLocalStorageSubscriber {
     func subscribeWeaklyRewardAnalytics(
         for address: AccountAddress,
-        url: URL
+        urls: [URL]
     ) -> AnySingleValueProvider<[SubqueryRewardItemData]>? {
         let provider = stakingAnalyticsLocalSubscriptionFactory
-            .getWeaklyAnalyticsProvider(for: address, url: url)
+            .getWeaklyAnalyticsProvider(for: address, urls: urls)
 
         let updateClosure = { [weak self] (changes: [DataProviderChange<[SubqueryRewardItemData]>]) in
             let result = changes.reduceToLastChange()
             self?.stakingAnalyticsLocalSubscriptionHandler.handleWeaklyRewardAnalytics(
                 result: .success(result),
                 address: address,
-                url: url
+                urls: urls
             )
         }
 
@@ -33,7 +33,7 @@ extension StakingAnalyticsLocalStorageSubscriber {
             self?.stakingAnalyticsLocalSubscriptionHandler.handleWeaklyRewardAnalytics(
                 result: .failure(error),
                 address: address,
-                url: url
+                urls: urls
             )
             return
         }

--- a/novawallet/Common/DataProvider/Subscription/StakingAnalyticsLocalSubscriptionHandler.swift
+++ b/novawallet/Common/DataProvider/Subscription/StakingAnalyticsLocalSubscriptionHandler.swift
@@ -4,7 +4,7 @@ protocol StakingAnalyticsLocalSubscriptionHandler {
     func handleWeaklyRewardAnalytics(
         result: Result<[SubqueryRewardItemData]?, Error>,
         address: AccountAddress,
-        url: URL
+        urls: [URL]
     )
 }
 
@@ -12,6 +12,6 @@ extension StakingAnalyticsLocalSubscriptionHandler {
     func handleWeaklyRewardAnalytics(
         result _: Result<[SubqueryRewardItemData]?, Error>,
         address _: AccountAddress,
-        url _: URL
+        urls _: [URL]
     ) {}
 }

--- a/novawallet/Common/DataProvider/Subscription/StakingRewardsLocalHandler.swift
+++ b/novawallet/Common/DataProvider/Subscription/StakingRewardsLocalHandler.swift
@@ -5,7 +5,7 @@ protocol StakingRewardsLocalHandler {
     func handleTotalReward(
         result: Result<TotalRewardItem, Error>,
         for address: AccountAddress,
-        api: LocalChainExternalApi
+        api: Set<LocalChainExternalApi>
     )
 }
 
@@ -13,6 +13,6 @@ extension StakingRewardsLocalHandler {
     func handleTotalReward(
         result _: Result<TotalRewardItem, Error>,
         for _: AccountAddress,
-        api _: LocalChainExternalApi
+        api _: Set<LocalChainExternalApi>
     ) {}
 }

--- a/novawallet/Common/DataProvider/Subscription/StakingRewardsLocalSubscriber.swift
+++ b/novawallet/Common/DataProvider/Subscription/StakingRewardsLocalSubscriber.swift
@@ -10,7 +10,7 @@ protocol StakingRewardsLocalSubscriber: AnyObject {
         for address: AccountAddress,
         startTimestamp: Int64?,
         endTimestamp: Int64?,
-        api: LocalChainExternalApi,
+        api: Set<LocalChainExternalApi>,
         assetPrecision: Int16
     ) -> AnySingleValueProvider<TotalRewardItem>?
 }
@@ -20,7 +20,7 @@ extension StakingRewardsLocalSubscriber {
         for address: AccountAddress,
         startTimestamp: Int64?,
         endTimestamp: Int64?,
-        api: LocalChainExternalApi,
+        api: Set<LocalChainExternalApi>,
         assetPrecision: Int16
     ) -> AnySingleValueProvider<TotalRewardItem>? {
         guard let totalRewardProvider = try? stakingRewardsLocalSubscriptionFactory.getTotalReward(

--- a/novawallet/Common/Model/ChainRegistry/LocalChain/LocalChainExternalApi.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/LocalChainExternalApi.swift
@@ -48,6 +48,10 @@ struct LocalChainExternalApiSet: Codable, Equatable, Hashable {
     func staking() -> Set<LocalChainExternalApi>? {
         getApis(for: .staking)
     }
+    
+    func stakingRewards() -> Set<LocalChainExternalApi>? {
+        getApis(for: .stakingRewards)
+    }
 
     func history() -> Set<LocalChainExternalApi>? {
         getApis(for: .history)

--- a/novawallet/Common/Model/ChainRegistry/LocalChain/LocalChainExternalApi.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/LocalChainExternalApi.swift
@@ -48,7 +48,7 @@ struct LocalChainExternalApiSet: Codable, Equatable, Hashable {
     func staking() -> Set<LocalChainExternalApi>? {
         getApis(for: .staking)
     }
-    
+
     func stakingRewards() -> Set<LocalChainExternalApi>? {
         getApis(for: .stakingRewards)
     }

--- a/novawallet/Common/Model/ChainRegistry/LocalChain/LocalChainExternalApi.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/LocalChainExternalApi.swift
@@ -4,6 +4,7 @@ import SubstrateSdk
 enum LocalChainApiExternalType: String {
     case history
     case staking
+    case stakingRewards
     case governance
     case crowdloans
     case governanceDelegations
@@ -85,6 +86,7 @@ struct LocalChainExternalApiSet: Codable, Equatable, Hashable {
             .addingApis(from: remoteApi.goverananceDelegations, apiType: .governanceDelegations)
             .addingApis(from: remoteApi.referendumSummary, apiType: .referendumSummary)
             .addingApis(from: remoteApi.multisig, apiType: .multisig)
+            .addingApis(from: remoteApi.stakingRewards, apiType: .stakingRewards)
     }
 }
 

--- a/novawallet/Common/Model/ChainRegistry/RemoteChain/RemoteChainExternalApi.swift
+++ b/novawallet/Common/Model/ChainRegistry/RemoteChain/RemoteChainExternalApi.swift
@@ -10,6 +10,7 @@ struct RemoteChainExternalApi: Equatable, Codable {
 struct RemoteChainExternalApiSet: Equatable, Codable {
     enum CodingKeys: String, CodingKey {
         case staking
+        case stakingRewards = "staking-rewards"
         case history
         case crowdloans
         case governance
@@ -19,6 +20,7 @@ struct RemoteChainExternalApiSet: Equatable, Codable {
     }
 
     let staking: [RemoteChainExternalApi]?
+    let stakingRewards: [RemoteChainExternalApi]?
     let history: [RemoteChainExternalApi]?
     let crowdloans: [RemoteChainExternalApi]?
     let governance: [RemoteChainExternalApi]?

--- a/novawallet/Common/Network/Subquery/SubqueryRewardAggregatingWrapperFactory.swift
+++ b/novawallet/Common/Network/Subquery/SubqueryRewardAggregatingWrapperFactory.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Operation_iOS
+import BigInt
+
+protocol SubqueryRewardWrapperFactoryProtocol {
+    func createOperation(
+        address: String,
+        startTimestamp: Int64?,
+        endTimestamp: Int64?
+    ) -> CompoundOperationWrapper<SubqueryRewardOrSlashData>
+
+    func createTotalRewardOperation(
+        for address: AccountAddress,
+        startTimestamp: Int64?,
+        endTimestamp: Int64?,
+        stakingType: SubqueryStakingType
+    ) -> CompoundOperationWrapper<BigUInt>
+}
+
+final class SubqueryRewardAggregatingWrapperFactory {
+    let factories: [SubqueryRewardOperationFactoryProtocol]
+
+    init(factories: [SubqueryRewardOperationFactoryProtocol]) {
+        self.factories = factories
+    }
+}
+
+// MARK: - SubqueryRewardWrapperFactoryProtocol
+
+extension SubqueryRewardAggregatingWrapperFactory: SubqueryRewardWrapperFactoryProtocol {
+    func createOperation(
+        address: String,
+        startTimestamp: Int64?,
+        endTimestamp: Int64?
+    ) -> CompoundOperationWrapper<SubqueryRewardOrSlashData> {
+        let operations = factories.map {
+            $0.createOperation(
+                address: address,
+                startTimestamp: startTimestamp,
+                endTimestamp: endTimestamp
+            )
+        }
+
+        let mergeOperation = ClosureOperation<SubqueryRewardOrSlashData> {
+            let results = try operations.map { try $0.extractNoCancellableResultData() }
+            let nodes: [SubqueryHistoryElement] = results.flatMap(\.historyElements.nodes)
+
+            return SubqueryRewardOrSlashData(historyElements: .init(nodes: nodes))
+        }
+
+        operations.forEach { mergeOperation.addDependency($0) }
+
+        return CompoundOperationWrapper(
+            targetOperation: mergeOperation,
+            dependencies: operations
+        )
+    }
+
+    func createTotalRewardOperation(
+        for address: AccountAddress,
+        startTimestamp: Int64?,
+        endTimestamp: Int64?,
+        stakingType: SubqueryStakingType
+    ) -> CompoundOperationWrapper<BigUInt> {
+        let operations = factories.map {
+            $0.createTotalRewardOperation(
+                for: address,
+                startTimestamp: startTimestamp,
+                endTimestamp: endTimestamp,
+                stakingType: stakingType
+            )
+        }
+
+        let mergeOperation = ClosureOperation<BigUInt> {
+            try operations
+                .map { try $0.extractNoCancellableResultData() }
+                .reduce(0, +)
+        }
+
+        operations.forEach { mergeOperation.addDependency($0) }
+
+        return CompoundOperationWrapper(
+            targetOperation: mergeOperation,
+            dependencies: operations
+        )
+    }
+}

--- a/novawallet/Modules/Staking/StakingMain/Mythos/MythosStakingDetailsInteractor.swift
+++ b/novawallet/Modules/Staking/StakingMain/Mythos/MythosStakingDetailsInteractor.swift
@@ -257,7 +257,7 @@ extension MythosStakingDetailsInteractor {
 
         if
             let address = selectedAccount.chainAccount.toChecksumedAddress(),
-            let rewardApi = chain.externalApis?.staking()?.first {
+            let rewardApi = chain.externalApis?.stakingRewards() {
             totalRewardProvider = subscribeTotalReward(
                 for: address,
                 startTimestamp: totalRewardInterval?.startTimestamp,

--- a/novawallet/Modules/Staking/StakingMain/Mythos/MythosStakingDetailsInteractor.swift
+++ b/novawallet/Modules/Staking/StakingMain/Mythos/MythosStakingDetailsInteractor.swift
@@ -369,7 +369,7 @@ extension MythosStakingDetailsInteractor: StakingRewardsLocalSubscriber, Staking
     func handleTotalReward(
         result: Result<TotalRewardItem, Error>,
         for _: AccountAddress,
-        api _: LocalChainExternalApi
+        api _: Set<LocalChainExternalApi>
     ) {
         switch result {
         case let .success(rewardItem):

--- a/novawallet/Modules/Staking/StakingMain/NominationPools/StakingNPoolsInteractor.swift
+++ b/novawallet/Modules/Staking/StakingMain/NominationPools/StakingNPoolsInteractor.swift
@@ -344,7 +344,7 @@ extension StakingNPoolsInteractor: StakingNPoolsInteractorInputProtocol {
         totalRewardsPeriod = filter
 
         if let address = try? accountId.toAddress(using: chain.chainFormat) {
-            if let rewardApi = chain.externalApis?.staking()?.first {
+            if let rewardApi = chain.externalApis?.stakingRewards() {
                 let totalRewardInterval = filter.interval
                 totalRewardProvider = subscribePoolTotalReward(
                     for: address,
@@ -514,7 +514,7 @@ extension StakingNPoolsInteractor: NPoolsLocalStorageSubscriber, NPoolsLocalSubs
         for _: AccountAddress,
         startTimestamp: Int64?,
         endTimestamp: Int64?,
-        api _: LocalChainExternalApi
+        api _: Set<LocalChainExternalApi>
     ) {
         guard
             let interval = totalRewardsPeriod?.interval,

--- a/novawallet/Modules/Staking/StakingMain/Parachain/StakingParachainInteractor+Subscription.swift
+++ b/novawallet/Modules/Staking/StakingMain/Parachain/StakingParachainInteractor+Subscription.swift
@@ -179,7 +179,7 @@ extension StakingParachainInteractor: StakingRewardsLocalSubscriber, StakingRewa
     func handleTotalReward(
         result: Result<TotalRewardItem, Error>,
         for address: AccountAddress,
-        api _: LocalChainExternalApi
+        api _: Set<LocalChainExternalApi>
     ) {
         guard selectedAccount?.chainAccount.toChecksumedAddress() == address else {
             return

--- a/novawallet/Modules/Staking/StakingMain/Parachain/StakingParachainInteractor+Subscription.swift
+++ b/novawallet/Modules/Staking/StakingMain/Parachain/StakingParachainInteractor+Subscription.swift
@@ -56,7 +56,7 @@ extension StakingParachainInteractor {
 
         if
             let address = selectedAccount?.chainAccount.toChecksumedAddress(),
-            let rewardApi = selectedChainAsset.chain.externalApis?.staking()?.first {
+            let rewardApi = selectedChainAsset.chain.externalApis?.stakingRewards() {
             totalRewardProvider = subscribeTotalReward(
                 for: address,
                 startTimestamp: totalRewardInterval?.startTimestamp,

--- a/novawallet/Modules/Staking/StakingMain/Relaychain/StakingRelaychainInteractor+Subscription.swift
+++ b/novawallet/Modules/Staking/StakingMain/Relaychain/StakingRelaychainInteractor+Subscription.swift
@@ -52,7 +52,7 @@ extension StakingRelaychainInteractor {
         if
             let stashItem = stashItem,
             let chainAsset = selectedChainAsset {
-            if let rewardApi = chainAsset.chain.externalApis?.staking()?.first {
+            if let rewardApi = chainAsset.chain.externalApis?.stakingRewards() {
                 totalRewardProvider = subscribeTotalReward(
                     for: stashItem.stash,
                     startTimestamp: totalRewardInterval?.startTimestamp,

--- a/novawallet/Modules/Staking/StakingMain/Relaychain/StakingRelaychainInteractor+Subscription.swift
+++ b/novawallet/Modules/Staking/StakingMain/Relaychain/StakingRelaychainInteractor+Subscription.swift
@@ -262,7 +262,7 @@ extension StakingRelaychainInteractor: StakingRewardsLocalSubscriber, StakingRew
     func handleTotalReward(
         result: Result<TotalRewardItem, Error>,
         for _: AccountAddress,
-        api _: LocalChainExternalApi
+        api _: Set<LocalChainExternalApi>
     ) {
         switch result {
         case let .success(totalReward):

--- a/novawallet/Modules/Staking/StakingRewardPayouts/StakingRewardPayoutsViewFactory.swift
+++ b/novawallet/Modules/Staking/StakingRewardPayouts/StakingRewardPayoutsViewFactory.swift
@@ -11,12 +11,12 @@ final class StakingRewardPayoutsViewFactory {
     ) -> StakingRewardPayoutsViewProtocol? {
         let chainAsset = state.stakingOption.chainAsset
 
-        guard let rewardsUrl = chainAsset.chain.externalApis?.staking()?.first?.url else {
+        guard let rewardsUrls = chainAsset.chain.externalApis?.stakingRewards()?.map(\.url) else {
             return nil
         }
 
         let validatorsResolutionFactory = PayoutValidatorsForNominatorFactory(
-            url: rewardsUrl
+            urls: rewardsUrls
         )
 
         let payoutInfoFactory = NominatorPayoutInfoFactory(chainAssetInfo: chainAsset.chainAssetInfo)

--- a/novawalletIntegrationTests/PayoutRewardsServiceTests.swift
+++ b/novawalletIntegrationTests/PayoutRewardsServiceTests.swift
@@ -68,7 +68,8 @@ class PayoutRewardsServiceTests: XCTestCase {
         guard
             let chain = chainRegistry.getChain(for: chainId),
             let chainAsset = chain.utilityChainAsset(),
-            let rewardUrl = chain.externalApis?.staking()?.first?.url else {
+            let rewardUrls = chainAsset.chain.externalApis?.stakingRewards()?.map(\.url)
+        else {
             throw ChainRegistryError.connectionUnavailable
         }
 
@@ -77,7 +78,7 @@ class PayoutRewardsServiceTests: XCTestCase {
             operationManager: operationManager
         )
         let validatorsResolutionFactory = PayoutValidatorsForNominatorFactory(
-            url: rewardUrl
+            urls: rewardUrls
         )
 
         let identityOperationFactory = IdentityOperationFactory(requestFactory: storageRequestFactory)

--- a/novawalletTests/Common/DataProvider/RewardDataSourceTests.swift
+++ b/novawalletTests/Common/DataProvider/RewardDataSourceTests.swift
@@ -25,7 +25,7 @@ class RewardDataSourceTests: NetworkBaseTests {
                 return
             }
 
-            urls.forEach { TotalRewardMock.register(mock: .error, url: $0) }
+            urls.forEach { TotalRewardMock.register(mock: .westend, url: $0) }
 
             let expectedReward: Decimal = 5.0
 

--- a/novawalletTests/Helper/ChainModelGenerator.swift
+++ b/novawalletTests/Helper/ChainModelGenerator.swift
@@ -337,6 +337,7 @@ enum ChainModelGenerator {
 
         return .init(
             staking: externalApis.staking()?.map(generateRemoteExternal(from:)),
+            stakingRewards: externalApis.stakingRewards()?.map(generateRemoteExternal(from:)),
             history: externalApis.history()?.map(generateRemoteExternal(from:)),
             crowdloans: externalApis.crowdloans()?.map(generateRemoteExternal(from:)),
             governance: externalApis.governance()?.map(generateRemoteExternal(from:)),
@@ -375,8 +376,15 @@ enum ChainModelGenerator {
                 url: URL(string: "https://staking.io/\(chainId)-\(UUID().uuidString).json")!,
                 parameters: nil
             )
+            let stakingRewardsApi = LocalChainExternalApi(
+                apiType: LocalChainApiExternalType.stakingRewards.rawValue,
+                serviceType: "test",
+                url: URL(string: "https://staking.io/\(chainId)-\(UUID().uuidString).json")!,
+                parameters: nil
+            )
 
             apis.insert(stakingApi)
+            apis.insert(stakingRewardsApi)
         }
 
         if !apis.isEmpty {

--- a/novawalletTests/Mocks/DataProviders/StakingAnalyticsLocalSubscriptionFactoryStub.swift
+++ b/novawalletTests/Mocks/DataProviders/StakingAnalyticsLocalSubscriptionFactoryStub.swift
@@ -12,7 +12,7 @@ class StakingAnalyticsLocalSubscriptionFactoryStub {
 extension StakingAnalyticsLocalSubscriptionFactoryStub: StakingAnalyticsLocalSubscriptionFactoryProtocol {
     func getWeaklyAnalyticsProvider(
         for address: AccountAddress,
-        url: URL
+        urls: [URL]
     ) -> AnySingleValueProvider<[SubqueryRewardItemData]> {
         let provider = SingleValueProviderStub(item: weaklyAnalytics)
         return AnySingleValueProvider(provider)


### PR DESCRIPTION
### SUMMARY

The PR adds support for `staking-rewards` external API list. The values received from the indexers are merged in result value.
`staking-rewards` API is used in place of old `staking` API for rewards and payouts fetch.