### PR TITLE
[AHM] Staking icons and naming update

### DIFF
--- a/novawallet/Common/Model/ChainAsset.swift
+++ b/novawallet/Common/Model/ChainAsset.swift
@@ -18,6 +18,10 @@ extension ChainAsset {
         ChainAssetId(chainId: chain.chainId, assetId: asset.assetId)
     }
 
+    var chainAssetName: String {
+        asset.name ?? chain.name
+    }
+
     var assetDisplayInfo: AssetBalanceDisplayInfo { asset.displayInfo(with: chain.icon) }
 
     var chainAssetInfo: ChainAssetDisplayInfo {

--- a/novawallet/Common/ViewModel/AssetViewModel.swift
+++ b/novawallet/Common/ViewModel/AssetViewModel.swift
@@ -2,5 +2,16 @@ import Foundation
 
 struct AssetViewModel {
     let symbol: String
+    let name: String?
     let imageViewModel: ImageViewModelProtocol?
+
+    init(
+        symbol: String,
+        name: String? = nil,
+        imageViewModel: ImageViewModelProtocol?
+    ) {
+        self.symbol = symbol
+        self.name = name
+        self.imageViewModel = imageViewModel
+    }
 }

--- a/novawallet/Common/ViewModel/ChainAssetViewModel.swift
+++ b/novawallet/Common/ViewModel/ChainAssetViewModel.swift
@@ -6,6 +6,10 @@ struct ChainAssetViewModel: Identifiable {
         chainAssetId.stringValue
     }
 
+    var assetName: String {
+        assetViewModel.name ?? networkViewModel.name
+    }
+
     let chainAssetId: ChainAssetId
 
     let networkViewModel: NetworkViewModel

--- a/novawallet/Common/ViewModel/ChainAssetViewModelFactory.swift
+++ b/novawallet/Common/ViewModel/ChainAssetViewModelFactory.swift
@@ -19,8 +19,14 @@ final class ChainAssetViewModelFactory: ChainAssetViewModelFactoryProtocol {
     func createViewModel(from chainAsset: ChainAsset) -> ChainAssetViewModel {
         let networkViewModel = networkViewModelFactory.createViewModel(from: chainAsset.chain)
 
-        let assetIconViewModel = assetIconViewModelFactory.createAssetIconViewModel(for: chainAsset.asset.icon)
-        let assetViewModel = AssetViewModel(symbol: chainAsset.asset.symbol, imageViewModel: assetIconViewModel)
+        let assetIconViewModel = assetIconViewModelFactory.createAssetIconViewModel(
+            for: chainAsset.asset.icon
+        )
+        let assetViewModel = AssetViewModel(
+            symbol: chainAsset.asset.symbol,
+            name: chainAsset.asset.name,
+            imageViewModel: assetIconViewModel
+        )
 
         return ChainAssetViewModel(
             chainAssetId: chainAsset.chainAssetId,

--- a/novawallet/Modules/AHMInfo/Factory/AHMInfoViewModelFactory.swift
+++ b/novawallet/Modules/AHMInfo/Factory/AHMInfoViewModelFactory.swift
@@ -283,6 +283,10 @@ extension AHMInfoViewModelFactory: AHMInfoViewModelFactoryProtocol {
         info: AHMFullInfo,
         locale: Locale
     ) -> AHMAlertView.Model {
+        let sourceChainAsset = ChainAsset(
+            chain: info.sourceChain,
+            asset: info.asset
+        )
         let languages = locale.rLanguages
 
         let date = Date(timeIntervalSince1970: TimeInterval(info.info.timestamp))
@@ -293,7 +297,7 @@ extension AHMInfoViewModelFactory: AHMInfoViewModelFactoryProtocol {
             .string(from: date)
 
         let title = R.string.localizable.ahmInfoAlertStakingDetailsMessage(
-            info.sourceChain.name,
+            sourceChainAsset.chainAssetName,
             info.destinationChain.name,
             formattedDate,
             preferredLanguages: languages

--- a/novawallet/Modules/Staking/Dashboard/StakingDashboardViewFactory.swift
+++ b/novawallet/Modules/Staking/Dashboard/StakingDashboardViewFactory.swift
@@ -27,7 +27,7 @@ struct StakingDashboardViewFactory {
         let viewModelFactory = StakingDashboardViewModelFactory(
             assetFormatterFactory: AssetBalanceFormatterFactory(),
             priceAssetInfoFactory: priceAssetInfoFactory,
-            networkViewModelFactory: NetworkViewModelFactory(),
+            chainAssetViewModelFactory: ChainAssetViewModelFactory(),
             estimatedEarningsFormatter: NumberFormatter.percentBase.localizableResource()
         )
 

--- a/novawallet/Modules/Staking/Dashboard/View/StakingDashboardActiveCell.swift
+++ b/novawallet/Modules/Staking/Dashboard/View/StakingDashboardActiveCell.swift
@@ -5,15 +5,23 @@ typealias StakingDashboardActiveCell = BlurredCollectionViewCell<StakingDashboar
 
 final class StakingDashboardActiveCellView: UIView {
     private enum Constants {
+        static let assetIconLeadingOffset = 10
+        static let assetIconTopOffset = 8
         static let leadingOffset = 16
         static let topOffset = 16
+        static let assetIconSize = CGSize(width: 48, height: 48)
     }
 
-    let networkContainerView: GenericPairValueView<
-        LoadableAssetListChainView, BorderedIconLabelView
+    let assetContainerView: GenericPairValueView<
+        AssetIconView, BorderedIconLabelView
     > = .create { view in
         view.makeHorizontal()
         view.spacing = 4
+
+        view.fView.backgroundView.cornerRadius = Constants.assetIconSize.height / 2.0
+        view.fView.backgroundView.fillColor = .clear
+        view.fView.backgroundView.strokeColor = .clear
+
         view.sView.iconDetailsView.apply(style: .chips)
         view.sView.iconDetailsView.detailsLabel.numberOfLines = 1
         view.sView.iconDetailsView.iconWidth = 10
@@ -22,9 +30,9 @@ final class StakingDashboardActiveCellView: UIView {
         view.stackView.alignment = .center
     }
 
-    var networkView: LoadableAssetListChainView { networkContainerView.fView }
+    var assetView: AssetIconView { assetContainerView.fView }
 
-    var stakingTypeView: BorderedIconLabelView { networkContainerView.sView }
+    var stakingTypeView: BorderedIconLabelView { assetContainerView.sView }
 
     let detailsView: BlurredView<StakingDashboardActiveDetailsView> = .create { view in
         view.contentInsets = .zero
@@ -46,6 +54,8 @@ final class StakingDashboardActiveCellView: UIView {
         view.valueBottom.priceSecureView.preferredSecuredHeight = 20
 
         view.valueBottom.amountSecureView.privacyModeConfiguration = .largeBalanceChip
+
+        view.spacing = 6
     }
 
     var skeletonView: SkrullableView?
@@ -72,23 +82,20 @@ final class StakingDashboardActiveCellView: UIView {
     }
 
     func bind(viewModel: StakingDashboardEnabledViewModel, locale: Locale) {
+        assetView.bind(
+            viewModel: viewModel.chainAssetViewModel.assetViewModel.imageViewModel,
+            size: Constants.assetIconSize
+        )
+
+        setRewardsText(
+            with: viewModel.chainAssetViewModel,
+            locale: locale
+        )
+
         var newLoadingState: LoadingState = .none
-
-        networkView.stopLoadingIfNeeded()
-
-        switch viewModel.networkViewModel {
-        case .loading:
-            newLoadingState.formUnion(.network)
-        case let .cached(value):
-            networkView.bind(viewModel: value)
-            networkView.startLoadingIfNeeded()
-        case let .loaded(value):
-            networkView.bind(viewModel: value)
-        }
 
         if let stakingTypeViewModel = viewModel.stakingType {
             stakingTypeView.isHidden = false
-
             stakingTypeView.bind(viewModel: stakingTypeViewModel)
         } else {
             stakingTypeView.isHidden = true
@@ -107,8 +114,6 @@ final class StakingDashboardActiveCellView: UIView {
             locale: locale
         )
 
-        setupStaticLocalization(for: locale)
-
         stopLoadingIfNeeded()
 
         loadingState = newLoadingState
@@ -116,6 +121,16 @@ final class StakingDashboardActiveCellView: UIView {
         if loadingState != .none {
             startLoadingIfNeeded()
         }
+    }
+
+    func setRewardsText(
+        with viewModel: ChainAssetViewModel,
+        locale: Locale
+    ) {
+        rewardsView.valueTop.text = [
+            viewModel.assetName,
+            R.string.localizable.commonRewards(preferredLanguages: locale.rLanguages).lowercased()
+        ].joined(with: .space)
     }
 
     func bindLoadingState() {
@@ -128,12 +143,6 @@ final class StakingDashboardActiveCellView: UIView {
         startLoadingIfNeeded()
     }
 
-    private func setupStaticLocalization(for locale: Locale) {
-        rewardsView.valueTop.text = R.string.localizable.stakingRewardsTitle(
-            preferredLanguages: locale.rLanguages
-        )
-    }
-
     private func setupLayout() {
         addSubview(detailsView)
 
@@ -142,22 +151,22 @@ final class StakingDashboardActiveCellView: UIView {
             make.width.equalTo(130)
         }
 
-        addSubview(networkContainerView)
+        addSubview(assetContainerView)
 
-        networkContainerView.snp.makeConstraints { make in
-            make.leading.equalToSuperview().inset(Constants.leadingOffset)
-            make.top.equalToSuperview().inset(Constants.topOffset)
+        assetContainerView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(Constants.assetIconLeadingOffset)
+            make.top.equalToSuperview().inset(Constants.assetIconTopOffset)
             make.trailing.lessThanOrEqualTo(detailsView.snp.leading).offset(-8)
         }
 
         addSubview(rewardsView)
         rewardsView.snp.makeConstraints { make in
-            make.top.equalTo(networkContainerView.snp.bottom).offset(24)
+            make.top.equalTo(assetContainerView.snp.bottom).offset(6)
             make.leading.equalToSuperview().inset(Constants.leadingOffset)
             make.trailing.lessThanOrEqualTo(detailsView.snp.leading).offset(-8)
         }
 
-        networkView.setContentCompressionResistancePriority(.low, for: .horizontal)
+        assetView.setContentCompressionResistancePriority(.low, for: .horizontal)
     }
 }
 
@@ -169,7 +178,6 @@ extension StakingDashboardActiveCellView: AnimationUpdatibleView {
             skeletonView?.restartSkrulling()
         }
 
-        networkView.updateLoadingAnimationIfActive()
         rewardsView.valueBottom.updateLoadingAnimationIfActive()
         detailsView.view.updateLoadingAnimationIfActive()
     }
@@ -183,7 +191,7 @@ extension StakingDashboardActiveCellView: SkeletonableView {
     var hidingViews: [UIView] {
         if loadingState == .all {
             return [
-                networkContainerView,
+                assetContainerView,
                 rewardsView
             ]
         }
@@ -191,7 +199,7 @@ extension StakingDashboardActiveCellView: SkeletonableView {
         var hidingViews: [UIView] = []
 
         if loadingState.contains(.network) {
-            hidingViews.append(networkContainerView)
+            hidingViews.append(assetContainerView)
         }
 
         if loadingState.contains(.rewards) {

--- a/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModel.swift
+++ b/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModel.swift
@@ -23,7 +23,7 @@ struct StakingDashboardEnabledViewModel {
         }
     }
 
-    let networkViewModel: LoadableViewModelState<NetworkViewModel>
+    let chainAssetViewModel: ChainAssetViewModel
     let totalRewards: SecuredViewModel<LoadableViewModelState<BalanceViewModelProtocol>>
     let status: LoadableViewModelState<Status>
     let yourStake: SecuredViewModel<LoadableViewModelState<BalanceViewModelProtocol>>
@@ -32,7 +32,7 @@ struct StakingDashboardEnabledViewModel {
 }
 
 struct StakingDashboardDisabledViewModel {
-    let networkViewModel: LoadableViewModelState<NetworkViewModel>
+    let chainAssetViewModel: LoadableViewModelState<ChainAssetViewModel>
     let estimatedEarnings: LoadableViewModelState<String?>
     let balance: SecuredViewModel<BalanceViewModelProtocol?>
     let stakingType: TitleIconViewModel?

--- a/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsViewFactory.swift
+++ b/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsViewFactory.swift
@@ -23,7 +23,7 @@ struct StakingMoreOptionsViewFactory {
         let viewModelFactory = StakingDashboardViewModelFactory(
             assetFormatterFactory: AssetBalanceFormatterFactory(),
             priceAssetInfoFactory: priceAssetInfoFactory,
-            networkViewModelFactory: NetworkViewModelFactory(),
+            chainAssetViewModelFactory: ChainAssetViewModelFactory(),
             estimatedEarningsFormatter: NumberFormatter.percentBase.localizableResource()
         )
 

--- a/novawallet/Modules/Staking/StartStakingInfo/Model/StartStakingViewModelFactory.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/Model/StartStakingViewModelFactory.swift
@@ -32,7 +32,7 @@ protocol StartStakingViewModelFactoryProtocol {
         chain: ChainModel,
         locale: Locale
     ) -> ParagraphView.Model
-    func wikiModel(url: URL, chain: ChainModel, locale: Locale) -> StartStakingUrlModel
+    func wikiModel(url: URL, chainAsset: ChainAsset, locale: Locale) -> StartStakingUrlModel
     func termsModel(url: URL, locale: Locale) -> StartStakingUrlModel
     func balance(amount: BigUInt?, priceData: PriceData?, chainAsset: ChainAsset, locale: Locale) -> String
     func noAccount(chain: ChainModel, locale: Locale) -> String
@@ -272,11 +272,16 @@ struct StartStakingViewModelFactory: StartStakingViewModelFactoryProtocol {
 
     func wikiModel(
         url: URL,
-        chain: ChainModel,
+        chainAsset: ChainAsset,
         locale: Locale
     ) -> StartStakingUrlModel {
         let linkName = R.string.localizable.stakingStartWikiLink(preferredLanguages: locale.rLanguages)
-        let text = R.string.localizable.stakingStartWiki(chain.name, linkName, preferredLanguages: locale.rLanguages)
+
+        let text = R.string.localizable.stakingStartWiki(
+            chainAsset.chainAssetName,
+            linkName,
+            preferredLanguages: locale.rLanguages
+        )
 
         return .init(text: text, url: url, urlName: linkName)
     }

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
@@ -100,7 +100,7 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
         )
         let wikiUrl = startStakingViewModelFactory.wikiModel(
             url: chainAsset.chain.stakingWiki ?? applicationConfig.websiteURL,
-            chain: chainAsset.chain,
+            chainAsset: chainAsset,
             locale: selectedLocale
         )
         let termsUrl = startStakingViewModelFactory.termsModel(

--- a/novawallet/en.lproj/Localizable.strings
+++ b/novawallet/en.lproj/Localizable.strings
@@ -1967,3 +1967,4 @@
 "ahm.info.alert.staking.details.message" = "%@ staking is live on %@ starting %@";
 "common.view" = "View";
 "ahm.info.in.progress.title" = "Starting %@ your %@ balance, Staking and Governance are on %@. These features might be unavailable for up to 24 hours.";
+"common.rewards" = "Rewards";


### PR DESCRIPTION
### SUMMARY

The PR updates staking flow to show asset icons instead of chain icons and use different naming.

### SCREENSHOTS

<img width="45%" height="45%" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-08 at 13 21 48" src="https://github.com/user-attachments/assets/250646c5-b3cb-4c3b-a1ca-b2d079dfb26f" />
<img width="45%" height="45%" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-08 at 13 21 38" src="https://github.com/user-attachments/assets/dac6e30e-3d88-490f-8494-c21b46d6afb0" />
