### PR TITLE
Feature/parachain staking storage update

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1975,6 +1975,7 @@
 		2D6F51AB2CDDD98300564C00 /* AssetsSearchFlowLayout+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D6F51AA2CDDD98300564C00 /* AssetsSearchFlowLayout+Types.swift */; };
 		2D6F51B12CE11EB100564C00 /* SpendAssetOperationNetworkBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D6F51B02CE11EB100564C00 /* SpendAssetOperationNetworkBuilder.swift */; };
 		2D6F51B32CE120AB00564C00 /* SpendAssetOperationNetworkListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D6F51B22CE120AB00564C00 /* SpendAssetOperationNetworkListInteractor.swift */; };
+		2D72133F2F0FC52F00826C7B /* ParaStkScheduledRequestsQueryWrapperFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D72133E2F0FC52F00826C7B /* ParaStkScheduledRequestsQueryWrapperFactory.swift */; };
 		2D73AD382EC32587002DE18F /* WalletListFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D73AD372EC32587002DE18F /* WalletListFilter.swift */; };
 		2D73AD4A2EC32CDD002DE18F /* WalletsAccountsChooseViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D73AD492EC32CDD002DE18F /* WalletsAccountsChooseViewModelFactory.swift */; };
 		2D73AD4F2EC32EE8002DE18F /* GiftWalletChoosePresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D73AD4E2EC32EE8002DE18F /* GiftWalletChoosePresentable.swift */; };
@@ -8553,6 +8554,7 @@
 		2D6F51AA2CDDD98300564C00 /* AssetsSearchFlowLayout+Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssetsSearchFlowLayout+Types.swift"; sourceTree = "<group>"; };
 		2D6F51B02CE11EB100564C00 /* SpendAssetOperationNetworkBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendAssetOperationNetworkBuilder.swift; sourceTree = "<group>"; };
 		2D6F51B22CE120AB00564C00 /* SpendAssetOperationNetworkListInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendAssetOperationNetworkListInteractor.swift; sourceTree = "<group>"; };
+		2D72133E2F0FC52F00826C7B /* ParaStkScheduledRequestsQueryWrapperFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParaStkScheduledRequestsQueryWrapperFactory.swift; sourceTree = "<group>"; };
 		2D73AD372EC32587002DE18F /* WalletListFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletListFilter.swift; sourceTree = "<group>"; };
 		2D73AD492EC32CDD002DE18F /* WalletsAccountsChooseViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletsAccountsChooseViewModelFactory.swift; sourceTree = "<group>"; };
 		2D73AD4E2EC32EE8002DE18F /* GiftWalletChoosePresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftWalletChoosePresentable.swift; sourceTree = "<group>"; };
@@ -26279,6 +26281,7 @@
 				841E5558282E6A7700C8438F /* ParaStkDurationOperationFactory.swift */,
 				84C3420628314D9600156569 /* ParaStkScheduledRequestsQueryFactory.swift */,
 				84C11F162840BD46007F7C05 /* ParaStkCollatorsOperationFactory.swift */,
+				2D72133E2F0FC52F00826C7B /* ParaStkScheduledRequestsQueryWrapperFactory.swift */,
 			);
 			path = ParachainStaking;
 			sourceTree = "<group>";
@@ -31599,6 +31602,7 @@
 				0C13DFE12AFBBAF600E5F355 /* SwapBaseViewModelFactory.swift in Sources */,
 				843E9B3627C8B915009C143A /* NftFileDownloadService.swift in Sources */,
 				842B17FF28649CCD0014CC57 /* CrossChainSelectionState.swift in Sources */,
+				2D72133F2F0FC52F00826C7B /* ParaStkScheduledRequestsQueryWrapperFactory.swift in Sources */,
 				0CAB67532D49338000E3A844 /* StakingGenericRewardsViewController.swift in Sources */,
 				0C1CF72E2E54A73E00B1DA66 /* HydraExchange.swift in Sources */,
 				8437F7C12924FF6400DB6366 /* EvmSubscriptionMessage.swift in Sources */,

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/ParaStkAccountSubscribeHandlingFactory.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/ParaStkAccountSubscribeHandlingFactory.swift
@@ -28,6 +28,10 @@ final class ParaStkAccountSubscribeHandlingFactory: RemoteSubscriptionHandlingFa
             remoteFactory: StorageKeyFactory(),
             operationManager: operationManager
         )
+        let queryWrapperFactory = ParaStkScheduledRequestsQueryWrapperFactory(
+            storageRequestFactory: storageRequestFactory,
+            operationManager: operationManager
+        )
 
         return ParaStkScheduledRequestsUpdater(
             remoteStorageKey: remoteStorageKey,
@@ -37,7 +41,7 @@ final class ParaStkAccountSubscribeHandlingFactory: RemoteSubscriptionHandlingFa
             accountId: accountId,
             chainId: chainId,
             operationManager: operationManager,
-            storageRequestFactory: storageRequestFactory,
+            queryWrapperFactory: queryWrapperFactory,
             logger: logger
         )
     }

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/ParaStkScheduledRequestsUpdater.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/ParaStkScheduledRequestsUpdater.swift
@@ -109,14 +109,16 @@ final class ParaStkScheduledRequestsUpdater: BaseStorageChildSubscription {
         connection: JSONRPCEngine,
         blockHash: Data?
     ) -> CompoundOperationWrapper<[StorageResponse<[ParachainStaking.ScheduledRequest]>]> {
-        let keyParams: () throws -> [BytesCodable] = {
+        let collators: () throws -> [BytesCodable] = {
             let delegator = try decodingOperation.extractNoCancellableResultData()
             return delegator.collators().map { BytesCodable(wrappedValue: $0) }
         }
+        let delegatorId = BytesCodable(wrappedValue: accountId)
 
         return storageRequestFactory.queryItems(
             engine: connection,
-            keyParams: keyParams,
+            keyParams1: collators,
+            keyParams2: { [delegatorId] },
             factory: {
                 try codingFactoryOperation.extractNoCancellableResultData()
             },

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/ParaStkScheduledRequestsUpdater.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/ParaStkScheduledRequestsUpdater.swift
@@ -6,7 +6,7 @@ final class ParaStkScheduledRequestsUpdater: BaseStorageChildSubscription {
     let chainRegistry: ChainRegistryProtocol
     let accountId: AccountId
     let chainId: ChainModel.Id
-    let storageRequestFactory: StorageRequestFactoryProtocol
+    let queryWrapperFactory: ParaStkScheduledRequestsQueryWrapperFactoryProtocol
 
     private lazy var localKeyFactory = LocalStorageKeyFactory()
 
@@ -18,13 +18,13 @@ final class ParaStkScheduledRequestsUpdater: BaseStorageChildSubscription {
         accountId: AccountId,
         chainId: ChainModel.Id,
         operationManager: OperationManagerProtocol,
-        storageRequestFactory: StorageRequestFactoryProtocol,
+        queryWrapperFactory: ParaStkScheduledRequestsQueryWrapperFactoryProtocol,
         logger: LoggerProtocol
     ) {
         self.chainRegistry = chainRegistry
         self.accountId = accountId
         self.chainId = chainId
-        self.storageRequestFactory = storageRequestFactory
+        self.queryWrapperFactory = queryWrapperFactory
 
         super.init(
             remoteStorageKey: remoteStorageKey,
@@ -68,11 +68,13 @@ final class ParaStkScheduledRequestsUpdater: BaseStorageChildSubscription {
             let responses = try requestResponsesClosure()
 
             return zip(collators, responses).compactMap { collator, response in
-                guard
-                    let scheduledRequests = response.value,
-                    let delegationRequest = scheduledRequests.first(where: { $0.delegator == delegatorId }) else {
-                    return nil
+                let delegationRequest = response.value?.first { request in
+                    guard let requestDelegator = request.delegator else { return true }
+
+                    return requestDelegator.wrappedValue == delegatorId
                 }
+
+                guard let delegationRequest else { return nil }
 
                 return ParachainStaking.DelegatorScheduledRequest(
                     collatorId: collator,
@@ -109,20 +111,18 @@ final class ParaStkScheduledRequestsUpdater: BaseStorageChildSubscription {
         connection: JSONRPCEngine,
         blockHash: Data?
     ) -> CompoundOperationWrapper<[StorageResponse<[ParachainStaking.ScheduledRequest]>]> {
-        let collators: () throws -> [BytesCodable] = {
-            let delegator = try decodingOperation.extractNoCancellableResultData()
-            return delegator.collators().map { BytesCodable(wrappedValue: $0) }
-        }
-        let delegatorId = BytesCodable(wrappedValue: accountId)
+        let delegatorId = accountId
 
-        return storageRequestFactory.queryItems(
-            engine: connection,
-            keyParams1: collators,
-            keyParams2: { [delegatorId] },
-            factory: {
-                try codingFactoryOperation.extractNoCancellableResultData()
+        return queryWrapperFactory.createQueryWrapper(
+            using: connection,
+            with: {
+                try decodingOperation
+                    .extractNoCancellableResultData()
+                    .collators()
+                    .map { BytesCodable(wrappedValue: $0) }
             },
-            storagePath: ParachainStaking.delegationRequestsPath,
+            delegator: { delegatorId },
+            codingFactory: { try codingFactoryOperation.extractNoCancellableResultData() },
             at: blockHash
         )
     }

--- a/novawallet/Common/Substrate/Types/ParachainStaking/ParachainStakingDelegator.swift
+++ b/novawallet/Common/Substrate/Types/ParachainStaking/ParachainStakingDelegator.swift
@@ -24,7 +24,8 @@ extension ParachainStaking {
     }
 
     struct ScheduledRequest: Decodable, Encodable, Equatable {
-        @BytesCodable var delegator: AccountId
+        /// legacy field to comply with older parachain-staking pallet version
+        var delegator: BytesCodable?
         @StringCodable var whenExecutable: RoundIndex
         let action: DelegationAction
     }

--- a/novawallet/Modules/Staking/Operations/ParachainStaking/ParaStkScheduledRequestsQueryFactory.swift
+++ b/novawallet/Modules/Staking/Operations/ParachainStaking/ParaStkScheduledRequestsQueryFactory.swift
@@ -52,10 +52,10 @@ extension ParachainStaking {
     }
 
     final class ScheduledRequestsQueryFactory: ParaStkScheduledRequestsQueryFactoryProtocol {
-        let operationQueue: OperationQueue
+        let queryWrapperFactory: ParaStkScheduledRequestsQueryWrapperFactoryProtocol
 
-        init(operationQueue: OperationQueue) {
-            self.operationQueue = operationQueue
+        init(queryWrapperFactory: ParaStkScheduledRequestsQueryWrapperFactoryProtocol) {
+            self.queryWrapperFactory = queryWrapperFactory
         }
 
         func createOperation(
@@ -64,23 +64,14 @@ extension ParachainStaking {
             runtimeService: RuntimeCodingServiceProtocol,
             connection: JSONRPCEngine
         ) -> CompoundOperationWrapper<[ParachainStaking.DelegatorScheduledRequest]> {
-            let operationManager = OperationManager(operationQueue: operationQueue)
-
-            let queryFactory = StorageRequestFactory(
-                remoteFactory: StorageKeyFactory(),
-                operationManager: operationManager
-            )
-
             let codingFactoryOperation = runtimeService.fetchCoderFactoryOperation()
 
-            let queryWrapper: CompoundOperationWrapper<[StorageResponse<[ParachainStaking.ScheduledRequest]>]> =
-                queryFactory.queryItems(
-                    engine: connection,
-                    keyParams1: { collators },
-                    keyParams2: { [delegator] },
-                    factory: { try codingFactoryOperation.extractNoCancellableResultData() },
-                    storagePath: ParachainStaking.delegationRequestsPath
-                )
+            let queryWrapper = queryWrapperFactory.createQueryWrapper(
+                using: connection,
+                with: { collators },
+                delegator: { delegator },
+                codingFactory: { try codingFactoryOperation.extractNoCancellableResultData() }
+            )
 
             queryWrapper.addDependency(operations: [codingFactoryOperation])
 
@@ -88,12 +79,13 @@ extension ParachainStaking {
                 let responses = try queryWrapper.targetOperation.extractNoCancellableResultData()
 
                 return zip(collators, responses).compactMap { collator, response in
-                    guard
-                        let delegatorRequest = response.value?.first(
-                            where: { $0.delegator == delegator }
-                        ) else {
-                        return nil
+                    let delegatorRequest = response.value?.first { request in
+                        guard let requestDelegator = request.delegator else { return true }
+
+                        return requestDelegator.wrappedValue == delegator
                     }
+
+                    guard let delegatorRequest else { return nil }
 
                     return ParachainStaking.DelegatorScheduledRequest(
                         collatorId: collator,

--- a/novawallet/Modules/Staking/Operations/ParachainStaking/ParaStkScheduledRequestsQueryFactory.swift
+++ b/novawallet/Modules/Staking/Operations/ParachainStaking/ParaStkScheduledRequestsQueryFactory.swift
@@ -76,7 +76,8 @@ extension ParachainStaking {
             let queryWrapper: CompoundOperationWrapper<[StorageResponse<[ParachainStaking.ScheduledRequest]>]> =
                 queryFactory.queryItems(
                     engine: connection,
-                    keyParams: { collators },
+                    keyParams1: { collators },
+                    keyParams2: { [delegator] },
                     factory: { try codingFactoryOperation.extractNoCancellableResultData() },
                     storagePath: ParachainStaking.delegationRequestsPath
                 )

--- a/novawallet/Modules/Staking/Operations/ParachainStaking/ParaStkScheduledRequestsQueryWrapperFactory.swift
+++ b/novawallet/Modules/Staking/Operations/ParachainStaking/ParaStkScheduledRequestsQueryWrapperFactory.swift
@@ -1,0 +1,103 @@
+import Foundation
+import SubstrateSdk
+import Operation_iOS
+
+// For more convenient usage cause of long type name
+private typealias Interface = ParaStkScheduledRequestsQueryWrapperFactoryProtocol
+
+typealias DelegationRequestsQueryResult = [StorageResponse<[ParachainStaking.ScheduledRequest]>]
+
+protocol ParaStkScheduledRequestsQueryWrapperFactoryProtocol {
+    func createQueryWrapper<K1, K2>(
+        using connection: JSONRPCEngine,
+        with collators: @escaping () throws -> [K1],
+        delegator: @escaping () throws -> K2,
+        codingFactory: @escaping () throws -> RuntimeCoderFactoryProtocol,
+        at blockHash: Data?
+    ) -> CompoundOperationWrapper<DelegationRequestsQueryResult> where K1: Encodable, K2: Encodable
+}
+
+extension ParaStkScheduledRequestsQueryWrapperFactoryProtocol {
+    func createQueryWrapper<K1, K2>(
+        using connection: JSONRPCEngine,
+        with collators: @escaping () throws -> [K1],
+        delegator: @escaping () throws -> K2,
+        codingFactory: @escaping () throws -> RuntimeCoderFactoryProtocol,
+        at blockHash: Data? = nil
+    ) -> CompoundOperationWrapper<DelegationRequestsQueryResult> where K1: Encodable, K2: Encodable {
+        createQueryWrapper(
+            using: connection,
+            with: collators,
+            delegator: delegator,
+            codingFactory: codingFactory,
+            at: blockHash
+        )
+    }
+}
+
+final class ParaStkScheduledRequestsQueryWrapperFactory {
+    private let storageRequestFactory: StorageRequestFactoryProtocol
+    private let operationManager: OperationManagerProtocol
+
+    init(
+        storageRequestFactory: StorageRequestFactoryProtocol,
+        operationManager: OperationManagerProtocol
+    ) {
+        self.storageRequestFactory = storageRequestFactory
+        self.operationManager = operationManager
+    }
+}
+
+extension ParaStkScheduledRequestsQueryWrapperFactory: Interface {
+    func createQueryWrapper<K1, K2>(
+        using connection: JSONRPCEngine,
+        with collators: @escaping () throws -> [K1],
+        delegator: @escaping () throws -> K2,
+        codingFactory: @escaping () throws -> RuntimeCoderFactoryProtocol,
+        at blockHash: Data?
+    ) -> CompoundOperationWrapper<DelegationRequestsQueryResult> where K1: Encodable, K2: Encodable {
+        OperationCombiningService.compoundNonOptionalWrapper(
+            operationManager: operationManager
+        ) { [weak self] in
+            guard let self else { throw BaseOperationError.parentOperationCancelled }
+
+            let codingFactory = try codingFactory()
+            let metadata = codingFactory.metadata
+
+            let storageMetadata = metadata.getStorageMetadata(
+                for: ParachainStaking.delegationRequestsPath
+            )
+
+            guard let storageMetadata else { throw ParaStkRequestsQueryError.storageMetadataNotFound }
+
+            return switch storageMetadata.type {
+            case .map:
+                storageRequestFactory.queryItems(
+                    engine: connection,
+                    keyParams: collators,
+                    factory: { codingFactory },
+                    storagePath: ParachainStaking.delegationRequestsPath,
+                    at: blockHash
+                )
+            case .doubleMap:
+                storageRequestFactory.queryItems(
+                    engine: connection,
+                    keyParams1: collators,
+                    keyParams2: { try Array(repeating: try delegator(), count: collators().count) },
+                    factory: { codingFactory },
+                    storagePath: ParachainStaking.delegationRequestsPath,
+                    at: blockHash
+                )
+            default:
+                throw ParaStkRequestsQueryError.unexpectedStorageType
+            }
+        }
+    }
+}
+
+// MARK: - Errors
+
+enum ParaStkRequestsQueryError: Error {
+    case storageMetadataNotFound
+    case unexpectedStorageType
+}

--- a/novawallet/Modules/Staking/StakingMain/Parachain/StakingMainPresenterFactory+Parachain.swift
+++ b/novawallet/Modules/Staking/StakingMain/Parachain/StakingMainPresenterFactory+Parachain.swift
@@ -94,6 +94,14 @@ extension StakingMainPresenterFactory {
 
         let applicationHandler = ApplicationHandler()
 
+        let queryWrapperFactory = ParaStkScheduledRequestsQueryWrapperFactory(
+            storageRequestFactory: storageRequestFactory,
+            operationManager: operationManager
+        )
+        let scheduledRequestsFactory = ParachainStaking.ScheduledRequestsQueryFactory(
+            queryWrapperFactory: queryWrapperFactory
+        )
+
         return StakingParachainInteractor(
             selectedWalletSettings: SelectedWalletSettings.shared,
             sharedState: state,
@@ -101,7 +109,7 @@ extension StakingMainPresenterFactory {
             priceLocalSubscriptionFactory: PriceProviderFactory.shared,
             networkInfoFactory: networkInfoFactory,
             durationOperationFactory: durationFactory,
-            scheduledRequestsFactory: ParachainStaking.ScheduledRequestsQueryFactory(operationQueue: operationQueue),
+            scheduledRequestsFactory: scheduledRequestsFactory,
             collatorsOperationFactory: collatorsOperationFactory,
             yieldBoostSupport: ParaStkYieldBoostSupport(),
             yieldBoostProviderFactory: ParaStkYieldBoostProviderFactory.shared,


### PR DESCRIPTION
### SUMMARY
This PR adds support for the `parachain-staking` pallet's `DelegationScheduledRequests` storage following a recent update. Moonriver has already received this update, and Moonbeam will receive it by January 28.

### SOLUTION
Introduced the `ParaStkScheduledRequestsQueryWrapperFactory` class to encapsulate storage determination logic. The storage type is determined by checking the storage metadata's `StorageEntryType`.

The `ScheduledRequest`'s delegator field is now optional, as the new pallet version removed it. The field is preserved for backward compatibility with parachains that may still be using the older pallet version, i.e. Moonbeam or Zeitgeist.