### PR TITLE
[NW-2033] Untradable segments disability

### DIFF
--- a/novawallet/Common/Services/AssetExchange/HydraExchange/Stableswap/AssetsHydraStableswapExchange.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/Stableswap/AssetsHydraStableswapExchange.swift
@@ -21,35 +21,135 @@ final class AssetsHydraStableswapExchange {
         self.tradabilityFactory = tradabilityFactory
         self.logger = logger
     }
+}
 
-    private func checkPairTradability(
-        assetIn: HydraDx.AssetId,
-        assetOut: HydraDx.AssetId,
-        tradabilities: [HydraStableswap.TradabilityPairKey: HydraStableswap.Tradability]
+// MARK: - Private
+
+private extension AssetsHydraStableswapExchange {
+    struct EdgeBuildingContext {
+        let tradabilities: [HydraStableswap.TradabilityPairKey: HydraStableswap.Tradability]
+        let remoteLocalMapping: [HydraDx.AssetId: ChainAssetId]
+    }
+
+    func checkAssetTradability(
+        poolId: HydraDx.AssetId,
+        assetId: HydraDx.AssetId,
+        tradabilities: [HydraStableswap.TradabilityPairKey: HydraStableswap.Tradability],
+        checkClosure: (HydraStableswap.Tradability) -> Bool
     ) -> Bool {
         let tradabilityKey = HydraStableswap.TradabilityPairKey(
-            assetIn: assetIn,
-            assetOut: assetOut
+            poolId: poolId,
+            assetId: assetId
         )
 
-        return if let pairTradability = tradabilities[tradabilityKey] {
-            pairTradability.canBuy() && pairTradability.canSell()
+        return if let assetTradability = tradabilities[tradabilityKey] {
+            checkClosure(assetTradability)
         } else {
             true
         }
     }
+
+    func buildEdge(
+        from remoteAssetIn: HydraDx.AssetId,
+        to remoteAssetOut: HydraDx.AssetId,
+        poolAsset: HydraDx.AssetId,
+        context: EdgeBuildingContext
+    ) -> AnyAssetExchangeEdge? {
+        guard let localAssetOut = context.remoteLocalMapping[remoteAssetOut] else {
+            logger.warning("Skipped remote out \(remoteAssetOut) as no mapping found")
+            return nil
+        }
+
+        guard checkAssetTradability(
+            poolId: poolAsset,
+            assetId: remoteAssetOut,
+            tradabilities: context.tradabilities,
+            checkClosure: { $0.canBuy() }
+        ) else {
+            logger.warning("Skipped remote asset \(remoteAssetOut) in pool \(poolAsset) as not buyable")
+            return nil
+        }
+
+        guard let localAssetIn = context.remoteLocalMapping[remoteAssetIn] else {
+            return nil
+        }
+
+        let edge = HydraStableswapExchangeEdge(
+            origin: localAssetIn,
+            destination: localAssetOut,
+            remoteSwapPair: .init(assetIn: remoteAssetIn, assetOut: remoteAssetOut),
+            poolAsset: poolAsset,
+            host: host,
+            quoteFactory: quoteFactory
+        )
+
+        return AnyAssetExchangeEdge(edge)
+    }
+
+    func buildEdges(
+        for remoteAssetIn: HydraDx.AssetId,
+        poolAsset: HydraDx.AssetId,
+        poolAssets: Set<HydraDx.AssetId>,
+        context: EdgeBuildingContext
+    ) -> [AnyAssetExchangeEdge] {
+        guard context.remoteLocalMapping[remoteAssetIn] != nil else {
+            logger.warning("Skipped remote in \(remoteAssetIn) as no mapping found")
+            return []
+        }
+
+        guard checkAssetTradability(
+            poolId: poolAsset,
+            assetId: remoteAssetIn,
+            tradabilities: context.tradabilities,
+            checkClosure: { $0.canSell() }
+        ) else {
+            logger.warning("Skipped remote asset \(remoteAssetIn) in pool \(poolAsset) as not sellable")
+            return []
+        }
+
+        let otherAssets = poolAssets.subtracting([remoteAssetIn])
+
+        return otherAssets.compactMap { remoteAssetOut in
+            buildEdge(
+                from: remoteAssetIn,
+                to: remoteAssetOut,
+                poolAsset: poolAsset,
+                context: context
+            )
+        }
+    }
+
+    func buildAllEdges(
+        from allPools: [HydraDx.AssetId: [HydraDx.AssetId]],
+        context: EdgeBuildingContext
+    ) -> [AnyAssetExchangeEdge] {
+        allPools.flatMap { poolAsset, poolMembers in
+            let poolAssets = Set(poolMembers + [poolAsset])
+
+            return poolAssets.flatMap { remoteAssetIn in
+                buildEdges(
+                    for: remoteAssetIn,
+                    poolAsset: poolAsset,
+                    poolAssets: poolAssets,
+                    context: context
+                )
+            }
+        }
+    }
 }
+
+// MARK: - AssetsExchangeProtocol
 
 extension AssetsHydraStableswapExchange: AssetsExchangeProtocol {
     func availableDirectSwapConnections() -> CompoundOperationWrapper<[any AssetExchangableGraphEdge]> {
-        let codingFactoryOpertion = host.runtimeService.fetchCoderFactoryOperation()
+        let codingFactoryOperation = host.runtimeService.fetchCoderFactoryOperation()
         let tradabilityWrapper = tradabilityFactory.fetchTradabilities()
         let allPoolsWrapper = swapFactory.fetchRemotePools()
 
         let mappingOperation = ClosureOperation<[any AssetExchangableGraphEdge]> {
             let tradabilities = try tradabilityWrapper.targetOperation.extractNoCancellableResultData()
             let allPools = try allPoolsWrapper.targetOperation.extractNoCancellableResultData()
-            let codingFactory = try codingFactoryOpertion.extractNoCancellableResultData()
+            let codingFactory = try codingFactoryOperation.extractNoCancellableResultData()
 
             let allRemoteAssets = Set(allPools.flatMap(\.value) + allPools.keys)
 
@@ -63,55 +163,21 @@ extension AssetsHydraStableswapExchange: AssetsExchangeProtocol {
 
             self.logger.debug("Complete processing edges \(remoteLocalMapping.count)")
 
-            return allPools.flatMap { keyValue in
-                let remotePoolAsset = keyValue.key
-                let remotePoolAssets = Set(keyValue.value + [remotePoolAsset])
+            let context = EdgeBuildingContext(
+                tradabilities: tradabilities,
+                remoteLocalMapping: remoteLocalMapping
+            )
 
-                return remotePoolAssets.flatMap { remoteAssetIn in
-                    guard let localAssetIn = remoteLocalMapping[remoteAssetIn] else {
-                        self.logger.warning("Skipped remote in \(remoteAssetIn) as no mapping found")
-                        return [AnyAssetExchangeEdge]()
-                    }
-
-                    let otherAssets = remotePoolAssets.subtracting([remoteAssetIn])
-
-                    return otherAssets.compactMap { remoteAssetOut in
-                        guard let localAssetOut = remoteLocalMapping[remoteAssetOut] else {
-                            self.logger.warning("Skipped remote out \(remoteAssetOut) as no mapping found")
-                            return nil
-                        }
-
-                        guard self.checkPairTradability(
-                            assetIn: remoteAssetIn,
-                            assetOut: remoteAssetOut,
-                            tradabilities: tradabilities
-                        ) else {
-                            self.logger.warning("Skipped remote out \(remoteAssetOut) as tradability check failed")
-                            return nil
-                        }
-
-                        let edge = HydraStableswapExchangeEdge(
-                            origin: localAssetIn,
-                            destination: localAssetOut,
-                            remoteSwapPair: .init(assetIn: remoteAssetIn, assetOut: remoteAssetOut),
-                            poolAsset: remotePoolAsset,
-                            host: self.host,
-                            quoteFactory: self.quoteFactory
-                        )
-
-                        return AnyAssetExchangeEdge(edge)
-                    }
-                }
-            }
+            return self.buildAllEdges(from: allPools, context: context)
         }
 
-        mappingOperation.addDependency(codingFactoryOpertion)
+        mappingOperation.addDependency(codingFactoryOperation)
         mappingOperation.addDependency(tradabilityWrapper.targetOperation)
         mappingOperation.addDependency(allPoolsWrapper.targetOperation)
 
         return allPoolsWrapper
             .insertingHead(operations: tradabilityWrapper.allOperations)
-            .insertingHead(operations: [codingFactoryOpertion])
+            .insertingHead(operations: [codingFactoryOperation])
             .insertingTail(operation: mappingOperation)
     }
 }

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraStableswap.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraStableswap.swift
@@ -46,31 +46,31 @@ enum HydraStableswap {
     }
 
     struct TradabilityPairKey: JSONListConvertible, Hashable {
-        let assetIn: HydraDx.AssetId
-        let assetOut: HydraDx.AssetId
+        let poolId: HydraDx.AssetId
+        let assetId: HydraDx.AssetId
 
         init(jsonList: [JSON], context: [CodingUserInfoKey: Any]?) throws {
             guard jsonList.count == 2 else {
                 throw CommonError.dataCorruption
             }
 
-            assetIn = try jsonList[0].map(
+            poolId = try jsonList[0].map(
                 to: StringScaleMapper<HydraDx.AssetId>.self,
                 with: context
             ).value
 
-            assetOut = try jsonList[1].map(
+            assetId = try jsonList[1].map(
                 to: StringScaleMapper<HydraDx.AssetId>.self,
                 with: context
             ).value
         }
 
         init(
-            assetIn: HydraDx.AssetId,
-            assetOut: HydraDx.AssetId
+            poolId: HydraDx.AssetId,
+            assetId: HydraDx.AssetId
         ) {
-            self.assetIn = assetIn
-            self.assetOut = assetOut
+            self.poolId = poolId
+            self.assetId = assetId
         }
     }
 


### PR DESCRIPTION
## SUMMARY

The PR improves the previous solution to check asset tradability in for pool members in Stableswap.

## SOLUTION

Check tradability for both assetIn and assetOut before adding the edge. Refactor class for better readability.

## TEST SWAP DATA

vDOT (15) -> GDOT (690) Disabled in Stableswap
```
"value": [
      {
        "asset_in": 15,
        "asset_out": 5,
        "pool": {
          "Omnipool": "NULL"
        }
      },
      {
        "asset_in": 5,
        "asset_out": 1001,
        "pool": {
          "Aave": "NULL"
        }
      },
      {
        "asset_in": 1001,
        "asset_out": 690,
        "pool": {
          "Stableswap": 690
        }
      },
      {
        "asset_in": 690,
        "asset_out": 69,
        "pool": {
          "Aave": "NULL"
        }
      }
    ]
```

GDOT (690) -> vDOT (15) Allowed in Stableswap

```
"value": [
      {
        "asset_in": 69,
        "asset_out": 690,
        "pool": {
          "Aave": "NULL"
        }
      },
      {
        "asset_in": 690,
        "asset_out": 15,
        "pool": {
          "Stableswap": 690
        }
      }
    ]
```