### PR TITLE
Support Rainbow WC links

### DIFF
--- a/novawallet/Common/URLHandling/Parsing/WalletConnectUrlParsingService.swift
+++ b/novawallet/Common/URLHandling/Parsing/WalletConnectUrlParsingService.swift
@@ -2,6 +2,7 @@ import Foundation
 
 protocol WCActivityValidatorMarker: URLActivityValidator {}
 protocol OldWCActivityValidatorMarker: URLActivityValidator {}
+protocol RainbowWCActivityValidatorMarker: URLActivityValidator {}
 
 final class WalletConnectUrlParsingService {
     private(set) var pendingUrl: Observable<String?>
@@ -16,7 +17,74 @@ final class WalletConnectUrlParsingService {
     }
 }
 
+// MARK: - Private
+
+private extension WalletConnectUrlParsingService {
+    func validateNewWC(url: URL) -> Bool {
+        guard
+            let newWCValidator = validators.first(where: { $0 is WCActivityValidatorMarker }),
+            newWCValidator.validate(url),
+            let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let link = urlComponents.queryItems?.first(where: { $0.name == "uri" })?.value
+        else { return false }
+
+        pendingUrl.state = link
+
+        return true
+    }
+
+    /**
+     * Older version of wc send both pair and sign requests through `wc:` deeplink
+     * so we additionaly check for `symKey` which is only present in pairing url
+     */
+    func validateOldWC(url: URL) -> Bool {
+        guard
+            let oldWCValidator = validators.first(where: { $0 is OldWCActivityValidatorMarker }),
+            oldWCValidator.validate(url)
+        else { return false }
+
+        pendingUrl.state = url.absoluteString
+
+        return true
+    }
+
+    func validateRainbowWC(url: URL) -> Bool {
+        guard
+            let rainbowWCValidator = validators.first(where: { $0 is RainbowWCActivityValidatorMarker }),
+            rainbowWCValidator.validate(url),
+            let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let link = urlComponents.queryItems?.first(where: { $0.name == "uri" })?.value
+        else { return false }
+
+        pendingUrl.state = link
+
+        return true
+    }
+}
+
+// MARK: - URLHandlingServiceProtocol
+
+extension WalletConnectUrlParsingService: URLHandlingServiceProtocol {
+    func handle(url: URL) -> Bool {
+        if validateNewWC(url: url) {
+            true
+        } else if validateOldWC(url: url) {
+            true
+        } else {
+            validateRainbowWC(url: url)
+        }
+    }
+}
+
+// MARK: - Validators
+
 extension WalletConnectUrlParsingService {
+    struct RainbowWCActivityValidator: RainbowWCActivityValidatorMarker {
+        func validate(_ url: URL) -> Bool {
+            url.scheme == "rainbow" && url.host == "wc"
+        }
+    }
+
     struct WCActivityValidator: WCActivityValidatorMarker {
         func validate(_ url: URL) -> Bool {
             url.scheme == ApplicationConfig.shared.deepLinkScheme && url.host == "wc"
@@ -27,37 +95,5 @@ extension WalletConnectUrlParsingService {
         func validate(_ url: URL) -> Bool {
             url.scheme == "wc" && url.absoluteString.contains(substring: "symKey")
         }
-    }
-}
-
-extension WalletConnectUrlParsingService: URLHandlingServiceProtocol {
-    func handle(url: URL) -> Bool {
-        let newWCValidator = validators.first(where: { $0 is WCActivityValidatorMarker })
-
-        if newWCValidator?.validate(url) == true {
-            guard
-                let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
-                let link = urlComponents.queryItems?.first(where: { $0.name == "uri" })?.value else {
-                return false
-            }
-
-            pendingUrl.state = link
-
-            return true
-        }
-
-        /**
-         * Older version of wc send both pair and sign requests through `wc:` deeplink
-         * so we additionaly check for `symKey` which is only present in pairing url
-         */
-        let oldWCValidator = validators.first(where: { $0 is OldWCActivityValidator })
-
-        if oldWCValidator?.validate(url) == true {
-            pendingUrl.state = url.absoluteString
-
-            return true
-        }
-
-        return false
     }
 }

--- a/novawallet/Common/URLHandling/URLLocalRouter.swift
+++ b/novawallet/Common/URLHandling/URLLocalRouter.swift
@@ -30,6 +30,6 @@ extension URLLocalRouter: URLLocalRouting {
 
 extension URLLocalRouter {
     static func createWithDeeplinks() -> URLLocalRouter {
-        .init(supportedSchemes: ["novawallet", "wc"])
+        .init(supportedSchemes: ["novawallet", "wc", "rainbow"])
     }
 }

--- a/novawallet/Info.plist
+++ b/novawallet/Info.plist
@@ -51,6 +51,14 @@
 				<string>wc</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>rainbow</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>

--- a/novawallet/Modules/Root/RootInteractor.swift
+++ b/novawallet/Modules/Root/RootInteractor.swift
@@ -68,7 +68,8 @@ final class RootInteractor {
 
         let wcURLActivityValidators: [URLActivityValidator] = [
             WalletConnectUrlParsingService.WCActivityValidator(),
-            WalletConnectUrlParsingService.OldWCActivityValidator()
+            WalletConnectUrlParsingService.OldWCActivityValidator(),
+            WalletConnectUrlParsingService.RainbowWCActivityValidator()
         ]
 
         let wcHandlingService = WalletConnectUrlParsingService(validators: wcURLActivityValidators)


### PR DESCRIPTION
### SUMMARY

The PR extends `WalletConnectUrlParsingService` adding support for WC links with `rainbow://` scheme.

The scheme also added to both `URLLocalRouter` and list of supported schemes and project's URL Types list.

### SCREEN RECORDINGS

https://github.com/user-attachments/assets/2b5b806b-3ad1-4cb7-bd88-06d077148869

