### PR TITLE
Fix DApp auth removal

### DIFF
--- a/novawallet/Modules/DApp/DAppAuthSettings/ViewModel/DAppsAuthViewModelFactory.swift
+++ b/novawallet/Modules/DApp/DAppAuthSettings/ViewModel/DAppsAuthViewModelFactory.swift
@@ -48,7 +48,7 @@ final class DAppsAuthViewModelFactory: DAppsAuthViewModelFactoryProtocol {
                 title: title,
                 subtitle: subtitle,
                 iconViewModel: imageViewModel,
-                identifier: dappId
+                identifier: auth.identifier
             )
         }.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
     }


### PR DESCRIPTION
### SUMMARY

The PR fixes auth removal logic by using new `identifier` field for view model instead of old `dAppId`.