### PR TITLE
Add support max slipage fee and integrate rust bindings for omnipool

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -37953,8 +37953,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/novasamatech/hydra-math-swift";
 			requirement = {
-				kind = revision;
-				revision = 1e40c9e092864c0b55c0b0736541ca0386cc807c;
+				kind = exactVersion;
+				version = 0.5.0;
 			};
 		};
 		0C2BAA592E687D2F008157E7 /* XCRemoteSwiftPackageReference "ios-branch-sdk-spm" */ = {

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -794,6 +794,7 @@
 		0C85FF2E2B6D300800FC0014 /* HydraOmnipoolFlowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C85FF2D2B6D300800FC0014 /* HydraOmnipoolFlowState.swift */; };
 		0C85FF302B6D35D600FC0014 /* AssetHubFlowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C85FF2F2B6D35D600FC0014 /* AssetHubFlowState.swift */; };
 		0C85FF342B6D523B00FC0014 /* HydraOmnipoolQuoteFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C85FF332B6D523B00FC0014 /* HydraOmnipoolQuoteFactory.swift */; };
+		39E4A6E114BBDB375D10D9EB /* HydraOmnipoolApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E4A6E114BBDB375D10D9EA /* HydraOmnipoolApi.swift */; };
 		0C883A722CE2235600CAB4C8 /* HydraSwapEventsMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C883A712CE2235600CAB4C8 /* HydraSwapEventsMatcher.swift */; };
 		0C883A742CE241CB00CAB4C8 /* AssetConversionEventsMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C883A732CE241CB00CAB4C8 /* AssetConversionEventsMatching.swift */; };
 		0C883A762CE25E6800CAB4C8 /* HydraSwapEventParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C883A752CE25E6800CAB4C8 /* HydraSwapEventParser.swift */; };
@@ -7387,6 +7388,7 @@
 		0C85FF2D2B6D300800FC0014 /* HydraOmnipoolFlowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolFlowState.swift; sourceTree = "<group>"; };
 		0C85FF2F2B6D35D600FC0014 /* AssetHubFlowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetHubFlowState.swift; sourceTree = "<group>"; };
 		0C85FF332B6D523B00FC0014 /* HydraOmnipoolQuoteFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolQuoteFactory.swift; sourceTree = "<group>"; };
+		39E4A6E114BBDB375D10D9EA /* HydraOmnipoolApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolApi.swift; sourceTree = "<group>"; };
 		0C883A712CE2235600CAB4C8 /* HydraSwapEventsMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraSwapEventsMatcher.swift; sourceTree = "<group>"; };
 		0C883A732CE241CB00CAB4C8 /* AssetConversionEventsMatching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetConversionEventsMatching.swift; sourceTree = "<group>"; };
 		0C883A752CE25E6800CAB4C8 /* HydraSwapEventParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraSwapEventParser.swift; sourceTree = "<group>"; };
@@ -15146,6 +15148,7 @@
 				0C11D8592CCA3377003EC46D /* AssetsHydraOmnipoolExchange.swift */,
 				0C11D8512CC9F5F2003EC46D /* HydraOmnipoolExchangeEdge.swift */,
 				0C1CF7402E550D5300B1DA66 /* HydraOmnipoolAssetsFeeService.swift */,
+				39E4A6E114BBDB375D10D9EA /* HydraOmnipoolApi.swift */,
 			);
 			path = Omnipool;
 			sourceTree = "<group>";
@@ -35659,6 +35662,7 @@
 				2CEFF4C2574F0AABE0E9BF89 /* BaseReferendumVoteSetupViewController.swift in Sources */,
 				0C59E8CF2AA5D744001E11F3 /* PooledBalanceUpdatingState.swift in Sources */,
 				0C85FF342B6D523B00FC0014 /* HydraOmnipoolQuoteFactory.swift in Sources */,
+				39E4A6E114BBDB375D10D9EB /* HydraOmnipoolApi.swift in Sources */,
 				0CAB7DA52C471D260070CE4D /* StakingActivityForValidating.swift in Sources */,
 				D1C4208A89633395AF2FDB74 /* ReferendumVoteSetupViewLayout.swift in Sources */,
 				84CE22D929A38AA600A03156 /* GovernanceDelegateInfoPresenter+Update.swift in Sources */,
@@ -37945,8 +37949,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/novasamatech/hydra-math-swift";
 			requirement = {
-				kind = exactVersion;
-				version = 0.4.1;
+				kind = revision;
+				revision = 1e40c9e092864c0b55c0b0736541ca0386cc807c;
 			};
 		};
 		0C2BAA592E687D2F008157E7 /* XCRemoteSwiftPackageReference "ios-branch-sdk-spm" */ = {

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -794,7 +794,6 @@
 		0C85FF2E2B6D300800FC0014 /* HydraOmnipoolFlowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C85FF2D2B6D300800FC0014 /* HydraOmnipoolFlowState.swift */; };
 		0C85FF302B6D35D600FC0014 /* AssetHubFlowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C85FF2F2B6D35D600FC0014 /* AssetHubFlowState.swift */; };
 		0C85FF342B6D523B00FC0014 /* HydraOmnipoolQuoteFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C85FF332B6D523B00FC0014 /* HydraOmnipoolQuoteFactory.swift */; };
-		39E4A6E114BBDB375D10D9EB /* HydraOmnipoolApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E4A6E114BBDB375D10D9EA /* HydraOmnipoolApi.swift */; };
 		0C883A722CE2235600CAB4C8 /* HydraSwapEventsMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C883A712CE2235600CAB4C8 /* HydraSwapEventsMatcher.swift */; };
 		0C883A742CE241CB00CAB4C8 /* AssetConversionEventsMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C883A732CE241CB00CAB4C8 /* AssetConversionEventsMatching.swift */; };
 		0C883A762CE25E6800CAB4C8 /* HydraSwapEventParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C883A752CE25E6800CAB4C8 /* HydraSwapEventParser.swift */; };
@@ -1083,6 +1082,7 @@
 		0CB433482CC0F9EF00F2CB59 /* AssetsHubExchange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB433472CC0F9EF00F2CB59 /* AssetsHubExchange.swift */; };
 		0CB4334C2CC10C3C00F2CB59 /* AssetsHydraExchangeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4334B2CC10C3C00F2CB59 /* AssetsHydraExchangeProvider.swift */; };
 		0CB4334E2CC1196400F2CB59 /* WeightableEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4334D2CC1196400F2CB59 /* WeightableEdge.swift */; };
+		0CB4B1A42F6414A600158374 /* AssetExchangeQuoteDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4B1A32F6414A600158374 /* AssetExchangeQuoteDescription.swift */; };
 		0CB618CF2E70C3160018C766 /* XcmCustomTeleport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB618CE2E70C3160018C766 /* XcmCustomTeleport.swift */; };
 		0CB618D02E70C3160018C766 /* XcmCustomTeleport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB618CE2E70C3160018C766 /* XcmCustomTeleport.swift */; };
 		0CB618D22E70C3320018C766 /* Xcm+TransferType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB618D12E70C3320018C766 /* Xcm+TransferType.swift */; };
@@ -2694,6 +2694,7 @@
 		39373DDCEE7CB9D04C310BC9 /* GovernanceRevokeDelegationConfirmProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3F5511D2E7AC283FF021E8 /* GovernanceRevokeDelegationConfirmProtocols.swift */; };
 		3983EDE80B9296F3A252BA03 /* StakingRewardFiltersViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F5CAA29A0D442151679EA8 /* StakingRewardFiltersViewFactory.swift */; };
 		39C1255EC6C5C7AC14680608 /* NPoolsUnstakeConfirmWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397F057FD5B16A58E5F30F07 /* NPoolsUnstakeConfirmWireframe.swift */; };
+		39E4A6E114BBDB375D10D9EB /* HydraOmnipoolApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E4A6E114BBDB375D10D9EA /* HydraOmnipoolApi.swift */; };
 		3A4743C7C74BE4F74F6390F6 /* MarkdownDescriptionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D087F5710630FCC968B65FB5 /* MarkdownDescriptionViewLayout.swift */; };
 		3AD7635AFA1F7E66A3C00F56 /* PVAddressesInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF715CEF29477B59119520F1 /* PVAddressesInteractor.swift */; };
 		3B1D2A0FCDDF1AAC32BFEE58 /* StakingSetupAmountWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71030ADF84393172807E434 /* StakingSetupAmountWireframe.swift */; };
@@ -7388,7 +7389,6 @@
 		0C85FF2D2B6D300800FC0014 /* HydraOmnipoolFlowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolFlowState.swift; sourceTree = "<group>"; };
 		0C85FF2F2B6D35D600FC0014 /* AssetHubFlowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetHubFlowState.swift; sourceTree = "<group>"; };
 		0C85FF332B6D523B00FC0014 /* HydraOmnipoolQuoteFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolQuoteFactory.swift; sourceTree = "<group>"; };
-		39E4A6E114BBDB375D10D9EA /* HydraOmnipoolApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolApi.swift; sourceTree = "<group>"; };
 		0C883A712CE2235600CAB4C8 /* HydraSwapEventsMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraSwapEventsMatcher.swift; sourceTree = "<group>"; };
 		0C883A732CE241CB00CAB4C8 /* AssetConversionEventsMatching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetConversionEventsMatching.swift; sourceTree = "<group>"; };
 		0C883A752CE25E6800CAB4C8 /* HydraSwapEventParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraSwapEventParser.swift; sourceTree = "<group>"; };
@@ -7677,6 +7677,7 @@
 		0CB433472CC0F9EF00F2CB59 /* AssetsHubExchange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsHubExchange.swift; sourceTree = "<group>"; };
 		0CB4334B2CC10C3C00F2CB59 /* AssetsHydraExchangeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsHydraExchangeProvider.swift; sourceTree = "<group>"; };
 		0CB4334D2CC1196400F2CB59 /* WeightableEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightableEdge.swift; sourceTree = "<group>"; };
+		0CB4B1A32F6414A600158374 /* AssetExchangeQuoteDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetExchangeQuoteDescription.swift; sourceTree = "<group>"; };
 		0CB618CE2E70C3160018C766 /* XcmCustomTeleport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmCustomTeleport.swift; sourceTree = "<group>"; };
 		0CB618D12E70C3320018C766 /* Xcm+TransferType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Xcm+TransferType.swift"; sourceTree = "<group>"; };
 		0CB618D42E70C4F00018C766 /* XcmUnweightedTransferRequest+TransferType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XcmUnweightedTransferRequest+TransferType.swift"; sourceTree = "<group>"; };
@@ -9040,6 +9041,7 @@
 		39907750D40A8DD7FE1288C8 /* CreateWatchOnlyViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CreateWatchOnlyViewController.swift; sourceTree = "<group>"; };
 		399700B22225DD916DFACAF9 /* DelegateVotedReferendaViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DelegateVotedReferendaViewFactory.swift; sourceTree = "<group>"; };
 		399E91BE2E289FE301D7846A /* SwapRouteDetailsPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwapRouteDetailsPresenter.swift; sourceTree = "<group>"; };
+		39E4A6E114BBDB375D10D9EA /* HydraOmnipoolApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraOmnipoolApi.swift; sourceTree = "<group>"; };
 		3A46EE888D60C1538A0A3EFC /* NftDetailsProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NftDetailsProtocols.swift; sourceTree = "<group>"; };
 		3A6CDEC83D8A51FD89673C31 /* SwapFeeDetailsProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwapFeeDetailsProtocols.swift; sourceTree = "<group>"; };
 		3A7235097E09C94005B091B4 /* CommonDelegationTracksPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CommonDelegationTracksPresenter.swift; sourceTree = "<group>"; };
@@ -13907,6 +13909,7 @@
 				0CBABFEC2CED438A0047F29E /* AssetExchangeOperationPrototype.swift */,
 				0CE94FF12D046A8700E31D0C /* AssetExchangeFeePayerMatcher.swift */,
 				0C2DA8AE2CC2F928001F79C8 /* AssetsExchangeGraphDescription.swift */,
+				0CB4B1A32F6414A600158374 /* AssetExchangeQuoteDescription.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -33461,6 +33464,7 @@
 				0C9C64342A8D67AF004DC078 /* StakingNPoolsWireframe.swift in Sources */,
 				0CC0F8222BB52C7E002C49F6 /* CloudBackup.swift in Sources */,
 				2D1006212EC0AF200017F48D /* GiftClaimWalletOperationFactory.swift in Sources */,
+				0CB4B1A42F6414A600158374 /* AssetExchangeQuoteDescription.swift in Sources */,
 				779F1F8B2B4D807200EF1EE9 /* ProxyDepositView.swift in Sources */,
 				84C4C2F9255DB9510045B582 /* PinChangeInteractor.swift in Sources */,
 				840874D82978284B00ACFA55 /* GovernanceDelegateMetadataRemote.swift in Sources */,

--- a/novawallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/novawallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -186,8 +186,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/novasamatech/hydra-math-swift",
       "state" : {
-        "revision" : "52c6a9882721751254b0615892c289e08f0ce663",
-        "version" : "0.4.1"
+        "revision" : "1e40c9e092864c0b55c0b0736541ca0386cc807c"
       }
     },
     {

--- a/novawallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/novawallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -186,7 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/novasamatech/hydra-math-swift",
       "state" : {
-        "revision" : "1e40c9e092864c0b55c0b0736541ca0386cc807c"
+        "revision" : "159870af6bed66520f6213e13c23f1b963e036fb",
+        "version" : "0.5.0"
       }
     },
     {

--- a/novawallet/Common/Services/AssetExchange/AssetsExchange.swift
+++ b/novawallet/Common/Services/AssetExchange/AssetsExchange.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum AssetsExchange {
-    static let maxQuotePaths: Int = 4
+    static let maxQuotePaths: Int = 10
     static let defaultEdgeWeight: Int = 100
     static let mergingEdgesWeightDivider: Int = 10
 }

--- a/novawallet/Common/Services/AssetExchange/Common/AssetExchangeQuoteDescription.swift
+++ b/novawallet/Common/Services/AssetExchange/Common/AssetExchangeQuoteDescription.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum AssetExchangeQuoteDescription {
+    static func getDescription(
+        quote: AssetExchangeQuote,
+        chainRegistry: ChainRegistryProtocol
+    ) -> String {
+        let edges = quote.route.items.map(\.edge)
+        let pathDescription = AssetsExchangeGraphDescription.getDescriptionForPath(
+            edges: edges,
+            chainRegistry: chainRegistry
+        )
+
+        return "Calculated quote for path: \(pathDescription)"
+    }
+}

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/Omnipool/HydraOmnipoolApi.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/Omnipool/HydraOmnipoolApi.swift
@@ -1,0 +1,91 @@
+import Foundation
+import HydraMathApi
+import BigInt
+
+enum HydraOmnipoolApiError: Error {
+    case runtimeError(String)
+}
+
+enum HydraOmnipoolApi {
+    struct Params {
+        let assetInState: HydraOmnipool.AssetState
+        let assetOutState: HydraOmnipool.AssetState
+        let assetInBalance: BigUInt
+        let assetOutBalance: BigUInt
+        let assetFee: BigUInt
+        let protocolFee: BigUInt
+        let maxSlipFee: BigUInt
+    }
+
+    static func calculateOutGivenIn(
+        for params: Params,
+        amountIn: BigUInt
+    ) throws -> BigUInt {
+        let assetFee = try BigRational.permillPercent(
+            of: params.assetFee
+        ).decimalOrError().stringWithPointSeparator
+
+        let protocolFee = try BigRational.permillPercent(
+            of: params.protocolFee
+        ).decimalOrError().stringWithPointSeparator
+
+        let maxSlipFee = try BigRational.permillPercent(
+            of: params.maxSlipFee
+        ).decimalOrError().stringWithPointSeparator
+
+        let result = HydraOmnipoolMath.omnipoolCalculateOutGivenIn(
+            String(params.assetInBalance),
+            String(params.assetInState.hubReserve),
+            String(params.assetInState.shares),
+            String(params.assetOutBalance),
+            String(params.assetOutState.hubReserve),
+            String(params.assetOutState.shares),
+            String(amountIn),
+            assetFee,
+            protocolFee,
+            maxSlipFee
+        )
+
+        guard let amount = BigUInt(result.toString()) else {
+            throw HydraOmnipoolApiError.runtimeError("out given in calc failed")
+        }
+
+        return amount
+    }
+
+    static func calculateInGivenOut(
+        for params: Params,
+        amountOut: BigUInt
+    ) throws -> BigUInt {
+        let assetFee = try BigRational.permillPercent(
+            of: params.assetFee
+        ).decimalOrError().stringWithPointSeparator
+
+        let protocolFee = try BigRational.permillPercent(
+            of: params.protocolFee
+        ).decimalOrError().stringWithPointSeparator
+
+        let maxSlipFee = try BigRational.permillPercent(
+            of: params.maxSlipFee
+        ).decimalOrError().stringWithPointSeparator
+
+        let result = HydraOmnipoolMath.omnipoolCalculateInGivenOut(
+            String(params.assetInBalance),
+            String(params.assetInState.hubReserve),
+            String(params.assetInState.shares),
+            String(params.assetOutBalance),
+            String(params.assetOutState.hubReserve),
+            String(params.assetOutState.shares),
+            String(amountOut),
+            assetFee,
+            protocolFee,
+            maxSlipFee
+        )
+
+        guard let amount = BigUInt(result.toString()) else {
+            throw HydraOmnipoolApiError.runtimeError("in given out calc failed")
+        }
+
+        return amount
+    }
+}

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/Omnipool/HydraOmnipoolAssetsFeeService.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/Omnipool/HydraOmnipoolAssetsFeeService.swift
@@ -85,11 +85,20 @@ final class HydraOmnipoolAssetsFeeService: ObservableSubscriptionSyncService<Hyd
             mappingKey: HydraOmnipool.AssetsFeeStateChange.Key.assetOutFee
         )
 
+        let maxSlipFeeRequest = BatchStorageSubscriptionRequest(
+            innerRequest: UnkeyedSubscriptionRequest(
+                storagePath: HydraOmnipool.slipFeePath,
+                localKey: ""
+            ),
+            mappingKey: HydraOmnipool.AssetsFeeStateChange.Key.maxSlipFee.rawValue
+        )
+
         return [
             assetInStateRequest,
             assetOutStateRequest,
             assetInFeeRequest,
-            assetOutFeeRequest
+            assetOutFeeRequest,
+            maxSlipFeeRequest
         ]
     }
 }

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/Omnipool/HydraOmnipoolQuoteFactory.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/Omnipool/HydraOmnipoolQuoteFactory.swift
@@ -11,27 +11,6 @@ final class HydraOmnipoolQuoteFactory {
     }
 
     private func createQuoteStateWrapper(
-        dependingOn swapPairOperation: BaseOperation<HydraDx.SwapPair>
-    ) -> CompoundOperationWrapper<HydraOmnipool.QuoteRemoteState> {
-        OperationCombiningService<HydraOmnipool.QuoteRemoteState>.compoundNonOptionalWrapper(
-            operationManager: OperationManager(operationQueue: flowState.operationQueue)
-        ) {
-            let swapPair = try swapPairOperation.extractNoCancellableResultData()
-
-            let remoteSwapPair = HydraDx.RemoteSwapPair(
-                assetIn: swapPair.assetIn.remoteAssetId,
-                assetOut: swapPair.assetOut.remoteAssetId
-            )
-
-            let quoteService = self.flowState.setupQuoteService(for: remoteSwapPair)
-
-            let operation = quoteService.createFetchOperation()
-
-            return CompoundOperationWrapper(targetOperation: operation)
-        }
-    }
-
-    private func createQuoteStateWrapper(
         for remoteSwapPair: HydraDx.RemoteSwapPair
     ) -> CompoundOperationWrapper<HydraOmnipool.QuoteRemoteState> {
         let quoteService = flowState.setupQuoteService(for: remoteSwapPair)
@@ -74,15 +53,10 @@ final class HydraOmnipoolQuoteFactory {
         )
     }
 
-    private func canTrade(assetIn: HydraOmnipool.AssetState, assetOut: HydraOmnipool.AssetState) -> Bool {
-        assetIn.tradable.canSell() && assetOut.tradable.canBuy()
-    }
-
-    private func calculateSellQuote(
-        for amount: BigUInt,
-        remoteState: HydraOmnipool.QuoteRemoteState,
+    private func deriveApiParams(
+        from remoteState: HydraOmnipool.QuoteRemoteState,
         defaultFee: HydraDx.FeeEntry
-    ) throws -> BigUInt {
+    ) throws -> HydraOmnipoolApi.Params {
         guard let assetInState = remoteState.assetInState else {
             throw AssetConversionOperationError.runtimeError("Asset in state not found")
         }
@@ -91,99 +65,32 @@ final class HydraOmnipoolQuoteFactory {
             throw AssetConversionOperationError.runtimeError("Asset out state not found")
         }
 
-        guard canTrade(assetIn: assetInState, assetOut: assetOutState) else {
+        guard assetInState.tradable.canSell(), assetOutState.tradable.canBuy() else {
             throw AssetConversionOperationError.tradeDisabled
         }
 
-        let assetFee = BigRational.permillPercent(
-            of: remoteState.assetOutFee?.assetFee ?? defaultFee.assetFee
+        return HydraOmnipoolApi.Params(
+            assetInState: assetInState,
+            assetOutState: assetOutState,
+            assetInBalance: remoteState.assetInBalance ?? 0,
+            assetOutBalance: remoteState.assetOutBalance ?? 0,
+            assetFee: remoteState.assetOutFee?.assetFee ?? defaultFee.assetFee,
+            protocolFee: remoteState.assetInFee?.protocolFee ?? defaultFee.protocolFee,
+            maxSlipFee: remoteState.maxSlipFee ?? 0
         )
-
-        let protocolFee = BigRational.permillPercent(
-            of: remoteState.assetInFee?.protocolFee ?? defaultFee.protocolFee
-        )
-
-        let inHubReserve = assetInState.hubReserve
-        let inReserve = remoteState.assetInBalance ?? 0
-
-        let divider = inReserve + amount
-
-        guard divider > 0 else {
-            throw AssetConversionOperationError.runtimeError("Unexpected zero reserve")
-        }
-
-        let deltaHubReserveIn = (amount * inHubReserve) / divider
-
-        let protocolFeeAmount = protocolFee.mul(value: deltaHubReserveIn)
-        let deltaHubReserveOut = deltaHubReserveIn - protocolFeeAmount
-
-        let outReserveHp = remoteState.assetOutBalance ?? 0
-        let outHubReserveHp = assetOutState.hubReserve
-
-        let deltaReserveOut = (deltaHubReserveOut * outReserveHp) / (outHubReserveHp + deltaHubReserveOut)
-
-        guard let amountOut = BigUInt(1).sub(rational: assetFee)?.mul(value: deltaReserveOut) else {
-            throw AssetConversionOperationError.runtimeError("Fee too big")
-        }
-
-        return amountOut
     }
 
-    private func calculateBuyQuote(
-        for amount: BigUInt,
-        remoteState: HydraOmnipool.QuoteRemoteState,
-        defaultFee: HydraDx.FeeEntry
+    private func calculateQuote(
+        for direction: AssetConversion.Direction,
+        args: HydraOmnipoolApi.Params,
+        amount: BigUInt
     ) throws -> BigUInt {
-        guard let assetInState = remoteState.assetInState else {
-            throw AssetConversionOperationError.runtimeError("Asset in state not found")
+        switch direction {
+        case .sell:
+            return try HydraOmnipoolApi.calculateOutGivenIn(for: args, amountIn: amount)
+        case .buy:
+            return try HydraOmnipoolApi.calculateInGivenOut(for: args, amountOut: amount)
         }
-
-        guard let assetOutState = remoteState.assetOutState else {
-            throw AssetConversionOperationError.runtimeError("Asset out state not found")
-        }
-
-        guard canTrade(assetIn: assetInState, assetOut: assetOutState) else {
-            throw AssetConversionOperationError.tradeDisabled
-        }
-
-        let assetFee = BigRational.permillPercent(
-            of: remoteState.assetOutFee?.assetFee ?? defaultFee.assetFee
-        )
-
-        let protocolFee = BigRational.permillPercent(
-            of: remoteState.assetInFee?.protocolFee ?? defaultFee.protocolFee
-        )
-
-        let outReserve = remoteState.assetOutBalance ?? 0
-        guard let outReserveNoFee = BigUInt(1).sub(rational: assetFee)?.mul(value: outReserve) else {
-            throw AssetConversionOperationError.runtimeError("Asset fee too big")
-        }
-
-        guard outReserveNoFee > amount else {
-            throw AssetConversionOperationError.quoteCalcFailed
-        }
-
-        let outHubReserve = assetOutState.hubReserve
-        let deltaHubReserveOut = (outHubReserve * amount) / (outReserveNoFee - amount) + 1
-
-        guard protocolFee.denominator > protocolFee.numerator else {
-            throw AssetConversionOperationError.runtimeError("Protocol fee too big")
-        }
-
-        // deltaHubReserveOut = (1 - protocolFee) * deltaHubReserveIn
-        let deltaHubReserveIn = (deltaHubReserveOut * protocolFee.denominator) /
-            (protocolFee.denominator - protocolFee.numerator)
-
-        let inReserveHp = remoteState.assetInBalance ?? 0
-        let inHubReserveHp = assetInState.hubReserve
-
-        guard inHubReserveHp > deltaHubReserveIn else {
-            throw AssetConversionOperationError.quoteCalcFailed
-        }
-
-        let amountIn = (inReserveHp * deltaHubReserveIn) / (inHubReserveHp - deltaHubReserveIn) + 1
-
-        return amountIn
     }
 }
 
@@ -198,21 +105,13 @@ extension HydraOmnipoolQuoteFactory {
             let quoteState = try quoteStateWrapper.targetOperation.extractNoCancellableResultData()
             let defaultFee = try defaultFeeWrapper.targetOperation.extractNoCancellableResultData()
 
-            switch args.direction {
-            case .sell:
-                return try self.calculateSellQuote(
-                    for: args.amount,
-                    remoteState: quoteState,
-                    defaultFee: defaultFee
-                )
+            let apiParams = try self.deriveApiParams(from: quoteState, defaultFee: defaultFee)
 
-            case .buy:
-                return try self.calculateBuyQuote(
-                    for: args.amount,
-                    remoteState: quoteState,
-                    defaultFee: defaultFee
-                )
-            }
+            return try self.calculateQuote(
+                for: args.direction,
+                args: apiParams,
+                amount: args.amount
+            )
         }
 
         calculateOperation.addDependency(defaultFeeWrapper.targetOperation)

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/Omnipool/HydraOmnipoolQuoteParamsService.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/Omnipool/HydraOmnipoolQuoteParamsService.swift
@@ -80,6 +80,7 @@ final class HydraOmnipoolQuoteParamsService: ObservableSyncService, ObservableSu
             assetOutBalance: balanceOut.free,
             assetInFee: assetFeeState.assetInFee,
             assetOutFee: assetFeeState.assetOutFee,
+            maxSlipFee: assetFeeState.maxSlipFee?.maxSlipFee,
             blockHash: assetFeeState.blockHash
         )
     }

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/Omnipool/HydraOmnipoolQuoteRemoteState.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/Omnipool/HydraOmnipoolQuoteRemoteState.swift
@@ -10,6 +10,7 @@ extension HydraOmnipool {
         let assetOutBalance: Balance?
         let assetInFee: HydraDx.FeeEntry?
         let assetOutFee: HydraDx.FeeEntry?
+        let maxSlipFee: BigUInt?
         let blockHash: Data?
     }
 
@@ -20,6 +21,7 @@ extension HydraOmnipool {
         let assetOutState: HydraOmnipool.AssetState?
         let assetInFee: HydraDx.FeeEntry?
         let assetOutFee: HydraDx.FeeEntry?
+        let maxSlipFee: HydraOmnipool.SlipFeeConfig?
         let blockHash: Data?
 
         init(
@@ -27,12 +29,14 @@ extension HydraOmnipool {
             assetOutState: HydraOmnipool.AssetState?,
             assetInFee: HydraDx.FeeEntry?,
             assetOutFee: HydraDx.FeeEntry?,
+            maxSlipFee: HydraOmnipool.SlipFeeConfig?,
             blockHash: Data?
         ) {
             self.assetInState = assetInState
             self.assetOutState = assetOutState
             self.assetInFee = assetInFee
             self.assetOutFee = assetOutFee
+            self.maxSlipFee = maxSlipFee
             self.blockHash = blockHash
         }
 
@@ -41,6 +45,7 @@ extension HydraOmnipool {
             assetOutState = change.assetOutState.valueWhenDefined(else: nil)
             assetInFee = change.assetInFee.valueWhenDefined(else: nil)
             assetOutFee = change.assetOutFee.valueWhenDefined(else: nil)
+            maxSlipFee = change.maxSlipFee.valueWhenDefined(else: nil)
             blockHash = change.blockHash
         }
 
@@ -50,6 +55,7 @@ extension HydraOmnipool {
                 assetOutState: change.assetOutState.valueWhenDefined(else: assetOutState),
                 assetInFee: change.assetInFee.valueWhenDefined(else: assetInFee),
                 assetOutFee: change.assetOutFee.valueWhenDefined(else: assetOutFee),
+                maxSlipFee: change.maxSlipFee.valueWhenDefined(else: maxSlipFee),
                 blockHash: change.blockHash
             )
         }
@@ -61,12 +67,14 @@ extension HydraOmnipool {
             case assetOutState
             case assetInFee
             case assetOutFee
+            case maxSlipFee
         }
 
         let assetInState: UncertainStorage<HydraOmnipool.AssetState?>
         let assetOutState: UncertainStorage<HydraOmnipool.AssetState?>
         let assetInFee: UncertainStorage<HydraDx.FeeEntry?>
         let assetOutFee: UncertainStorage<HydraDx.FeeEntry?>
+        let maxSlipFee: UncertainStorage<HydraOmnipool.SlipFeeConfig?>
         let blockHash: Data?
 
         init(
@@ -74,12 +82,14 @@ extension HydraOmnipool {
             assetOutState: UncertainStorage<HydraOmnipool.AssetState?>,
             assetInFee: UncertainStorage<HydraDx.FeeEntry?>,
             assetOutFee: UncertainStorage<HydraDx.FeeEntry?>,
+            maxSlipFee: UncertainStorage<HydraOmnipool.SlipFeeConfig?>,
             blockHash: Data?
         ) {
             self.assetInState = assetInState
             self.assetOutState = assetOutState
             self.assetInFee = assetInFee
             self.assetOutFee = assetOutFee
+            self.maxSlipFee = maxSlipFee
             self.blockHash = blockHash
         }
 
@@ -109,6 +119,12 @@ extension HydraOmnipool {
             assetOutFee = try UncertainStorage<HydraDx.FeeEntry?>(
                 values: values,
                 mappingKey: Key.assetOutFee.rawValue,
+                context: context
+            )
+
+            maxSlipFee = try UncertainStorage<HydraOmnipool.SlipFeeConfig?>(
+                values: values,
+                mappingKey: Key.maxSlipFee.rawValue,
                 context: context
             )
 

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/Stableswap/HydraStableswapExchangeEdge.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/Stableswap/HydraStableswapExchangeEdge.swift
@@ -36,7 +36,7 @@ extension HydraStableswapExchangeEdge: AssetsHydraExchangeEdgeProtocol {
 }
 
 extension HydraStableswapExchangeEdge: AssetExchangableGraphEdge {
-    var weight: Int { AssetsExchange.defaultEdgeWeight - 10 }
+    var weight: Int { AssetsExchange.defaultEdgeWeight - 20 }
 
     func addingWeight(to currentWeight: Int, predecessor edge: AnyGraphEdgeProtocol?) -> Int {
         addingWeight(to: currentWeight, predecessor: edge, suggestedEdgeWeight: weight)

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraOmnipool+Storages.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraOmnipool+Storages.swift
@@ -8,4 +8,8 @@ extension HydraOmnipool {
     static var assetsPath: StorageCodingPath {
         StorageCodingPath(moduleName: Self.moduleName, itemName: "Assets")
     }
+
+    static var slipFeePath: StorageCodingPath {
+        StorageCodingPath(moduleName: Self.moduleName, itemName: "SlipFee")
+    }
 }

--- a/novawallet/Common/Substrate/Types/HydraDx/HydraOmnipool.swift
+++ b/novawallet/Common/Substrate/Types/HydraDx/HydraOmnipool.swift
@@ -28,6 +28,10 @@ enum HydraOmnipool {
         let tradable: Tradable
     }
 
+    struct SlipFeeConfig: Decodable {
+        @StringCodable var maxSlipFee: BigUInt
+    }
+
     static func getPoolAccountId(for size: Int) throws -> AccountId {
         guard let accountIdPrefix = "modlomnipool".data(using: .utf8) else {
             throw CommonError.dataCorruption

--- a/novawallet/Modules/Swaps/Base/SwapBaseInteractor.swift
+++ b/novawallet/Modules/Swaps/Base/SwapBaseInteractor.swift
@@ -209,8 +209,19 @@ class SwapBaseInteractor: AnyCancellableCleaning, AnyProviderAutoCleaning, SwapB
         ) { [weak self] result in
             switch result {
             case let .success(quote):
-                self?.basePresenter?.didReceive(quote: quote, for: args)
-                self?.setupReQuoteSubscription(for: args.assetIn, assetOut: args.assetOut)
+                guard let self else {
+                    return
+                }
+
+                let description = AssetExchangeQuoteDescription.getDescription(
+                    quote: quote,
+                    chainRegistry: chainRegistry
+                )
+
+                logger.debug(description)
+
+                basePresenter?.didReceive(quote: quote, for: args)
+                setupReQuoteSubscription(for: args.assetIn, assetOut: args.assetOut)
             case let .failure(error):
                 self?.basePresenter?.didReceive(baseError: .quote(error, args))
             }

--- a/novawalletIntegrationTests/AssetsExchange/AssetsExchangeTests.swift
+++ b/novawalletIntegrationTests/AssetsExchange/AssetsExchangeTests.swift
@@ -262,6 +262,30 @@ final class AssetsExchangeTests: XCTestCase {
         }
     }
 
+    func testRouteDOTUSDTHydration() throws {
+        let params = buildCommonParams()
+
+        let pahChain = try params.chainRegistry.getChainOrError(for: KnowChainId.hydra)
+
+        let dot = try pahChain.chainAssetForSymbolOrError("DOT").chainAssetId
+        let usdt = try pahChain.chainAssetForSymbolOrError("USDT").chainAssetId
+
+        guard let graph = createGraph(for: params) else {
+            XCTFail("No graph")
+            return
+        }
+
+        let route = graph.fetchPaths(from: dot, to: usdt, maxTopPaths: 10)
+        for path in route {
+            let pathDescription = AssetsExchangeGraphDescription.getDescriptionForPath(
+                edges: path,
+                chainRegistry: params.chainRegistry
+            )
+
+            Logger.shared.info("Route: \(pathDescription)")
+        }
+    }
+
     func testRouteGDOTDOTPolkadot() throws {
         let params = buildCommonParams()
 


### PR DESCRIPTION
## Purpose

Replace manual BigInt arithmetic in `HydraOmnipoolQuoteFactory` with native `HydraOmnipoolMath` FFI bindings (`omnipoolCalculateOutGivenIn` / `omnipoolCalculateInGivenOut`) from the updated `HydraMathApi` SPM package. This also adds support for the new on-chain `Omnipool.SlipFee` storage parameter (`maxSlipFee`) used by the Rust math library. iOS counterpart of Android PR #2265.

## Solution

- Added `SlipFeeConfig` type to `HydraOmnipool` and `slipFeePath` storage path to `HydraOmnipool+Storages`
- Extended `QuoteRemoteState`, `AssetsFeeState`, and `AssetsFeeStateChange` with `maxSlipFee` field
- Subscribed to `Omnipool.SlipFee` on-chain storage in `HydraOmnipoolAssetsFeeService` via `UnkeyedSubscriptionRequest`
- Passed `maxSlipFee` through `HydraOmnipoolQuoteParamsService.getState()`
- Created `HydraOmnipoolApi.swift` — an enum wrapping `HydraOmnipoolMath` FFI calls, following the existing `HydraStableswapApi` / `HydraXYKSwapApi` pattern
- Rewrote `HydraOmnipoolQuoteFactory` to delegate math to `HydraOmnipoolApi` instead of inline BigInt formulas, removing `calculateSellQuote`, `calculateBuyQuote`, and `canTrade` private methods

## Other changes

- allow max 10 path candidates for swaps instead of 4
- decrease stableswaps priority
