### PR TITLE
EVM-only WO wallet

### DIFF
--- a/novawallet/Modules/AssetList/View/AssetListTotalBalanceView.swift
+++ b/novawallet/Modules/AssetList/View/AssetListTotalBalanceView.swift
@@ -164,7 +164,18 @@ final class AssetListTotalBalanceView: UIView {
         swapButton.isEnabled = viewModel.hasSwaps
         giftButton.isEnabled = viewModel.hasGifts
 
+        setupTotalBalanceTitle(for: viewModel.walletSwitch.type)
         setupPrivacyModeToggle(enabled: viewModel.privacyModelEnabled)
+    }
+
+    func setupTotalBalanceTitle(for walletType: WalletsListSectionViewModel.SectionType) {
+        let localizedStrings = R.string(preferredLanguages: locale.rLanguages).localizable
+
+        if walletType == .watchOnly {
+            titleLabel.text = localizedStrings.assetListWatchOnlyBalance()
+        } else {
+            titleLabel.text = localizedStrings.walletTotalBalance()
+        }
     }
 
     private func setupPrivacyModeToggle(enabled: Bool) {

--- a/novawallet/Modules/WatchOnly/CreateWatchOnly/CreateWatchOnlyPresenter.swift
+++ b/novawallet/Modules/WatchOnly/CreateWatchOnly/CreateWatchOnlyPresenter.swift
@@ -36,9 +36,8 @@ private extension CreateWatchOnlyPresenter {
             return
         }
 
-        guard
-            getSubstrateAccountId() != nil,
-            let substrateAddress = partialSubstrateAddress else {
+        let substrateAddressEmpty = (partialSubstrateAddress ?? "").isEmpty
+        if !substrateAddressEmpty, getSubstrateAccountId() == nil {
             let languages = view?.selectedLocale.rLanguages ?? []
             wireframe.present(
                 message: R.string(preferredLanguages: languages).localizable.commonInvalidSubstrateAddress(),
@@ -49,6 +48,8 @@ private extension CreateWatchOnlyPresenter {
 
             return
         }
+
+        let substrateAddress = !substrateAddressEmpty ? partialSubstrateAddress : nil
 
         let evmAddressEmpty = (partialEvmAddress ?? "").isEmpty
         if !evmAddressEmpty, getEVMAccountId() == nil {
@@ -94,6 +95,7 @@ private extension CreateWatchOnlyPresenter {
 
         let inputViewModel = InputViewModel.createAccountInputViewModel(
             for: value,
+            required: false,
             enabled: enabled
         )
 

--- a/novawallet/Modules/WatchOnly/CreateWatchOnly/CreateWatchOnlyPresenter.swift
+++ b/novawallet/Modules/WatchOnly/CreateWatchOnly/CreateWatchOnlyPresenter.swift
@@ -95,7 +95,6 @@ private extension CreateWatchOnlyPresenter {
 
         let inputViewModel = InputViewModel.createAccountInputViewModel(
             for: value,
-            required: false,
             enabled: enabled
         )
 
@@ -120,7 +119,6 @@ private extension CreateWatchOnlyPresenter {
 
         let inputViewModel = InputViewModel.createAccountInputViewModel(
             for: value,
-            required: false,
             enabled: enabled
         )
 

--- a/novawallet/Modules/WatchOnly/CreateWatchOnly/CreateWatchOnlyViewController.swift
+++ b/novawallet/Modules/WatchOnly/CreateWatchOnly/CreateWatchOnlyViewController.swift
@@ -162,8 +162,8 @@ private extension CreateWatchOnlyViewController {
             setDisabledButton { $0.createWatchOnlyMissingWalletName() }
             return
         }
-        guard rootView.substrateAddressInputView.completed else {
-            setDisabledButton { $0.createWatchOnlyMissingSubstrate() }
+        guard rootView.substrateAddressInputView.completed || rootView.evmAddressInputView.completed else {
+            setDisabledButton { $0.createWatchOnlyMissingAnyAddress() }
             return
         }
         guard termsAccepted else {
@@ -256,6 +256,8 @@ private extension CreateWatchOnlyViewController {
     @objc func actionEVMAddressChanged() {
         let partialAddress = rootView.evmAddressInputView.textField.text ?? ""
         presenter.updateEVMAddress(partialAddress)
+
+        updateActionButtonState()
     }
 
     @objc func actionEVMAddressScan() {

--- a/novawallet/Modules/WatchOnly/CreateWatchOnly/Model/WatchOnlyWallet.swift
+++ b/novawallet/Modules/WatchOnly/CreateWatchOnly/Model/WatchOnlyWallet.swift
@@ -2,6 +2,6 @@ import Foundation
 
 struct WatchOnlyWallet: Decodable {
     let name: String
-    let substrateAddress: AccountAddress
+    let substrateAddress: AccountAddress?
     let evmAddress: AccountAddress?
 }

--- a/novawallet/Modules/WatchOnly/CreateWatchOnly/Model/WatchOnlyWalletOperationFactory.swift
+++ b/novawallet/Modules/WatchOnly/CreateWatchOnly/Model/WatchOnlyWalletOperationFactory.swift
@@ -13,7 +13,7 @@ protocol WatchOnlyWalletOperationFactoryProtocol {
 final class WatchOnlyWalletOperationFactory: WatchOnlyWalletOperationFactoryProtocol {
     func newWatchOnlyWalletOperation(for request: WatchOnlyWallet) -> BaseOperation<MetaAccountModel> {
         ClosureOperation {
-            let substrateAccountId = try request.substrateAddress.toAccountId()
+            let substrateAccountId = try request.substrateAddress?.toAccountId()
             let evmAddress = try request.evmAddress?.toAccountId()
 
             let substrateCryptoType = MultiassetCryptoType.sr25519.rawValue

--- a/novawallet/en.lproj/Localizable.strings
+++ b/novawallet/en.lproj/Localizable.strings
@@ -2041,3 +2041,4 @@ Do you want to continue?";
 "create.watch.only.missing.wallet.name" = "Enter a wallet name...";
 "inlinable.alert.wo.message" = "Beware of scammers. No one can unlock a watch-only wallet or its funds";
 "create.watch.only.missing.any.address" = "Enter at least one address...";
+"asset.list.watch.only.balance" = "Watch-only balance";

--- a/novawallet/en.lproj/Localizable.strings
+++ b/novawallet/en.lproj/Localizable.strings
@@ -839,7 +839,7 @@
 "common.wallet.presets" = "Preset wallets";
 "create.watch.only.details" = "Track any wallet by its address";
 //"create.watch.only.details" = "Track wallet activity without a private key.\nYou won’t be able to perform any transactions.";
-"create.watch.only.missing.substrate" = "Enter substrate address...";
+//"create.watch.only.missing.substrate" = "Enter substrate address...";
 "common.invalid.substrate.address" = "Invalid substrate address";
 "common.invalid.evm.address" = "Invalid evm address";
 "common.address.scan.error" = "Can't extract address from the code";
@@ -2040,3 +2040,4 @@ Do you want to continue?";
 "watch.only.scam.alert.confirm" = "I understood";
 "create.watch.only.missing.wallet.name" = "Enter a wallet name...";
 "inlinable.alert.wo.message" = "Beware of scammers. No one can unlock a watch-only wallet or its funds";
+"create.watch.only.missing.any.address" = "Enter at least one address...";


### PR DESCRIPTION
## SUMMARY

The PR changes field validation rules for `CreateWatchOnly` module allowing user to add EVM-only wallet.

## SCREEN RECORDINGS

https://github.com/user-attachments/assets/47273b6e-24c4-4080-9dd1-5aaa79da8223

