### PR TITLE
Fix staking inflation for PAH

### DIFF
--- a/novawallet/Modules/Staking/Services/RewardCalculatorService/RelayChain/PolkadotInflationPredictionFactory.swift
+++ b/novawallet/Modules/Staking/Services/RewardCalculatorService/RelayChain/PolkadotInflationPredictionFactory.swift
@@ -49,7 +49,7 @@ private extension PolkadotInflationPredictionFactory {
 
             let runtimeApi = try codingFactory.metadata.getRuntimeApiMethodOrError(
                 for: "Inflation",
-                methodName: "experimental_inflation_prediction_info"
+                methodName: "experimental_issuance_prediction_info"
             )
 
             return stateCallFactory.createWrapper(

--- a/novawallet/Modules/Staking/Services/RewardCalculatorService/RelayChain/PolkadotRewardParamsService.swift
+++ b/novawallet/Modules/Staking/Services/RewardCalculatorService/RelayChain/PolkadotRewardParamsService.swift
@@ -4,6 +4,11 @@ import BigInt
 import Operation_iOS
 
 struct RuntimeApiInflationPrediction: Decodable, Equatable {
+    enum CodingKeys: String, CodingKey {
+        case inflation = "issuance"
+        case nextMint
+    }
+
     struct NextMint: Decodable, Equatable {
         let items: [BigUInt]
 

--- a/novawallet/Modules/Staking/Services/RewardCalculatorService/RelayChain/RewardCalculatorParamsServiceFactory.swift
+++ b/novawallet/Modules/Staking/Services/RewardCalculatorService/RelayChain/RewardCalculatorParamsServiceFactory.swift
@@ -35,7 +35,7 @@ final class RewardCalculatorParamsServiceFactory {
                 runtimeCodingService: runtimeService,
                 operationQueue: operationQueue
             )
-        case KnowChainId.polkadot:
+        case KnowChainId.polkadotAssetHub:
             PolkadotRewardParamsService(
                 connection: connection,
                 runtimeCodingService: runtimeService,


### PR DESCRIPTION
## Purpose

The PR enables inflation API for Polkadot Asset Hub staking to estimate rewards

##

<img width="471" height="1024" alt="staking" src="https://github.com/user-attachments/assets/0a581495-fdc1-4085-aee3-965454b537e5" />

<img width="471" height="1024" alt="apy-details" src="https://github.com/user-attachments/assets/88536af7-e1d6-4b6b-a180-7dd8daf6f16f" />
