### PR TITLE
Prepare for AHM

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -370,7 +370,7 @@
 		0C259EA42B46721B00CB86E4 /* DelegatedMessageSheetViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C259EA32B46721B00CB86E4 /* DelegatedMessageSheetViewFactory.swift */; };
 		0C259EA82B46C55C00CB86E4 /* ExtrinsicSigningErrorHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C259EA72B46C55C00CB86E4 /* ExtrinsicSigningErrorHandling.swift */; };
 		0C277D982D80779B004FF053 /* KodadotMediaViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C277D972D80779B004FF053 /* KodadotMediaViewModelFactory.swift */; };
-		0C277D9A2D814CB1004FF053 /* XcmTransferType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C277D992D814CB1004FF053 /* XcmTransferType.swift */; };
+		0C277D9A2D814CB1004FF053 /* XcmCallType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C277D992D814CB1004FF053 /* XcmCallType.swift */; };
 		0C277D9C2D8151C9004FF053 /* XcmCrosschainFeeCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C277D9B2D8151C9004FF053 /* XcmCrosschainFeeCalculation.swift */; };
 		0C277D9E2D815297004FF053 /* XcmLegacyCrosschainFeeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C277D9D2D815297004FF053 /* XcmLegacyCrosschainFeeCalculator.swift */; };
 		0C277DA02D829DB1004FF053 /* XcmDynamicTransfers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C277D9F2D829DB1004FF053 /* XcmDynamicTransfers.swift */; };
@@ -1005,6 +1005,11 @@
 		0CB433482CC0F9EF00F2CB59 /* AssetsHubExchange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB433472CC0F9EF00F2CB59 /* AssetsHubExchange.swift */; };
 		0CB4334C2CC10C3C00F2CB59 /* AssetsHydraExchangeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4334B2CC10C3C00F2CB59 /* AssetsHydraExchangeProvider.swift */; };
 		0CB4334E2CC1196400F2CB59 /* WeightableEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4334D2CC1196400F2CB59 /* WeightableEdge.swift */; };
+		0CB618CF2E70C3160018C766 /* XcmCustomTeleport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB618CE2E70C3160018C766 /* XcmCustomTeleport.swift */; };
+		0CB618D02E70C3160018C766 /* XcmCustomTeleport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB618CE2E70C3160018C766 /* XcmCustomTeleport.swift */; };
+		0CB618D22E70C3320018C766 /* Xcm+TransferType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB618D12E70C3320018C766 /* Xcm+TransferType.swift */; };
+		0CB618D32E70C3320018C766 /* Xcm+TransferType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB618D12E70C3320018C766 /* Xcm+TransferType.swift */; };
+		0CB618D52E70C4F00018C766 /* XcmUnweightedTransferRequest+TransferType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB618D42E70C4F00018C766 /* XcmUnweightedTransferRequest+TransferType.swift */; };
 		0CB64E5A2AFE9947008F268F /* GetTokenOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB64E592AFE9947008F268F /* GetTokenOperation.swift */; };
 		0CB64E5C2B009DA9008F268F /* GetTokenOptionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB64E5B2B009DA9008F268F /* GetTokenOptionsModel.swift */; };
 		0CB64E5E2B00AA8F008F268F /* GetTokenOptionsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB64E5D2B00AA8F008F268F /* GetTokenOptionsResult.swift */; };
@@ -2128,7 +2133,7 @@
 		2DEDEF9B2E4D1444008F07B2 /* XcmTotalFeeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C32728E2CD203F000FC1B42 /* XcmTotalFeeModel.swift */; };
 		2DEDEF9C2E4D1444008F07B2 /* XcmTransfersProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD61EC72D356B770064AC97 /* XcmTransfersProtocol.swift */; };
 		2DEDEF9D2E4D1444008F07B2 /* XcmTransfers+Protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD61ECD2D3572AC0064AC97 /* XcmTransfers+Protocol.swift */; };
-		2DEDEF9E2E4D1444008F07B2 /* XcmTransferType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C277D992D814CB1004FF053 /* XcmTransferType.swift */; };
+		2DEDEF9E2E4D1444008F07B2 /* XcmCallType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C277D992D814CB1004FF053 /* XcmCallType.swift */; };
 		2DEDEF9F2E4D1444008F07B2 /* XcmDynamicTransfers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C277D9F2D829DB1004FF053 /* XcmDynamicTransfers.swift */; };
 		2DEDEFA02E4D1444008F07B2 /* XcmDynamicChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C277DA12D829EC0004FF053 /* XcmDynamicChain.swift */; };
 		2DEDEFA12E4D1444008F07B2 /* XcmDynamicAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C277DA32D829EDC004FF053 /* XcmDynamicAsset.swift */; };
@@ -6814,7 +6819,7 @@
 		0C259EA32B46721B00CB86E4 /* DelegatedMessageSheetViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegatedMessageSheetViewFactory.swift; sourceTree = "<group>"; };
 		0C259EA72B46C55C00CB86E4 /* ExtrinsicSigningErrorHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrinsicSigningErrorHandling.swift; sourceTree = "<group>"; };
 		0C277D972D80779B004FF053 /* KodadotMediaViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KodadotMediaViewModelFactory.swift; sourceTree = "<group>"; };
-		0C277D992D814CB1004FF053 /* XcmTransferType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmTransferType.swift; sourceTree = "<group>"; };
+		0C277D992D814CB1004FF053 /* XcmCallType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmCallType.swift; sourceTree = "<group>"; };
 		0C277D9B2D8151C9004FF053 /* XcmCrosschainFeeCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmCrosschainFeeCalculation.swift; sourceTree = "<group>"; };
 		0C277D9D2D815297004FF053 /* XcmLegacyCrosschainFeeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmLegacyCrosschainFeeCalculator.swift; sourceTree = "<group>"; };
 		0C277D9F2D829DB1004FF053 /* XcmDynamicTransfers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmDynamicTransfers.swift; sourceTree = "<group>"; };
@@ -7484,6 +7489,9 @@
 		0CB433472CC0F9EF00F2CB59 /* AssetsHubExchange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsHubExchange.swift; sourceTree = "<group>"; };
 		0CB4334B2CC10C3C00F2CB59 /* AssetsHydraExchangeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsHydraExchangeProvider.swift; sourceTree = "<group>"; };
 		0CB4334D2CC1196400F2CB59 /* WeightableEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightableEdge.swift; sourceTree = "<group>"; };
+		0CB618CE2E70C3160018C766 /* XcmCustomTeleport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmCustomTeleport.swift; sourceTree = "<group>"; };
+		0CB618D12E70C3320018C766 /* Xcm+TransferType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Xcm+TransferType.swift"; sourceTree = "<group>"; };
+		0CB618D42E70C4F00018C766 /* XcmUnweightedTransferRequest+TransferType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XcmUnweightedTransferRequest+TransferType.swift"; sourceTree = "<group>"; };
 		0CB64E592AFE9947008F268F /* GetTokenOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTokenOperation.swift; sourceTree = "<group>"; };
 		0CB64E5B2B009DA9008F268F /* GetTokenOptionsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTokenOptionsModel.swift; sourceTree = "<group>"; };
 		0CB64E5D2B00AA8F008F268F /* GetTokenOptionsResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTokenOptionsResult.swift; sourceTree = "<group>"; };
@@ -13622,6 +13630,7 @@
 				0CED71B62D9C105200F79C02 /* XcmExecuteDerivator.swift */,
 				0C1CF6F42E4CC50B00B1DA66 /* XcmOneOfCallDerivation.swift */,
 				0C1CF6F62E4CC52000B1DA66 /* XcmCallDerivating.swift */,
+				0CB618D42E70C4F00018C766 /* XcmUnweightedTransferRequest+TransferType.swift */,
 			);
 			path = CallDerivation;
 			sourceTree = "<group>";
@@ -19940,7 +19949,7 @@
 				0C32728E2CD203F000FC1B42 /* XcmTotalFeeModel.swift */,
 				0CD61EC72D356B770064AC97 /* XcmTransfersProtocol.swift */,
 				0CD61ECD2D3572AC0064AC97 /* XcmTransfers+Protocol.swift */,
-				0C277D992D814CB1004FF053 /* XcmTransferType.swift */,
+				0C277D992D814CB1004FF053 /* XcmCallType.swift */,
 				0C277D9F2D829DB1004FF053 /* XcmDynamicTransfers.swift */,
 				0C277DA12D829EC0004FF053 /* XcmDynamicChain.swift */,
 				0C277DA32D829EDC004FF053 /* XcmDynamicAsset.swift */,
@@ -19948,6 +19957,7 @@
 				0C277DA72D82A2F9004FF053 /* XcmDynamicTransfers+Protocol.swift */,
 				0CA8AF322D86419400DB4E6A /* XcmTransfers.swift */,
 				0CFF82342D8C305A00DB17A4 /* XcmTransferOrigin.swift */,
+				0CB618CE2E70C3160018C766 /* XcmCustomTeleport.swift */,
 			);
 			path = Xcm;
 			sourceTree = "<group>";
@@ -26477,6 +26487,7 @@
 				0CFF821E2D8B580E00DB17A4 /* Xcm+Event.swift */,
 				84EBFCEA285E7E130006327E /* XcmWeightLimit.swift */,
 				0CE6F4E12DA08782002A57C5 /* Xcm+V4.swift */,
+				0CB618D12E70C3320018C766 /* Xcm+TransferType.swift */,
 			);
 			path = Xcm;
 			sourceTree = "<group>";
@@ -30093,8 +30104,9 @@
 				2DEDEF9B2E4D1444008F07B2 /* XcmTotalFeeModel.swift in Sources */,
 				2DEDEF9C2E4D1444008F07B2 /* XcmTransfersProtocol.swift in Sources */,
 				2DEDEF9D2E4D1444008F07B2 /* XcmTransfers+Protocol.swift in Sources */,
-				2DEDEF9E2E4D1444008F07B2 /* XcmTransferType.swift in Sources */,
+				2DEDEF9E2E4D1444008F07B2 /* XcmCallType.swift in Sources */,
 				2DEDEF9F2E4D1444008F07B2 /* XcmDynamicTransfers.swift in Sources */,
+				0CB618D02E70C3160018C766 /* XcmCustomTeleport.swift in Sources */,
 				2DE8B0942E54444600F8BD40 /* RuntimeCall+Init.swift in Sources */,
 				2DEDEFA02E4D1444008F07B2 /* XcmDynamicChain.swift in Sources */,
 				2DEDEFA12E4D1444008F07B2 /* XcmDynamicAsset.swift in Sources */,
@@ -30105,6 +30117,7 @@
 				2DEDEFA52E4D1444008F07B2 /* XcmTransferOrigin.swift in Sources */,
 				778215B92B91223D006C7D13 /* NotificationService.swift in Sources */,
 				2DEDF03A2E4D15CD008F07B2 /* DelegationResolutionPathFinder.swift in Sources */,
+				0CB618D32E70C3320018C766 /* Xcm+TransferType.swift in Sources */,
 				77AE4F902B9058D300426519 /* Web3AlertLocalModel.swift in Sources */,
 				7778FE5E2B910B8A0023E801 /* OperationManagerFacade.swift in Sources */,
 				2DEDEF882E4D135B008F07B2 /* (null) in Sources */,
@@ -31037,7 +31050,7 @@
 				2D6AED5F2C05EB47001A0A15 /* CheckboxListViewModelFactory.swift in Sources */,
 				0C29B5382A4C68A500E35C6D /* AnimationUpdatibleView.swift in Sources */,
 				2D039DE62BFC8D4000A928E5 /* GenericBackgroundView.swift in Sources */,
-				0C277D9A2D814CB1004FF053 /* XcmTransferType.swift in Sources */,
+				0C277D9A2D814CB1004FF053 /* XcmCallType.swift in Sources */,
 				84002AA32992508600A80672 /* GovernanceDelegateInteractorError.swift in Sources */,
 				840DFDD8277061ED00B62981 /* DAppOperationConfirmModel.swift in Sources */,
 				84F4393A25DAC48D00AEDA56 /* JSONRPCAliases.swift in Sources */,
@@ -32865,6 +32878,7 @@
 				84CEEDE2284E3DCE0039364A /* AccountDetailsNavigationCell.swift in Sources */,
 				0CCDB2FB2B75E938007BC5D6 /* HydraStableswapQuoteFactory.swift in Sources */,
 				77DAFF6B2B297CFE00D4220C /* ProxyListLocalSubscriptionFactory.swift in Sources */,
+				0CB618D52E70C4F00018C766 /* XcmUnweightedTransferRequest+TransferType.swift in Sources */,
 				8466781127EB4078007935D3 /* StackNetworkFeeCell.swift in Sources */,
 				0C8AF7BC2B38076900005AC9 /* Pdc20NftModelConverter.swift in Sources */,
 				8D9BC9C36DC891CDD900A895 /* AccountConfirmViewController.swift in Sources */,
@@ -35009,6 +35023,7 @@
 				A05C2B3458F12EFE1633D917 /* MarkdownDescriptionPresenter.swift in Sources */,
 				91201789084DD9A419CA8CD3 /* MarkdownDescriptionViewController.swift in Sources */,
 				0C2A3C982CDCCECC00A0E2B3 /* SwapTokensFlowState.swift in Sources */,
+				0CB618CF2E70C3160018C766 /* XcmCustomTeleport.swift in Sources */,
 				84A0166929A4E6AC00C9D415 /* MarkdownDescriptionModel.swift in Sources */,
 				3A4743C7C74BE4F74F6390F6 /* MarkdownDescriptionViewLayout.swift in Sources */,
 				0CD846212BDCA9F60026B5CA /* WalletImportOptionPrimaryView.swift in Sources */,
@@ -35693,6 +35708,7 @@
 				AD87A679F6E61D7AA20DF60C /* NotificationWalletListInteractor.swift in Sources */,
 				6B1BDD1421916CCF59DF6F5F /* NotificationWalletListViewController.swift in Sources */,
 				0CA8AD622CE08FEE00ED9746 /* BlockEventsQueryFactory.swift in Sources */,
+				0CB618D22E70C3320018C766 /* Xcm+TransferType.swift in Sources */,
 				0CA8AD632CE08FEE00ED9746 /* ExtrinsicStatusService.swift in Sources */,
 				2DD018C72D63B3690063F9BB /* AutoScrollManager.swift in Sources */,
 				0CA8AD642CE08FEE00ED9746 /* SubstrateExtrinsicEvents.swift in Sources */,

--- a/novawallet/Common/Configs/ApplicationConfigs.swift
+++ b/novawallet/Common/Configs/ApplicationConfigs.swift
@@ -186,17 +186,17 @@ extension ApplicationConfig: ApplicationConfigProtocol {
 
     var xcmTransfersURL: URL {
         #if F_RELEASE
-            URL(string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/xcm/v7/transfers.json")!
+            URL(string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/xcm/v8/transfers.json")!
         #else
-            URL(string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/xcm/v7/transfers_dev.json")!
+            URL(string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/xcm/v8/transfers_dev.json")!
         #endif
     }
 
     var xcmDynamicTransfersURL: URL {
         #if F_RELEASE
-            URL(string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/xcm/v7/transfers_dynamic.json")!
+            URL(string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/xcm/v8/transfers_dynamic.json")!
         #else
-            URL(string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/xcm/v7/transfers_dynamic_dev.json")!
+            URL(string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/xcm/v8/transfers_dynamic_dev.json")!
         #endif
     }
 

--- a/novawallet/Common/Model/Xcm/XcmAssetTransfer.swift
+++ b/novawallet/Common/Model/Xcm/XcmAssetTransfer.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct XcmAssetTransfer: Decodable {
     let destination: XcmAssetTransfer.Destination
-    let type: XcmTransferType
+    let type: XcmCallType
 }
 
 extension XcmAssetTransfer {

--- a/novawallet/Common/Model/Xcm/XcmCallType.swift
+++ b/novawallet/Common/Model/Xcm/XcmCallType.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-enum XcmTransferTypeError: Error {
+enum XcmCallTypeError: Error {
     case unknownType
 }
 
-enum XcmTransferType: String, Decodable {
+enum XcmCallType: String, Decodable {
     case xtokens
     case xcmpallet
     case teleport = "xcmpallet-teleport"

--- a/novawallet/Common/Model/Xcm/XcmCustomTeleport.swift
+++ b/novawallet/Common/Model/Xcm/XcmCustomTeleport.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct XcmCustomTeleport: Equatable, Hashable, Decodable {
+    let originChain: ChainModel.Id
+    let destChain: ChainModel.Id
+    let originAsset: AssetModel.Id
+}

--- a/novawallet/Common/Model/Xcm/XcmDynamicAssetTransfer.swift
+++ b/novawallet/Common/Model/Xcm/XcmDynamicAssetTransfer.swift
@@ -5,5 +5,4 @@ struct XcmDynamicAssetTransfer: Decodable {
     let assetId: AssetModel.Id
     let hasDeliveryFee: Bool?
     let supportsXcmExecute: Bool?
-    let usesTeleport: Bool?
 }

--- a/novawallet/Common/Model/Xcm/XcmDynamicTransfers+Protocol.swift
+++ b/novawallet/Common/Model/Xcm/XcmDynamicTransfers+Protocol.swift
@@ -19,5 +19,5 @@ extension XcmDynamicAsset: XcmTransferAssetProtocol {
 }
 
 extension XcmDynamicAssetTransfer: XcmTransferDestinationProtocol {
-    var type: XcmTransferType { .xcmpalletTransferAssets }
+    var type: XcmCallType { .xcmpalletTransferAssets }
 }

--- a/novawallet/Common/Model/Xcm/XcmDynamicTransfers.swift
+++ b/novawallet/Common/Model/Xcm/XcmDynamicTransfers.swift
@@ -8,6 +8,7 @@ struct XcmDynamicTransfers: Decodable {
 
     let assetsLocation: [AssetLocationId: AssetLocation]
     let reserveIdOverrides: [ChainModel.Id: [AssetIdKey: AssetLocationId]]
+    let customTeleports: Set<XcmCustomTeleport>?
     let chains: [XcmDynamicChain]
 
     func transfer(
@@ -44,5 +45,19 @@ struct XcmDynamicTransfers: Decodable {
         let assetLocationId = reserveIdOverrides[chainId]?[assetIdKey] ?? chainAsset.asset.symbol
 
         return assetsLocation[assetLocationId]?.chainId?.stringValue
+    }
+
+    func getUsesCustomTeleport(from origin: ChainAssetId, destination: ChainModel.Id) -> Bool {
+        guard let customTeleports else {
+            return false
+        }
+
+        let model = XcmCustomTeleport(
+            originChain: origin.chainId,
+            destChain: destination,
+            originAsset: origin.assetId
+        )
+
+        return customTeleports.contains(model)
     }
 }

--- a/novawallet/Common/Model/Xcm/XcmTransfers.swift
+++ b/novawallet/Common/Model/Xcm/XcmTransfers.swift
@@ -220,6 +220,11 @@ private extension XcmTransfers {
             throw XcmTransfersError.noReserve(chainAsset.chainAssetId)
         }
 
+        let usesTeleport = dynamicTransfers.getUsesCustomTeleport(
+            from: chainAsset.chainAssetId,
+            destination: destinationChain.chainId
+        )
+
         return XcmTransferMetadata(
             callType: transfer.type,
             reserve: XcmTransferMetadata.Reserve(
@@ -229,7 +234,7 @@ private extension XcmTransfers {
             fee: .dynamic,
             paysDeliveryFee: transfer.hasDeliveryFee ?? false,
             supportsXcmExecute: transfer.supportsXcmExecute ?? false,
-            usesTeleport: transfer.usesTeleport ?? false
+            usesTeleport: usesTeleport
         )
     }
 }
@@ -303,7 +308,7 @@ struct XcmTransferMetadata {
         }
     }
 
-    let callType: XcmTransferType
+    let callType: XcmCallType
     let reserve: Reserve
     let fee: Fee
     let paysDeliveryFee: Bool

--- a/novawallet/Common/Model/Xcm/XcmTransfersProtocol.swift
+++ b/novawallet/Common/Model/Xcm/XcmTransfersProtocol.swift
@@ -17,5 +17,5 @@ protocol XcmTransferAssetProtocol {
 protocol XcmTransferDestinationProtocol {
     var chainId: ChainModel.Id { get }
     var assetId: AssetModel.Id { get }
-    var type: XcmTransferType { get }
+    var type: XcmCallType { get }
 }

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/CallDerivation/XcmUnweightedTransferRequest+TransferType.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/CallDerivation/XcmUnweightedTransferRequest+TransferType.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+extension XcmUnweightedTransferRequest {
+    func isTeleport() -> Bool {
+        let systemToRelay = origin.parachainId.isSystemParachain && destination.parachainId.isRelay
+        let relayToSystem = origin.parachainId.isRelay && destination.parachainId.isSystemParachain
+        let systemToSystem = origin.parachainId.isSystemParachain && destination.parachainId.isSystemParachain
+
+        return systemToRelay || relayToSystem || systemToSystem || metadata.usesTeleport
+    }
+
+    func deriveXcmTransferType() -> Xcm.TransferTypeWithRelativeLocation {
+        if isTeleport() {
+            .teleport
+        } else if origin.chainAsset.chainAssetId.chainId == reserve.chain.chainId {
+            .localReserve
+        } else if destination.chain.chainId == reserve.chain.chainId {
+            .destinationReserve
+        } else {
+            .remoteReserve(
+                XcmUni.AbsoluteLocation(
+                    paraId: reserve.parachainId
+                ).fromChainPointOfView(
+                    origin.parachainId
+                )
+            )
+        }
+    }
+}

--- a/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmLegacyCrosschainFeeCalculator.swift
+++ b/novawallet/Common/Services/ExtrinsicService/Substrate/Xcm/XcmLegacyCrosschainFeeCalculator.swift
@@ -147,7 +147,7 @@ final class XcmLegacyCrosschainFeeCalculator {
 
 private extension XcmLegacyCrosschainFeeCalculator {
     func createModuleResolutionWrapper(
-        for transferType: XcmTransferType,
+        for transferType: XcmCallType,
         runtimeProvider: RuntimeProviderProtocol
     ) -> CompoundOperationWrapper<String> {
         switch transferType {
@@ -156,7 +156,7 @@ private extension XcmLegacyCrosschainFeeCalculator {
         case .xcmpallet, .teleport, .xcmpalletTransferAssets:
             return xcmPalletQueryFactory.createModuleNameResolutionWrapper(for: runtimeProvider)
         case .unknown:
-            return CompoundOperationWrapper.createWithError(XcmTransferTypeError.unknownType)
+            return CompoundOperationWrapper.createWithError(XcmCallTypeError.unknownType)
         }
     }
 

--- a/novawallet/Common/Substrate/Calls/Xcm/XcmPalletTransfer.swift
+++ b/novawallet/Common/Substrate/Calls/Xcm/XcmPalletTransfer.swift
@@ -33,4 +33,32 @@ extension Xcm {
     static func transferAssetsPath(for module: String) -> CallCodingPath {
         CallCodingPath(moduleName: module, callName: "transfer_assets")
     }
+
+    struct TransferAssetsUsingTypeAndThen: Codable {
+        enum CodingKeys: String, CodingKey {
+            case destination
+            case assets
+            case assetsTransferType = "assets_transfer_type"
+            case remoteFeesId = "remote_fees_Id"
+            case feesTransferType = "fees_transfer_type"
+            case customXcmOnDest = "custom_xcm_on_dest"
+            case weightLimit = "weight_limit"
+        }
+        
+        let destination: XcmUni.VersionedLocation
+        let assets: XcmUni.VersionedAssets
+        let assetsTransferType: TransferType
+        let remoteFeesId: XcmUni.VersionedAssetId
+        let feesTransferType: TransferType
+        let customXcmOnDest: XcmUni.VersionedMessage
+        let weightLimit: Xcm.WeightLimit<JSON> // maximum weight for remote execution
+
+        func runtimeCall(for moduleName: String) -> RuntimeCall<Self> {
+            RuntimeCall(
+                moduleName: moduleName,
+                callName: "transfer_assets_using_type_and_then",
+                args: self
+            )
+        }
+    }
 }

--- a/novawallet/Common/Substrate/Calls/Xcm/XcmPalletTransfer.swift
+++ b/novawallet/Common/Substrate/Calls/Xcm/XcmPalletTransfer.swift
@@ -44,7 +44,7 @@ extension Xcm {
             case customXcmOnDest = "custom_xcm_on_dest"
             case weightLimit = "weight_limit"
         }
-        
+
         let destination: XcmUni.VersionedLocation
         let assets: XcmUni.VersionedAssets
         let assetsTransferType: TransferType

--- a/novawallet/Common/Substrate/Calls/Xcm/XcmPalletTransfer.swift
+++ b/novawallet/Common/Substrate/Calls/Xcm/XcmPalletTransfer.swift
@@ -36,10 +36,10 @@ extension Xcm {
 
     struct TransferAssetsUsingTypeAndThen: Codable {
         enum CodingKeys: String, CodingKey {
-            case destination
+            case destination = "dest"
             case assets
             case assetsTransferType = "assets_transfer_type"
-            case remoteFeesId = "remote_fees_Id"
+            case remoteFeesId = "remote_fees_id"
             case feesTransferType = "fees_transfer_type"
             case customXcmOnDest = "custom_xcm_on_dest"
             case weightLimit = "weight_limit"

--- a/novawallet/Common/Substrate/Types/Xcm/Universal/XcmUni+Version.swift
+++ b/novawallet/Common/Substrate/Types/Xcm/Universal/XcmUni+Version.swift
@@ -11,6 +11,7 @@ extension XcmUni {
     typealias VersionedAssets = Versioned<XcmUni.Assets>
     typealias VersionedLocation = Versioned<XcmUni.RelativeLocation>
     typealias VersionedLocatableAsset = Versioned<XcmUni.LocatableAsset>
+    typealias VersionedAssetId = Versioned<XcmUni.AssetId>
 }
 
 extension XcmUni.Versioned: Equatable where Entity: Equatable {}

--- a/novawallet/Common/Substrate/Types/Xcm/Xcm+TransferType.swift
+++ b/novawallet/Common/Substrate/Types/Xcm/Xcm+TransferType.swift
@@ -1,0 +1,83 @@
+import Foundation
+import SubstrateSdk
+
+extension Xcm {
+    enum GenericTransferType<Location> {
+        case teleport
+        case localReserve
+        case destinationReserve
+        case remoteReserve(Location)
+    }
+
+    typealias TransferType = GenericTransferType<XcmUni.VersionedLocation>
+    typealias TransferTypeWithRelativeLocation = GenericTransferType<XcmUni.RelativeLocation>
+}
+
+extension Xcm.TransferType: Codable {
+    init(from decoder: any Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+
+        let type = try container.decode(String.self)
+
+        switch type {
+        case "Teleport":
+            self = .teleport
+        case "LocalReserve":
+            self = .localReserve
+        case "DestinationReserve":
+            self = .destinationReserve
+        case "RemoteReserve":
+            let location = try container.decode(Location.self)
+            self = .remoteReserve(location)
+        default:
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unsupported transfer type \(type)"
+                )
+            )
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.unkeyedContainer()
+
+        switch self {
+        case .teleport:
+            try container.encode("Teleport")
+            try container.encode(JSON.null)
+        case .localReserve:
+            try container.encode("LocalReserve")
+            try container.encode(JSON.null)
+        case .destinationReserve:
+            try container.encode("DestinationReserve")
+            try container.encode(JSON.null)
+        case let .remoteReserve(location):
+            try container.encode("RemoteReserve")
+            try container.encode(location)
+        }
+    }
+}
+
+extension Xcm.TransferType {
+    init(
+        transferTypeWithRelativeLocation: Xcm.TransferTypeWithRelativeLocation,
+        version: Xcm.Version
+    ) {
+        switch transferTypeWithRelativeLocation {
+        case .teleport:
+            self = .teleport
+        case .localReserve:
+            self = .localReserve
+        case .destinationReserve:
+            self = .destinationReserve
+        case let .remoteReserve(location):
+            self = .remoteReserve(
+                XcmUni.VersionedLocation(
+                    entity: location,
+                    version: version
+                )
+            )
+        }
+    }
+}

--- a/novawalletIntegrationTests/RuntimeFetchOperationFactoryTests.swift
+++ b/novawalletIntegrationTests/RuntimeFetchOperationFactoryTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import novawallet
 import Operation_iOS
+import SubstrateSdk
 
 final class RuntimeFetchOperationFactoryTests: XCTestCase {
     
@@ -17,6 +18,18 @@ final class RuntimeFetchOperationFactoryTests: XCTestCase {
         do {
             let metadata = try performTestFetchLatestMetadata(for: KnowChainId.edgeware)
             Logger.shared.info("Metadata opaque: \(metadata.isOpaque)")
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+    
+    func testBasiliskOpaque() {
+        do {
+            let rawMetadata = try performTestFetchLatestMetadata(for: "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755")
+            
+            let metadata = try RuntimeMetadataContainer.createFromOpaque(data: rawMetadata.metadata)
+            
+            Logger.shared.info("Metadata opaque: \(metadata)")
         } catch {
             XCTFail("Error: \(error)")
         }


### PR DESCRIPTION
## Purpose

Recent runtime upgrade on Kusama that prepares Asset Hub Migration forbids now `transfer_assets` usage for crosschain transfers. The PR replaces it with `transfer_assets_using_type_and_then` method. Also PR adopts new customTeleport field in the dynamic config that replaces usesTeleport field.