### PR TITLE
Privacy overlay for network group asset balance

### DIFF
--- a/novawallet/Modules/AssetList/Base/AssetListAssetsViewModelFactory.swift
+++ b/novawallet/Modules/AssetList/Base/AssetListAssetsViewModelFactory.swift
@@ -357,7 +357,10 @@ extension AssetListAssetViewModelFactory: AssetListAssetViewModelFactoryProtocol
 
         return AssetListNetworkGroupViewModel(
             networkName: networkName,
-            amount: .loaded(value: priceString),
+            amount: .wrapped(
+                .loaded(value: priceString),
+                with: genericParams.privacyModeEnabled
+            ),
             icon: iconViewModel,
             assets: assetViewModels
         )

--- a/novawallet/Modules/AssetList/View/AssetListNetworkView.swift
+++ b/novawallet/Modules/AssetList/View/AssetListNetworkView.swift
@@ -3,13 +3,12 @@ import UIKit
 final class AssetListNetworkView: UICollectionReusableView {
     let chainView = AssetListChainView()
 
-    let valueLabel: UILabel = {
-        let view = UILabel()
-        view.textColor = R.color.colorTextSecondary()
-        view.font = .regularFootnote
-        view.textAlignment = .right
-        return view
-    }()
+    let valueLabel: DotsSecureView<UILabel> = .create { view in
+        view.preferredSecuredHeight = 18
+        view.originalView.textColor = R.color.colorTextSecondary()
+        view.originalView.font = .regularFootnote
+        view.originalView.textAlignment = .right
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -25,18 +24,22 @@ final class AssetListNetworkView: UICollectionReusableView {
     }
 
     func bind(viewModel: AssetListNetworkGroupViewModel) {
-        switch viewModel.amount {
+        switch viewModel.amount.originalContent {
         case let .loaded(value), let .cached(value):
-            valueLabel.text = value
+            valueLabel.originalView.text = value
         case .loading:
-            valueLabel.text = ""
+            valueLabel.originalView.text = ""
         }
 
         chainView.nameLabel.text = viewModel.networkName
 
-        let networkViewModel = NetworkViewModel(name: viewModel.networkName, icon: viewModel.icon)
+        let networkViewModel = NetworkViewModel(
+            name: viewModel.networkName,
+            icon: viewModel.icon
+        )
 
         chainView.bind(viewModel: networkViewModel)
+        valueLabel.bind(viewModel.amount.privacyMode)
     }
 
     private func setupLayout() {

--- a/novawallet/Modules/AssetList/ViewModel/AssetListViewModel.swift
+++ b/novawallet/Modules/AssetList/ViewModel/AssetListViewModel.swift
@@ -163,7 +163,7 @@ struct AssetListNetworkGroupViewModel: Identifiable {
     var id: String { networkName }
 
     let networkName: String
-    let amount: LoadableViewModelState<String>
+    let amount: SecuredViewModel<LoadableViewModelState<String>>
     let icon: ImageViewModelProtocol?
     let assets: [AssetListNetworkGroupAssetViewModel]
 }


### PR DESCRIPTION
### SUMMARY

The PR adds privacy mode overlay for network group asset balance in `AssetList`.

### SCREENSHOTS

<img width="45%" height="45%" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-09-24 at 21 02 59" src="https://github.com/user-attachments/assets/00de0866-4ab5-4a7d-90d7-1422e0026c1e" />
<img width="45%" height="45%" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-09-24 at 21 02 54" src="https://github.com/user-attachments/assets/688aad3c-caeb-4fda-a2b6-b2178d0ffbe5" />
