### PR TITLE
Fix authorized dApps presentation

### DIFF
--- a/novawallet/Modules/DApp/DAppAuthSettings/ViewModel/DAppsAuthViewModelFactory.swift
+++ b/novawallet/Modules/DApp/DAppAuthSettings/ViewModel/DAppsAuthViewModelFactory.swift
@@ -18,12 +18,14 @@ final class DAppsAuthViewModelFactory: DAppsAuthViewModelFactoryProtocol {
             }
         } ?? [:]
 
-        return authorizationStore.values.map { auth in
+        return authorizationStore.values.compactMap { auth in
+            guard let dappId = auth.dAppId else { return nil }
+
             let title: String
             let subtitle: String?
 
-            let path = URL(string: auth.dAppId)?.path
-            let optDApp = dAppsStore[auth.dAppId]
+            let path = URL(string: dappId)?.path
+            let optDApp = dAppsStore[dappId]
 
             if let dApp = optDApp {
                 title = dApp.name
@@ -46,7 +48,7 @@ final class DAppsAuthViewModelFactory: DAppsAuthViewModelFactoryProtocol {
                 title: title,
                 subtitle: subtitle,
                 iconViewModel: imageViewModel,
-                identifier: auth.dAppId
+                identifier: dappId
             )
         }.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
     }

--- a/novawallet/Modules/DApp/Model/DAppSettings.swift
+++ b/novawallet/Modules/DApp/Model/DAppSettings.swift
@@ -3,11 +3,11 @@ import Operation_iOS
 
 struct DAppSettings: Identifiable {
     var identifier: String {
-        dAppId + metaId
+        (dAppId ?? "") + metaId
     }
 
     // normaly it is a dapp url's host
-    let dAppId: String
+    let dAppId: String?
     let metaId: String
     let source: String?
 }

--- a/novawallet/Modules/DApp/Model/DAppSettingsMapper.swift
+++ b/novawallet/Modules/DApp/Model/DAppSettingsMapper.swift
@@ -8,7 +8,7 @@ final class DAppSettingsMapper: CoreDataMapperProtocol {
 
     func transform(entity: CoreDataEntity) throws -> DataProviderModel {
         DAppSettings(
-            dAppId: entity.dAppId!,
+            dAppId: entity.dAppId,
             metaId: entity.metaId!,
             source: entity.source
         )


### PR DESCRIPTION
### SUMMARY

The PR fixes `DAppsAuthViewModelFactory` by usage of `dAppId` instead of settings persistence identifier.