### PR TITLE
10.3.8 Make iCloud Backup visible

### DIFF
--- a/novawallet/Info.plist
+++ b/novawallet/Info.plist
@@ -93,7 +93,7 @@
 		<key>iCloud.io.novafoundation.novawallet.Documents</key>
 		<dict>
 			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
-			<false/>
+			<true/>
 			<key>NSUbiquitousContainerName</key>
 			<string>Backup</string>
 			<key>NSUbiquitousContainerSupportedFolderLevels</key>

--- a/novawallet/Info.plist
+++ b/novawallet/Info.plist
@@ -95,7 +95,7 @@
 			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
 			<true/>
 			<key>NSUbiquitousContainerName</key>
-			<string>Backup</string>
+			<string>Backup Nova Wallet</string>
 			<key>NSUbiquitousContainerSupportedFolderLevels</key>
 			<string>ANY</string>
 		</dict>
@@ -104,7 +104,7 @@
 			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
 			<true/>
 			<key>NSUbiquitousContainerName</key>
-			<string>Backup</string>
+			<string>Backup Nova Wallet Dev</string>
 			<key>NSUbiquitousContainerSupportedFolderLevels</key>
 			<string>ANY</string>
 		</dict>


### PR DESCRIPTION
## Purpose

There is a community feature request to make encrypted iCloud file visible in the iCloud Drive (Files -> iCloud Drive -> Backup (with Nova Wallet icon)). The PR enables visibility of the app's backup directory