### PR TITLE
[NW-2033] Remove non-tradable segments for stablepool exchanges

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1909,6 +1909,7 @@
 		2D5EBEB02D37D4090016AC4E /* WalletStorageCleanerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5EBEAF2D37D4090016AC4E /* WalletStorageCleanerFactory.swift */; };
 		2D5EBEB22D37DE440016AC4E /* RemovedWalletDAppSettingsCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5EBEB12D37DE440016AC4E /* RemovedWalletDAppSettingsCleaner.swift */; };
 		2D5EBEB42D38F0FD0016AC4E /* AssetListMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5EBEB32D38F0FD0016AC4E /* AssetListMeasurement.swift */; };
+		2D5F77F92F19013F005D77BC /* HydraStableswapTradabilityFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5F77F82F19013F005D77BC /* HydraStableswapTradabilityFactory.swift */; };
 		2D5FC1A42C5220900013352B /* AccountVoteFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5FC1A32C5220900013352B /* AccountVoteFactory.swift */; };
 		2D60C9BD2D1AA97C00027EC6 /* ModalCardPresentationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D60C9BC2D1AA97C00027EC6 /* ModalCardPresentationConfiguration.swift */; };
 		2D60C9BF2D1AA9E500027EC6 /* ModalCardPresentationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D60C9BE2D1AA9E500027EC6 /* ModalCardPresentationStyle.swift */; };
@@ -8493,6 +8494,7 @@
 		2D5EBEAF2D37D4090016AC4E /* WalletStorageCleanerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletStorageCleanerFactory.swift; sourceTree = "<group>"; };
 		2D5EBEB12D37DE440016AC4E /* RemovedWalletDAppSettingsCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemovedWalletDAppSettingsCleaner.swift; sourceTree = "<group>"; };
 		2D5EBEB32D38F0FD0016AC4E /* AssetListMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetListMeasurement.swift; sourceTree = "<group>"; };
+		2D5F77F82F19013F005D77BC /* HydraStableswapTradabilityFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraStableswapTradabilityFactory.swift; sourceTree = "<group>"; };
 		2D5FC1A32C5220900013352B /* AccountVoteFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountVoteFactory.swift; sourceTree = "<group>"; };
 		2D60C9BC2D1AA97C00027EC6 /* ModalCardPresentationConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalCardPresentationConfiguration.swift; sourceTree = "<group>"; };
 		2D60C9BE2D1AA9E500027EC6 /* ModalCardPresentationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalCardPresentationStyle.swift; sourceTree = "<group>"; };
@@ -15137,6 +15139,7 @@
 				0CA719992B79DF5B000B086E /* HydraStableswapApi.swift */,
 				0C11D8532CC9F82C003EC46D /* HydraStableswapExchangeEdge.swift */,
 				0C11D8572CC9FED7003EC46D /* AssetsHydraStableswapExchange.swift */,
+				2D5F77F82F19013F005D77BC /* HydraStableswapTradabilityFactory.swift */,
 			);
 			path = Stableswap;
 			sourceTree = "<group>";
@@ -32777,6 +32780,7 @@
 				8860F3E4289D50BA00C0BF86 /* Array+SectionProtocol.swift in Sources */,
 				7778FE392B907C220023E801 /* StorePathMigrator.swift in Sources */,
 				8454C26F2632BBAA00657DAD /* ExtrinsicProcessing.swift in Sources */,
+				2D5F77F92F19013F005D77BC /* HydraStableswapTradabilityFactory.swift in Sources */,
 				84E25BE227E5F23E00290BF1 /* PasteboardHandler.swift in Sources */,
 				8466782027ED9B39007935D3 /* PhishingErrorPresentable.swift in Sources */,
 				84FF2684284951AF003EC78D /* DelegationCallWrapper.swift in Sources */,

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/AssetsHydraExchangeProvider.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/AssetsHydraExchangeProvider.swift
@@ -88,6 +88,14 @@ final class AssetsHydraExchangeProvider: AssetsExchangeBaseProvider {
                 operationQueue: host.operationQueue
             ),
             quoteFactory: HydraStableswapQuoteFactory(flowState: flowState),
+            tradabilityFactory: .init(
+                requestFactory: StorageRequestFactory(
+                    remoteFactory: StorageKeyFactory(),
+                    operationManager: OperationManager(operationQueue: host.operationQueue)
+                ),
+                runtimeService: host.runtimeService,
+                connection: host.connection
+            ),
             logger: logger
         )
     }

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/Stableswap/AssetsHydraStableswapExchange.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/Stableswap/AssetsHydraStableswapExchange.swift
@@ -4,6 +4,7 @@ import Operation_iOS
 final class AssetsHydraStableswapExchange {
     let swapFactory: HydraStableswapTokensFactory
     let quoteFactory: HydraStableswapQuoteFactory
+    let tradabilityFactory: HydraStableswapTradabilityFactory
     let host: HydraExchangeHostProtocol
     let logger: LoggerProtocol
 
@@ -11,21 +12,42 @@ final class AssetsHydraStableswapExchange {
         host: HydraExchangeHostProtocol,
         swapFactory: HydraStableswapTokensFactory,
         quoteFactory: HydraStableswapQuoteFactory,
+        tradabilityFactory: HydraStableswapTradabilityFactory,
         logger: LoggerProtocol
     ) {
         self.host = host
         self.swapFactory = swapFactory
         self.quoteFactory = quoteFactory
+        self.tradabilityFactory = tradabilityFactory
         self.logger = logger
+    }
+
+    private func checkPairTradability(
+        assetIn: HydraDx.AssetId,
+        assetOut: HydraDx.AssetId,
+        tradabilities: [HydraStableswap.TradabilityPairKey: HydraStableswap.Tradability]
+    ) -> Bool {
+        let tradabilityKey = HydraStableswap.TradabilityPairKey(
+            assetIn: assetIn,
+            assetOut: assetOut
+        )
+
+        return if let pairTradability = tradabilities[tradabilityKey] {
+            pairTradability.canBuy() && pairTradability.canSell()
+        } else {
+            true
+        }
     }
 }
 
 extension AssetsHydraStableswapExchange: AssetsExchangeProtocol {
     func availableDirectSwapConnections() -> CompoundOperationWrapper<[any AssetExchangableGraphEdge]> {
         let codingFactoryOpertion = host.runtimeService.fetchCoderFactoryOperation()
+        let tradabilityWrapper = tradabilityFactory.fetchTradabilities()
         let allPoolsWrapper = swapFactory.fetchRemotePools()
 
         let mappingOperation = ClosureOperation<[any AssetExchangableGraphEdge]> {
+            let tradabilities = try tradabilityWrapper.targetOperation.extractNoCancellableResultData()
             let allPools = try allPoolsWrapper.targetOperation.extractNoCancellableResultData()
             let codingFactory = try codingFactoryOpertion.extractNoCancellableResultData()
 
@@ -59,6 +81,15 @@ extension AssetsHydraStableswapExchange: AssetsExchangeProtocol {
                             return nil
                         }
 
+                        guard self.checkPairTradability(
+                            assetIn: remoteAssetIn,
+                            assetOut: remoteAssetOut,
+                            tradabilities: tradabilities
+                        ) else {
+                            self.logger.warning("Skipped remote out \(remoteAssetOut) as tradability check failed")
+                            return nil
+                        }
+
                         let edge = HydraStableswapExchangeEdge(
                             origin: localAssetIn,
                             destination: localAssetOut,
@@ -75,9 +106,11 @@ extension AssetsHydraStableswapExchange: AssetsExchangeProtocol {
         }
 
         mappingOperation.addDependency(codingFactoryOpertion)
+        mappingOperation.addDependency(tradabilityWrapper.targetOperation)
         mappingOperation.addDependency(allPoolsWrapper.targetOperation)
 
         return allPoolsWrapper
+            .insertingHead(operations: tradabilityWrapper.allOperations)
             .insertingHead(operations: [codingFactoryOpertion])
             .insertingTail(operation: mappingOperation)
     }

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/Stableswap/HydraStableswapQuoteParamsService.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/Stableswap/HydraStableswapQuoteParamsService.swift
@@ -117,7 +117,7 @@ private extension HydraStableswapQuoteParamsService {
         poolService = .init(
             poolAsset: poolAsset,
             assetIn: assetIn,
-            assetOut: assetIn,
+            assetOut: assetOut,
             connection: connection,
             runtimeProvider: runtimeProvider,
             operationQueue: operationQueue,

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/Stableswap/HydraStableswapTradabilityFactory.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/Stableswap/HydraStableswapTradabilityFactory.swift
@@ -1,0 +1,39 @@
+import Foundation
+import SubstrateSdk
+import Operation_iOS
+
+final class HydraStableswapTradabilityFactory {
+    private let requestFactory: StorageRequestFactoryProtocol
+    private let runtimeService: RuntimeProviderProtocol
+    private let connection: JSONRPCEngine
+
+    init(
+        requestFactory: StorageRequestFactoryProtocol,
+        runtimeService: RuntimeProviderProtocol,
+        connection: JSONRPCEngine
+    ) {
+        self.requestFactory = requestFactory
+        self.runtimeService = runtimeService
+        self.connection = connection
+    }
+}
+
+extension HydraStableswapTradabilityFactory {
+    func fetchTradabilities() -> CompoundOperationWrapper<
+        [HydraStableswap.TradabilityPairKey: HydraStableswap.Tradability]
+    > {
+        let codingFactoryOperation = runtimeService.fetchCoderFactoryOperation()
+
+        let wrapper: CompoundOperationWrapper<[HydraStableswap.TradabilityPairKey: HydraStableswap.Tradability]>
+        wrapper = requestFactory.queryByPrefix(
+            engine: connection,
+            request: UnkeyedRemoteStorageRequest(storagePath: HydraStableswap.tradability),
+            storagePath: HydraStableswap.tradability,
+            factory: { try codingFactoryOperation.extractNoCancellableResultData() }
+        )
+
+        wrapper.addDependency(operations: [codingFactoryOperation])
+
+        return wrapper.insertingHead(operations: [codingFactoryOperation])
+    }
+}

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraStableswap.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraStableswap.swift
@@ -45,6 +45,35 @@ enum HydraStableswap {
         }
     }
 
+    struct TradabilityPairKey: JSONListConvertible, Hashable {
+        let assetIn: HydraDx.AssetId
+        let assetOut: HydraDx.AssetId
+
+        init(jsonList: [JSON], context: [CodingUserInfoKey: Any]?) throws {
+            guard jsonList.count == 2 else {
+                throw CommonError.dataCorruption
+            }
+
+            assetIn = try jsonList[0].map(
+                to: StringScaleMapper<HydraDx.AssetId>.self,
+                with: context
+            ).value
+
+            assetOut = try jsonList[1].map(
+                to: StringScaleMapper<HydraDx.AssetId>.self,
+                with: context
+            ).value
+        }
+
+        init(
+            assetIn: HydraDx.AssetId,
+            assetOut: HydraDx.AssetId
+        ) {
+            self.assetIn = assetIn
+            self.assetOut = assetOut
+        }
+    }
+
     static func poolAccountId(for asset: HydraDx.AssetId) throws -> AccountId {
         guard let accountIdPrefix = "sts".data(using: .utf8) else {
             throw CommonError.dataCorruption


### PR DESCRIPTION
## SUMMARY

The PR extends `AssetsHydraStableswapExchange.availableDirectSwapConnections` with tradability check for each edge. If check is failed, we skip the edge. 