### PR TITLE
Add wallet search bar and favourites section to wallet lists

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -2989,6 +2989,7 @@
 		7308DEA4955C03B95A214B8C /* DelegationListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC224725C0C1743FDFED5F6E /* DelegationListPresenter.swift */; };
 		735E83BE57E30FBFD1382474 /* SwipeGovViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6AB6A7632DAA329CD5E4F8B /* SwipeGovViewLayout.swift */; };
 		73B9C322A5033A4534238B25 /* AssetsSearchViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367393F8CA6157A999F69573 /* AssetsSearchViewLayout.swift */; };
+		73F2A4F7B39607E731255EF6 /* IdentifiableStaticImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924D390C0F924524E54EE105 /* IdentifiableStaticImageViewModel.swift */; };
 		7401E7CAEEE6890BE74ACCE1 /* CustomValidatorListViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2956D0C69019DDCDAB2EB34 /* CustomValidatorListViewLayout.swift */; };
 		7489BDA1D23D8DF73E7EB9BC /* UsernameSetupWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AD15693E21C869DE1FDD17 /* UsernameSetupWireframe.swift */; };
 		74A93B3225BF8541B69F88EF /* CloudBackupAddWalletPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7F67ECE6129E9249F89202 /* CloudBackupAddWalletPresenter.swift */; };
@@ -3291,6 +3292,7 @@
 		77D5569D2BAC3CBD009AC873 /* LocalizationManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D5569C2BAC3CBD009AC873 /* LocalizationManagerExtensions.swift */; };
 		77D7BB8E2B8C6B6400D42E8A /* PushNotificationSettingsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D7BB8D2B8C6B6400D42E8A /* PushNotificationSettingsFactory.swift */; };
 		77D7BB902B8D2BEC00D42E8A /* WalletCheckboxTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D7BB8F2B8D2BEC00D42E8A /* WalletCheckboxTableViewCell.swift */; };
+		77D805387EB5548E05E796FD /* WalletFavouriteRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B28DC9E1AD20FCAE0CD348 /* WalletFavouriteRepository.swift */; };
 		77DAFF662B2979B100D4220C /* ProxyLocalStorageSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DAFF652B2979B100D4220C /* ProxyLocalStorageSubscriber.swift */; };
 		77DAFF682B297A9C00D4220C /* ProxyListLocalStorageSubscriptionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DAFF672B297A9C00D4220C /* ProxyListLocalStorageSubscriptionHandler.swift */; };
 		77DAFF6B2B297CFE00D4220C /* ProxyListLocalSubscriptionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DAFF6A2B297CFE00D4220C /* ProxyListLocalSubscriptionFactory.swift */; };
@@ -8271,7 +8273,6 @@
 		2D0C96F22EC9F2300034F9F8 /* GiftsLocalStorageSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftsLocalStorageSubscriber.swift; sourceTree = "<group>"; };
 		2D0C96F72EC9F25B0034F9F8 /* GiftsLocalSubscriptionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftsLocalSubscriptionHandler.swift; sourceTree = "<group>"; };
 		2D0C96FC2EC9F2C20034F9F8 /* GiftsLocalSubscriptionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftsLocalSubscriptionFactory.swift; sourceTree = "<group>"; };
-		2D0C97032ECA07960034F9F8 /* MultiassetUserDataModel20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MultiassetUserDataModel20.xcdatamodel; sourceTree = "<group>"; };
 		2D0C97332ECA48710034F9F8 /* GiftsOnboardingVIew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftsOnboardingVIew.swift; sourceTree = "<group>"; };
 		2D0C97592ECA49A30034F9F8 /* GiftsOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftsOnboardingViewModel.swift; sourceTree = "<group>"; };
 		2D0C97692ECA4DFB0034F9F8 /* GiftsSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftsSyncService.swift; sourceTree = "<group>"; };
@@ -12000,6 +12001,7 @@
 		88B1C34129BA046000DCA101 /* StakingRebagConfirmError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingRebagConfirmError.swift; sourceTree = "<group>"; };
 		88B1C34329BA0CB900DCA101 /* NetworkStakingInfo+BagList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkStakingInfo+BagList.swift"; sourceTree = "<group>"; };
 		88B1C34529BA0CEE00DCA101 /* BagListBounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BagListBounds.swift; sourceTree = "<group>"; };
+		88B28DC9E1AD20FCAE0CD348 /* WalletFavouriteRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletFavouriteRepository.swift; sourceTree = "<group>"; };
 		88B438E628F6C629001FC08A /* StatusTimeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusTimeViewModel.swift; sourceTree = "<group>"; };
 		88B560BB28F80DCB00A5EB59 /* VoteRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoteRowView.swift; sourceTree = "<group>"; };
 		88BB0B3C29C1E16300D041C1 /* KiltWeb3n+Ownership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KiltWeb3n+Ownership.swift"; sourceTree = "<group>"; };
@@ -12121,6 +12123,7 @@
 		9145D8F7C51281BB8B0B36DA /* OnboardingWalletReadyWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingWalletReadyWireframe.swift; sourceTree = "<group>"; };
 		91C760EDD8CDD8073063D76D /* NominationPoolBondMoreSetupViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NominationPoolBondMoreSetupViewFactory.swift; sourceTree = "<group>"; };
 		92381CBE193B3317F477D377 /* GovernanceRevokeDelegationConfirmViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceRevokeDelegationConfirmViewController.swift; sourceTree = "<group>"; };
+		924D390C0F924524E54EE105 /* IdentifiableStaticImageViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IdentifiableStaticImageViewModel.swift; sourceTree = "<group>"; };
 		92C421F2837A9F70C467AB47 /* GiftPrepareShareInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiftPrepareShareInteractor.swift; sourceTree = "<group>"; };
 		932EBC486896C9ECB60977C4 /* NetworksListWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworksListWireframe.swift; sourceTree = "<group>"; };
 		9332C701E51E9D4031BCE90D /* SwipeGovViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwipeGovViewController.swift; sourceTree = "<group>"; };
@@ -12648,6 +12651,7 @@
 		E13BDB2E7FF04670131408DB /* StakingMoreOptionsWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingMoreOptionsWireframe.swift; sourceTree = "<group>"; };
 		E18B94164B49123E62FA60B7 /* AccountManagementViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountManagementViewFactory.swift; sourceTree = "<group>"; };
 		E193257ED2B3E3960849204A /* StakingConfirmProxyPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingConfirmProxyPresenter.swift; sourceTree = "<group>"; };
+		E1BA8AB29D2A7E1B01B2AB3E /* MultiassetUserDataModel21.xcdatamodel */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcdatamodel; path = MultiassetUserDataModel21.xcdatamodel; sourceTree = "<group>"; };
 		E1E60EF37AC0A7646ED8FE64 /* AccountImportViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountImportViewFactory.swift; sourceTree = "<group>"; };
 		E20124142C4011901EF55AAA /* HardwareWalletAddressesViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HardwareWalletAddressesViewLayout.swift; sourceTree = "<group>"; };
 		E245CA0789F68382248F42C1 /* OnboardingWalletReadyViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingWalletReadyViewController.swift; sourceTree = "<group>"; };
@@ -22947,6 +22951,7 @@
 				84D8753928EB0A93004065BD /* GovernanceChainSettings.swift */,
 				0C90C6C12B4FA9FB0084B5C2 /* WalletsUpdateMediator.swift */,
 				2D20F1C52D3648F5003E9CF2 /* WalletStorageCleaning */,
+				88B28DC9E1AD20FCAE0CD348 /* WalletFavouriteRepository.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -24858,6 +24863,7 @@
 				779F1F8C2B4D8A9100EF1EE9 /* NetworkFeeInfoViewModel.swift */,
 				8490140524A92F6D008F705E /* AttributedStringDecorator+Terms.swift */,
 				0CE9339B2C051F0E000F3EFE /* WalletPrimitiveViewModelFactory.swift */,
+				924D390C0F924524E54EE105 /* IdentifiableStaticImageViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -30341,7 +30347,7 @@
 				0C8FCEA02E672BB000034ED3 /* XCRemoteSwiftPackageReference "UIKit-iOS" */,
 				0C8FCEA62E672BFB00034ED3 /* XCRemoteSwiftPackageReference "Foundation-iOS" */,
 				0C8FCEA92E672C5500034ED3 /* XCRemoteSwiftPackageReference "SwiftyBeaver" */,
-				0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability" */,
+				0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability.swift" */,
 				0C8FCEAF2E672CFA00034ED3 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				0C8FCEB22E672D3900034ED3 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				0C8FCEB52E672D8100034ED3 /* XCRemoteSwiftPackageReference "SwiftDraw" */,
@@ -30353,7 +30359,7 @@
 				0C8FCEC72E6734E900034ED3 /* XCRemoteSwiftPackageReference "ZMarkupParser" */,
 				0C8FCECA2E6735F300034ED3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				0C8FCED32E67363000034ED3 /* XCRemoteSwiftPackageReference "metadata-shortener-ios" */,
-				0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */,
+				0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */,
 				0CF8F68E2E673E73007E41C4 /* XCRemoteSwiftPackageReference "Cuckoo" */,
 				0C32522B2E67477700E322DB /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */,
 				0C2BAA1B2E677B6E008157E7 /* XCRemoteSwiftPackageReference "web3swift" */,
@@ -36845,6 +36851,8 @@
 				33096BCF84A6ABA8416678FF /* CrowdloanUnlockViewController.swift in Sources */,
 				F170C0900DB942030B2107C7 /* CrowdloanUnlockViewLayout.swift in Sources */,
 				6B19F3A772108FBED12A7260 /* CrowdloanUnlockViewFactory.swift in Sources */,
+				73F2A4F7B39607E731255EF6 /* IdentifiableStaticImageViewModel.swift in Sources */,
+				77D805387EB5548E05E796FD /* WalletFavouriteRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -37035,15 +37043,15 @@
 /* Begin PBXTargetDependency section */
 		0C1995CB2E6B2DE600E0B909 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 0C1995CA2E6B2DE600E0B909 /* RswiftGenerateInternalResources */;
+			productRef = 0C1995CA2E6B2DE600E0B909 /* plugin:RswiftGenerateInternalResources */;
 		};
 		0C1A0F502E69C04E00254E20 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 0C1A0F4F2E69C04E00254E20 /* CuckooPluginSingleFile */;
+			productRef = 0C1A0F4F2E69C04E00254E20 /* plugin:CuckooPluginSingleFile */;
 		};
 		0C6A9E2D2E6B1FC40088C2BA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 0C6A9E2C2E6B1FC40088C2BA /* RswiftGenerateInternalResources */;
+			productRef = 0C6A9E2C2E6B1FC40088C2BA /* plugin:RswiftGenerateInternalResources */;
 		};
 		77CAF4352B8E96A400E4297C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -38037,7 +38045,7 @@
 				version = 2.1.1;
 			};
 		};
-		0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability" */ = {
+		0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ashleymills/Reachability.swift";
 			requirement = {
@@ -38133,7 +38141,7 @@
 				version = 0.2.1;
 			};
 		};
-		0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */ = {
+		0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mac-cain13/R.swift";
 			requirement = {
@@ -38192,24 +38200,24 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0C1995CA2E6B2DE600E0B909 /* RswiftGenerateInternalResources */ = {
+		0C1995CA2E6B2DE600E0B909 /* plugin:RswiftGenerateInternalResources */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = "plugin:RswiftGenerateInternalResources";
 		};
 		0C1A0F472E68E01C00254E20 /* RswiftLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = RswiftLibrary;
 		};
-		0C1A0F4F2E69C04E00254E20 /* CuckooPluginSingleFile */ = {
+		0C1A0F4F2E69C04E00254E20 /* plugin:CuckooPluginSingleFile */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0CF8F68E2E673E73007E41C4 /* XCRemoteSwiftPackageReference "Cuckoo" */;
 			productName = "plugin:CuckooPluginSingleFile";
 		};
 		0C1A0F562E69EC5C00254E20 /* RswiftLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = RswiftLibrary;
 		};
 		0C2BAA1C2E677B6E008157E7 /* web3swift */ = {
@@ -38224,7 +38232,7 @@
 		};
 		0C2BAA332E67841C008157E7 /* RswiftLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = RswiftLibrary;
 		};
 		0C2BAA552E687BD0008157E7 /* HydraMathApi */ = {
@@ -38262,9 +38270,9 @@
 			package = 0C8FCE972E6725D700034ED3 /* XCRemoteSwiftPackageReference "web3swift" */;
 			productName = web3swift;
 		};
-		0C6A9E2C2E6B1FC40088C2BA /* RswiftGenerateInternalResources */ = {
+		0C6A9E2C2E6B1FC40088C2BA /* plugin:RswiftGenerateInternalResources */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = "plugin:RswiftGenerateInternalResources";
 		};
 		0C8FCE752E65ED3400034ED3 /* DGCharts */ = {
@@ -38309,7 +38317,7 @@
 		};
 		0C8FCEAD2E672CB000034ED3 /* Reachability */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability" */;
+			package = 0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability.swift" */;
 			productName = Reachability;
 		};
 		0C8FCEB02E672CFA00034ED3 /* SnapKit */ = {
@@ -38476,7 +38484,6 @@
 		8467FD4F24EFD11E005D486C /* UserDataModel.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
-				2D0C97032ECA07960034F9F8 /* MultiassetUserDataModel20.xcdatamodel */,
 				2DA4D6582EB3BBD3006FCCC0 /* MultiassetUserDataModel19.xcdatamodel */,
 				2D32AA252E6604CF0083233B /* MultiassetUserDataModel18.xcdatamodel */,
 				2D06CC472E3C94780093CA84 /* MultiassetUserDataModel17.xcdatamodel */,
@@ -38497,8 +38504,9 @@
 				849E17EE27918999002D1744 /* MultiassetUserDataModel2.xcdatamodel */,
 				848DE75726D595660045CD29 /* MultiassetUserDataModel.xcdatamodel */,
 				8467FD5024EFD11E005D486C /* UserDataModel.xcdatamodel */,
+				E1BA8AB29D2A7E1B01B2AB3E /* MultiassetUserDataModel21.xcdatamodel */,
 			);
-			currentVersion = 2D0C97032ECA07960034F9F8 /* MultiassetUserDataModel20.xcdatamodel */;
+			currentVersion = E1BA8AB29D2A7E1B01B2AB3E /* MultiassetUserDataModel21.xcdatamodel */;
 			path = UserDataModel.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/novawallet/Common/Migration/UserStorageVersion.swift
+++ b/novawallet/Common/Migration/UserStorageVersion.swift
@@ -22,6 +22,7 @@ enum UserStorageVersion: String, CaseIterable {
     case version19 = "MultiassetUserDataModel18"
     case version20 = "MultiassetUserDataModel19"
     case version21 = "MultiassetUserDataModel20"
+    case version22 = "MultiassetUserDataModel21"
 
     static var current: UserStorageVersion {
         guard let currentVersion = allCases.last else {
@@ -53,7 +54,8 @@ enum UserStorageVersion: String, CaseIterable {
         case .version18: .version19
         case .version19: .version20
         case .version20: .version21
-        case .version21: nil
+        case .version21: .version22
+        case .version22: nil
         }
     }
 }

--- a/novawallet/Common/Model/ChainRegistry/Account/ManagedMetaAccountModel.swift
+++ b/novawallet/Common/Model/ChainRegistry/Account/ManagedMetaAccountModel.swift
@@ -7,11 +7,18 @@ struct ManagedMetaAccountModel: Equatable, Hashable {
     let info: MetaAccountModel
     let isSelected: Bool
     let order: UInt32
+    let isFavourite: Bool
 
-    init(info: MetaAccountModel, isSelected: Bool = false, order: UInt32 = Self.noOrder) {
+    init(
+        info: MetaAccountModel,
+        isSelected: Bool = false,
+        order: UInt32 = Self.noOrder,
+        isFavourite: Bool = false
+    ) {
         self.info = info
         self.isSelected = isSelected
         self.order = order
+        self.isFavourite = isFavourite
     }
 }
 
@@ -21,15 +28,19 @@ extension ManagedMetaAccountModel: Identifiable {
 
 extension ManagedMetaAccountModel {
     func replacingOrder(_ newOrder: UInt32) -> ManagedMetaAccountModel {
-        ManagedMetaAccountModel(info: info, isSelected: isSelected, order: newOrder)
+        ManagedMetaAccountModel(info: info, isSelected: isSelected, order: newOrder, isFavourite: isFavourite)
     }
 
     func replacingInfo(_ newInfo: MetaAccountModel) -> ManagedMetaAccountModel {
-        ManagedMetaAccountModel(info: newInfo, isSelected: isSelected, order: order)
+        ManagedMetaAccountModel(info: newInfo, isSelected: isSelected, order: order, isFavourite: isFavourite)
     }
 
     func replacingSelection(_ isSelected: Bool) -> ManagedMetaAccountModel {
-        ManagedMetaAccountModel(info: info, isSelected: isSelected, order: order)
+        ManagedMetaAccountModel(info: info, isSelected: isSelected, order: order, isFavourite: isFavourite)
+    }
+
+    func replacingFavourite(_ isFavourite: Bool) -> ManagedMetaAccountModel {
+        ManagedMetaAccountModel(info: info, isSelected: isSelected, order: order, isFavourite: isFavourite)
     }
 }
 

--- a/novawallet/Common/Storage/EntityToModel/ManagedMetaAccountMapper.swift
+++ b/novawallet/Common/Storage/EntityToModel/ManagedMetaAccountMapper.swift
@@ -18,7 +18,8 @@ extension ManagedMetaAccountMapper: CoreDataMapperProtocol {
         return ManagedMetaAccountModel(
             info: metaAccount,
             isSelected: entity.isSelected,
-            order: UInt32(bitPattern: entity.order)
+            order: UInt32(bitPattern: entity.order),
+            isFavourite: entity.isFavourite
         )
     }
 
@@ -32,6 +33,7 @@ extension ManagedMetaAccountMapper: CoreDataMapperProtocol {
         try metaAccountMapper.populate(entity: entity, from: model.info, using: context)
 
         entity.isSelected = model.isSelected
+        entity.isFavourite = model.isFavourite
 
         let order: Int32
 

--- a/novawallet/Common/Storage/UserDataModel.xcdatamodeld/.xccurrentversion
+++ b/novawallet/Common/Storage/UserDataModel.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>MultiassetUserDataModel20.xcdatamodel</string>
+	<string>MultiassetUserDataModel21.xcdatamodel</string>
 </dict>
 </plist>

--- a/novawallet/Common/Storage/UserDataModel.xcdatamodeld/MultiassetUserDataModel21.xcdatamodel/contents
+++ b/novawallet/Common/Storage/UserDataModel.xcdatamodeld/MultiassetUserDataModel21.xcdatamodel/contents
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CDAppAttestBrowserSettings" representedClassName="CDAppAttestBrowserSettings" syncable="YES" codeGenerationType="class">
+        <attribute name="baseURL" optional="YES" attributeType="String"/>
+        <attribute name="isAttested" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="keyId" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDChainAccount" representedClassName="CDChainAccount" syncable="YES" codeGenerationType="class">
+        <attribute name="accountId" attributeType="String"/>
+        <attribute name="chainId" attributeType="String"/>
+        <attribute name="cryptoType" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="publicKey" attributeType="Binary"/>
+        <relationship name="metaAccount" maxCount="1" deletionRule="Nullify" destinationEntity="CDMetaAccount" inverseName="chainAccounts" inverseEntity="CDMetaAccount"/>
+        <relationship name="multisig" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="CDMultisig" inverseName="chainAccount" inverseEntity="CDMultisig"/>
+        <relationship name="proxy" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="CDProxy" inverseName="chainAccount" inverseEntity="CDProxy"/>
+    </entity>
+    <entity name="CDChainSettings" representedClassName="CDChainSettings" syncable="YES" codeGenerationType="class">
+        <attribute name="autobalanced" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="chainId" attributeType="String"/>
+    </entity>
+    <entity name="CDCustomChainNode" representedClassName="CDCustomChainNode" syncable="YES" codeGenerationType="class">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="url" attributeType="URI"/>
+    </entity>
+    <entity name="CDDAppBrowserTab" representedClassName="CDDAppBrowserTab" syncable="YES" codeGenerationType="class">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="desktopOnly" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="icon" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="metaId" attributeType="String"/>
+        <attribute name="renderModifiedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="url" optional="YES" attributeType="URI"/>
+    </entity>
+    <entity name="CDDAppFavorite" representedClassName="CDDAppFavorite" syncable="YES" codeGenerationType="class">
+        <attribute name="icon" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="index" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDDAppGlobalSettings" representedClassName="CDDAppGlobalSettings" syncable="YES" codeGenerationType="class">
+        <attribute name="desktopDisplayMode" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDDAppSettings" representedClassName="CDDAppSettings" syncable="YES" codeGenerationType="class">
+        <attribute name="dAppId" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="metaId" optional="YES" attributeType="String"/>
+        <attribute name="source" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDDelegatedAccountSettings" representedClassName="CDDelegatedAccountSettings" elementID="CDProxiedSettings" syncable="YES" codeGenerationType="class">
+        <attribute name="confirmsOperation" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDGift" representedClassName="CDGift" syncable="YES" codeGenerationType="class">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="assetId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="creationDate" optional="YES" attributeType="Date" defaultDateTimeInterval="784758480" usesScalarValueType="NO"/>
+        <attribute name="giftAccountId" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="metaId" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="CDMetaAccount" representedClassName="CDMetaAccount" syncable="YES" codeGenerationType="class">
+        <attribute name="ethereumAddress" optional="YES" attributeType="String"/>
+        <attribute name="ethereumPublicKey" optional="YES" attributeType="Binary"/>
+        <attribute name="isFavourite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="metaId" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="substrateAccountId" optional="YES" attributeType="String"/>
+        <attribute name="substrateCryptoType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="substratePublicKey" optional="YES" attributeType="Binary"/>
+        <attribute name="type" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="chainAccounts" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="CDChainAccount" inverseName="metaAccount" inverseEntity="CDChainAccount"/>
+        <relationship name="multisig" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="CDMultisig" inverseName="metaAccount" inverseEntity="CDMultisig"/>
+    </entity>
+    <entity name="CDMultisig" representedClassName="CDMultisig" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="multisigAccountId" optional="YES" attributeType="String"/>
+        <attribute name="otherSignatories" optional="YES" attributeType="String"/>
+        <attribute name="signatory" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
+        <attribute name="threshold" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="chainAccount" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDChainAccount" inverseName="multisig" inverseEntity="CDChainAccount"/>
+        <relationship name="metaAccount" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDMetaAccount" inverseName="multisig" inverseEntity="CDMetaAccount"/>
+    </entity>
+    <entity name="CDProxy" representedClassName="CDProxy" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="proxyAccountId" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <relationship name="chainAccount" optional="YES" maxCount="1" deletionRule="Deny" destinationEntity="CDChainAccount" inverseName="proxy" inverseEntity="CDChainAccount"/>
+    </entity>
+    <entity name="CDStakingRewardsFilter" representedClassName="CDStakingRewardsFilter" syncable="YES" codeGenerationType="class">
+        <attribute name="assetId" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="chainAccountId" attributeType="String"/>
+        <attribute name="chainId" attributeType="String"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="period" attributeType="String"/>
+        <attribute name="stakingType" attributeType="String"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="CDUserSingleValue" representedClassName="CDUserSingleValue" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="payload" optional="YES" attributeType="Binary"/>
+    </entity>
+    <entity name="CDVotingBasketItem" representedClassName="CDVotingBasketItem" syncable="YES" codeGenerationType="class">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="conviction" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="metaId" optional="YES" attributeType="String"/>
+        <attribute name="referendumId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="voteType" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="CDVotingPower" representedClassName="CDVotingPower" syncable="YES" codeGenerationType="class">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="conviction" optional="YES" attributeType="String"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="metaId" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/novawallet/Common/Storage/UserDataStorageFacade.swift
+++ b/novawallet/Common/Storage/UserDataStorageFacade.swift
@@ -16,7 +16,7 @@ enum UserStorageParams {
      *  - update mappings between CoreData Entities and App Models;
      *  - switch version of UserStorageParams.modelVersion;
      */
-    static let modelVersion: UserStorageVersion = .version21
+    static let modelVersion: UserStorageVersion = .version22
     static let modelDirectory: String = "UserDataModel.momd"
     static let databaseName = "UserDataModel.sqlite"
 

--- a/novawallet/Common/Storage/WalletFavouriteRepository.swift
+++ b/novawallet/Common/Storage/WalletFavouriteRepository.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Operation_iOS
+
+/**
+ Lightweight write path for the per-wallet `isFavourite` flag.
+
+ Favourite is a local-only UI preference — it is not part of the cloud backup
+ payload. We therefore deliberately bypass `WalletUpdateMediator` (and the
+ `CloudBackupSyncService` it triggers) here so that toggling a star does not
+ cause an unnecessary cloud sync. All other wallet writes still go through the
+ mediator unchanged.
+ */
+protocol WalletFavouriteRepositoryProtocol {
+    func toggleFavouriteWrapper(for metaId: MetaAccountModel.Id) -> CompoundOperationWrapper<Void>
+}
+
+final class WalletFavouriteRepository {
+    let repository: AnyDataProviderRepository<ManagedMetaAccountModel>
+
+    init(repository: AnyDataProviderRepository<ManagedMetaAccountModel>) {
+        self.repository = repository
+    }
+}
+
+extension WalletFavouriteRepository: WalletFavouriteRepositoryProtocol {
+    func toggleFavouriteWrapper(
+        for metaId: MetaAccountModel.Id
+    ) -> CompoundOperationWrapper<Void> {
+        let fetchOperation = repository.fetchOperation(
+            by: { metaId },
+            options: RepositoryFetchOptions()
+        )
+
+        let saveOperation = repository.saveOperation({
+            guard let existing = try fetchOperation.extractNoCancellableResultData() else {
+                return []
+            }
+            let updated = existing.replacingFavourite(!existing.isFavourite)
+            return [updated]
+        }, { [] })
+
+        saveOperation.addDependency(fetchOperation)
+
+        return CompoundOperationWrapper(
+            targetOperation: saveOperation,
+            dependencies: [fetchOperation]
+        )
+    }
+}

--- a/novawallet/Common/View/WalletSwitchControl.swift
+++ b/novawallet/Common/View/WalletSwitchControl.swift
@@ -138,6 +138,12 @@ final class WalletSwitchControl: ControlView<RoundedView, WalletSwitchContentVie
             applyCommonStyle(to: controlBackgroundView)
 
             typeImageView.image = R.image.iconLedger()
+        case .favourites, .searchResults:
+            controlBackgroundView.fillColor = .clear
+            controlBackgroundView.highlightedFillColor = .clear
+            controlBackgroundView.strokeColor = .clear
+            controlBackgroundView.highlightedStrokeColor = .clear
+            typeImageView.image = nil
         }
 
         controlContentView.badgeView.isHidden = !viewModel.hasNotification

--- a/novawallet/Common/ViewModel/IdentifiableStaticImageViewModel.swift
+++ b/novawallet/Common/ViewModel/IdentifiableStaticImageViewModel.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+final class IdentifiableStaticImageViewModel: IdentifiableImageViewModelProtocol {
+    let staticViewModel: StaticImageViewModel
+    let identifier: String
+
+    init(image: UIImage, identifier: String) {
+        staticViewModel = StaticImageViewModel(image: image)
+        self.identifier = identifier
+    }
+
+    func loadImage(on imageView: UIImageView, settings: ImageViewModelSettings, animated: Bool) {
+        staticViewModel.loadImage(on: imageView, settings: settings, animated: animated)
+    }
+
+    func cancel(on imageView: UIImageView) {
+        staticViewModel.cancel(on: imageView)
+    }
+}

--- a/novawallet/Modules/WalletsList/Common/WalletsListPresenter.swift
+++ b/novawallet/Modules/WalletsList/Common/WalletsListPresenter.swift
@@ -12,6 +12,7 @@ class WalletsListPresenter {
 
     var viewModels: [WalletsListSectionViewModel] = []
     private(set) var chains: [ChainModel.Id: ChainModel] = [:]
+    var searchQuery: String = ""
 
     let walletsList: ListDifferenceCalculator<ManagedMetaAccountModel> = {
         let calculator = ListDifferenceCalculator<ManagedMetaAccountModel>(
@@ -78,10 +79,27 @@ class WalletsListPresenter {
     }
 
     private func updateViewModels() {
-        if let balancesCalculator = balancesCalculator {
+        let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty,
+           let factory = viewModelFactory as? WalletsListViewModelFactory {
+            let section = factory.createSearchResultsSection(
+                query: trimmed,
+                wallets: walletsList.allItems,
+                balancesCalculator: balancesCalculator,
+                chains: chains,
+                locale: selectedLocale
+            )
+            viewModels = [section]
+        } else if let balancesCalculator = balancesCalculator {
             viewModels = viewModelFactory.createSectionViewModels(
                 for: walletsList.allItems,
                 balancesCalculator: balancesCalculator,
+                chains: chains,
+                locale: selectedLocale
+            )
+        } else {
+            viewModels = viewModelFactory.createSectionViewModels(
+                for: walletsList.allItems,
                 chains: chains,
                 locale: selectedLocale
             )
@@ -106,6 +124,11 @@ extension WalletsListPresenter: WalletsListPresenterProtocol {
 
     func section(at index: Int) -> WalletsListSectionViewModel {
         viewModels[index]
+    }
+
+    func search(query: String) {
+        searchQuery = query
+        updateViewModels()
     }
 }
 

--- a/novawallet/Modules/WalletsList/Common/WalletsListProtocols.swift
+++ b/novawallet/Modules/WalletsList/Common/WalletsListProtocols.swift
@@ -12,6 +12,7 @@ protocol WalletsListPresenterProtocol: AnyObject {
     func numberOfItems(in section: Int) -> Int
     func item(at index: Int, in section: Int) -> WalletsListViewModel
     func section(at index: Int) -> WalletsListSectionViewModel
+    func search(query: String)
 }
 
 protocol WalletsListInteractorInputProtocol: AnyObject {

--- a/novawallet/Modules/WalletsList/Common/WalletsListViewController.swift
+++ b/novawallet/Modules/WalletsList/Common/WalletsListViewController.swift
@@ -78,8 +78,8 @@ class WalletsListViewController<
 
         switch section.type {
         case .secrets:
-            icon = nil
-            title = nil
+            icon = UIImage(systemName: "wallet.pass.fill")
+            title = R.string(preferredLanguages: selectedLocale.rLanguages).localizable.commonWallets().uppercased()
         case .watchOnly:
             icon = R.image.iconWatchOnlyHeader()
             title = R.string(preferredLanguages: selectedLocale.rLanguages).localizable.commonWatchOnly().uppercased()
@@ -103,6 +103,15 @@ class WalletsListViewController<
         case .genericLedger:
             icon = R.image.iconLedgerHeader()
             title = R.string(preferredLanguages: selectedLocale.rLanguages).localizable.commonLedger().uppercased()
+        case .favourites:
+            icon = UIImage(systemName: "star.fill")?.withTintColor(
+                R.color.colorIconAccent() ?? .systemYellow,
+                renderingMode: .alwaysOriginal
+            )
+            title = R.string(preferredLanguages: selectedLocale.rLanguages).localizable.commonFavourites().uppercased()
+        case .searchResults:
+            icon = UIImage(systemName: "magnifyingglass")
+            title = R.string(preferredLanguages: selectedLocale.rLanguages).localizable.commonSearchResults().uppercased()
         }
 
         guard let title, let icon else { return nil }
@@ -123,15 +132,16 @@ class WalletsListViewController<
         let section = basePresenter.section(at: section)
 
         switch section.type {
-        case .secrets:
-            return 0.0
         case .watchOnly,
+             .secrets,
              .paritySigner,
              .polkadotVault,
              .ledger,
              .proxied,
              .genericLedger,
-             .multisig:
+             .multisig,
+             .favourites,
+             .searchResults:
             return 46.0
         }
     }

--- a/novawallet/Modules/WalletsList/Common/WalletsListViewModel.swift
+++ b/novawallet/Modules/WalletsList/Common/WalletsListViewModel.swift
@@ -6,22 +6,30 @@ struct WalletsListViewModel {
     let walletViewModel: WalletView.ViewModel
     let isSelected: Bool
     let isSelectable: Bool
+    let isFavourite: Bool
+    let typeBadge: String?
 
     init(
         identifier: String,
         walletViewModel: WalletView.ViewModel,
         isSelected: Bool,
-        isSelectable: Bool = true
+        isSelectable: Bool = true,
+        isFavourite: Bool = false,
+        typeBadge: String? = nil
     ) {
         self.identifier = identifier
         self.walletViewModel = walletViewModel
         self.isSelected = isSelected
         self.isSelectable = isSelectable
+        self.isFavourite = isFavourite
+        self.typeBadge = typeBadge
     }
 }
 
 struct WalletsListSectionViewModel {
     enum SectionType: Hashable {
+        case favourites
+        case searchResults
         case secrets
         case watchOnly
         case paritySigner

--- a/novawallet/Modules/WalletsList/Common/WalletsListViewModelFactory.swift
+++ b/novawallet/Modules/WalletsList/Common/WalletsListViewModelFactory.swift
@@ -71,7 +71,8 @@ class WalletsListViewModelFactory {
         return WalletsListViewModel(
             identifier: wallet.identifier,
             walletViewModel: walletViewModel,
-            isSelected: isSelected(wallet: wallet)
+            isSelected: isSelected(wallet: wallet),
+            isFavourite: wallet.isFavourite
         )
     }
 
@@ -92,7 +93,8 @@ class WalletsListViewModelFactory {
         return WalletsListViewModel(
             identifier: wallet.identifier,
             walletViewModel: walletViewModel,
-            isSelected: isSelected(wallet: wallet)
+            isSelected: isSelected(wallet: wallet),
+            isFavourite: wallet.isFavourite
         )
     }
 }
@@ -165,7 +167,8 @@ extension WalletsListViewModelFactory {
         return WalletsListViewModel(
             identifier: wallet.identifier,
             walletViewModel: viewModel,
-            isSelected: isSelected(wallet: wallet)
+            isSelected: isSelected(wallet: wallet),
+            isFavourite: wallet.isFavourite
         )
     }
 
@@ -215,7 +218,8 @@ extension WalletsListViewModelFactory {
         return WalletsListViewModel(
             identifier: wallet.identifier,
             walletViewModel: proxyModel,
-            isSelected: isSelected(wallet: wallet)
+            isSelected: isSelected(wallet: wallet),
+            isFavourite: wallet.isFavourite
         )
     }
 
@@ -229,7 +233,7 @@ extension WalletsListViewModelFactory {
 
 // MARK: - Private
 
-private extension WalletsListViewModelFactory {
+extension WalletsListViewModelFactory {
     func createSection(
         type: WalletsListSectionViewModel.SectionType,
         wallets: [ManagedMetaAccountModel],
@@ -303,6 +307,159 @@ private extension WalletsListViewModelFactory {
         }
     }
 
+    func createSingleItemViewModel(
+        for wallet: ManagedMetaAccountModel,
+        wallets: [ManagedMetaAccountModel],
+        balancesCalculator: BalancesCalculating?,
+        chains: [ChainModel.Id: ChainModel],
+        locale: Locale
+    ) -> WalletsListViewModel? {
+        switch WalletsListSectionViewModel.SectionType(walletType: wallet.info.type) {
+        case .proxied:
+            return createProxyItemViewModel(for: wallet, wallets: wallets, chains: chains, locale: locale)
+        case .multisig:
+            return createMultisigItemViewModel(for: wallet, wallets: wallets, chains: chains, locale: locale)
+        default:
+            if let balancesCalculator = balancesCalculator {
+                return createItemViewModel(for: wallet, balancesCalculator: balancesCalculator, locale: locale)
+            } else {
+                return createItemViewModel(for: wallet)
+            }
+        }
+    }
+
+    func createFavouritesSection(
+        wallets: [ManagedMetaAccountModel],
+        balancesCalculator: BalancesCalculating?,
+        chains: [ChainModel.Id: ChainModel],
+        locale: Locale
+    ) -> WalletsListSectionViewModel? {
+        let viewModels: [WalletsListViewModel] = wallets
+            .filter { $0.isFavourite }
+            .compactMap { wallet in
+                guard let base = createSingleItemViewModel(
+                    for: wallet,
+                    wallets: wallets,
+                    balancesCalculator: balancesCalculator,
+                    chains: chains,
+                    locale: locale
+                ) else { return nil }
+
+                // Multisig parity with Android: when a favourited multisig has
+                // no network-specific chain icon, surface the multisig pencils
+                // icon over its identicon so the type stays visible in the
+                // Favourites section.
+                guard wallet.info.type == .multisig,
+                      case let .multisig(info) = base.walletViewModel.type,
+                      info.networkIcon == nil,
+                      let multisigImage = R.image.iconMultisig()
+                else { return base }
+
+                let multisigIconViewModel = IdentifiableStaticImageViewModel(
+                    image: multisigImage,
+                    identifier: "favourites.multisig.\(wallet.identifier)"
+                )
+                let updatedInfo = WalletView.ViewModel.DelegatedAccountInfo(
+                    networkIcon: multisigIconViewModel,
+                    type: info.type,
+                    pairedAccountIcon: info.pairedAccountIcon,
+                    pairedAccountName: info.pairedAccountName,
+                    isNew: info.isNew
+                )
+                let updatedWalletViewModel = WalletView.ViewModel(
+                    wallet: base.walletViewModel.wallet,
+                    type: .multisig(updatedInfo)
+                )
+                return WalletsListViewModel(
+                    identifier: base.identifier,
+                    walletViewModel: updatedWalletViewModel,
+                    isSelected: base.isSelected,
+                    isSelectable: base.isSelectable,
+                    isFavourite: base.isFavourite,
+                    typeBadge: base.typeBadge
+                )
+            }
+        guard !viewModels.isEmpty else { return nil }
+        return WalletsListSectionViewModel(type: .favourites, items: viewModels)
+    }
+
+    func createSearchResultsSection(
+        query: String,
+        wallets: [ManagedMetaAccountModel],
+        balancesCalculator: BalancesCalculating?,
+        chains: [ChainModel.Id: ChainModel],
+        locale: Locale
+    ) -> WalletsListSectionViewModel {
+        let lowered = query.lowercased()
+        let normalizedQuery = lowered.replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: " ", with: "")
+
+        let proxyTypeKeywords: Set<String> = [
+            "any", "nontransfer", "governance", "staking",
+            "identityjudgement", "cancelproxy", "auction", "nominationpools"
+        ]
+        // Prefix-style match only: typing `gov` matches `governance`, but a
+        // longer query is never assumed to "be" a proxy keyword. This avoids
+        // pulling unrelated wallets in when the query happens to share a
+        // substring with a proxy type word.
+        let isProxyTypeQuery = !normalizedQuery.isEmpty
+            && proxyTypeKeywords.contains { $0.contains(normalizedQuery) }
+
+        let matched = wallets.filter { wallet in
+            // Strict proxy type query: only proxied wallets matching the type
+            if isProxyTypeQuery {
+                guard wallet.info.type == .proxied else { return false }
+                for chainAccount in wallet.info.chainAccounts {
+                    if let proxy = chainAccount.proxy {
+                        let proxyTypeName = "\(proxy.type)".lowercased()
+                        if proxyTypeName.contains(normalizedQuery) {
+                            return true
+                        }
+                    }
+                }
+                return false
+            }
+
+            if wallet.info.name.lowercased().contains(lowered) { return true }
+            for chainAccount in wallet.info.chainAccounts {
+                if let chain = chains[chainAccount.chainId],
+                   let addr = try? chainAccount.accountId.toAddress(using: chain.chainFormat),
+                   addr.lowercased().contains(lowered) {
+                    return true
+                }
+                if let chain = chains[chainAccount.chainId],
+                   chain.name.lowercased().contains(lowered) {
+                    return true
+                }
+            }
+            return false
+        }
+        let viewModels: [WalletsListViewModel] = matched.compactMap { wallet in
+            guard let base = createSingleItemViewModel(
+                for: wallet,
+                wallets: wallets,
+                balancesCalculator: balancesCalculator,
+                chains: chains,
+                locale: locale
+            ) else { return nil }
+            let badge: String?
+            switch WalletsListSectionViewModel.SectionType(walletType: wallet.info.type) {
+            case .proxied: badge = R.string.localizable.commonProxy(preferredLanguages: locale.rLanguages)
+            case .multisig: badge = R.string.localizable.commonMultisig(preferredLanguages: locale.rLanguages)
+            default: badge = nil
+            }
+            return WalletsListViewModel(
+                identifier: base.identifier,
+                walletViewModel: base.walletViewModel,
+                isSelected: base.isSelected,
+                isSelectable: base.isSelectable,
+                isFavourite: base.isFavourite,
+                typeBadge: badge
+            )
+        }
+        return WalletsListSectionViewModel(type: .searchResults, items: viewModels)
+    }
+
     // swiftlint:disable:next function_body_length
     func internalCreateSectionViewModels(
         for wallets: [ManagedMetaAccountModel],
@@ -311,6 +468,15 @@ private extension WalletsListViewModelFactory {
         locale: Locale
     ) -> [WalletsListSectionViewModel] {
         var sections: [WalletsListSectionViewModel] = []
+
+        if let favSection = createFavouritesSection(
+            wallets: wallets,
+            balancesCalculator: balancesCalculator,
+            chains: chains,
+            locale: locale
+        ) {
+            sections.append(favSection)
+        }
 
         if let secretsSection = createSection(
             type: .secrets,

--- a/novawallet/Modules/WalletsList/Manage/WalletManageInteractor.swift
+++ b/novawallet/Modules/WalletsList/Manage/WalletManageInteractor.swift
@@ -3,6 +3,7 @@ import Operation_iOS
 
 final class WalletManageInteractor: WalletsListInteractor {
     let walletUpdateMediator: WalletUpdateMediating
+    let walletFavouriteRepository: WalletFavouriteRepositoryProtocol
     let cloudBackupSyncService: CloudBackupSyncServiceProtocol
     let eventCenter: EventCenterProtocol
     let operationQueue: OperationQueue
@@ -23,12 +24,14 @@ final class WalletManageInteractor: WalletsListInteractor {
         balancesStore: BalancesStoreProtocol,
         walletListLocalSubscriptionFactory: WalletListLocalSubscriptionFactoryProtocol,
         walletUpdateMediator: WalletUpdateMediating,
+        walletFavouriteRepository: WalletFavouriteRepositoryProtocol,
         eventCenter: EventCenterProtocol,
         operationQueue: OperationQueue,
         logger: LoggerProtocol
     ) {
         self.cloudBackupSyncService = cloudBackupSyncService
         self.walletUpdateMediator = walletUpdateMediator
+        self.walletFavouriteRepository = walletFavouriteRepository
         self.eventCenter = eventCenter
         self.operationQueue = operationQueue
         self.logger = logger
@@ -98,6 +101,25 @@ extension WalletManageInteractor: WalletManageInteractorInputProtocol {
         ) { result in
             self.eventCenter.notify(with: WalletRemoved())
             self.handleWalletsUpdate(result: result)
+        }
+    }
+
+    func toggleFavourite(metaId: MetaAccountModel.Id) {
+        // Bypasses WalletUpdateMediator on purpose: isFavourite is local-only
+        // metadata and not part of the cloud backup payload, so a star tap
+        // should not trigger a backup sync. The wallets-list local subscription
+        // observing the underlying store still picks up the change and the UI
+        // refreshes through the standard didReceiveWalletsChanges path.
+        let wrapper = walletFavouriteRepository.toggleFavouriteWrapper(for: metaId)
+
+        execute(
+            wrapper: wrapper,
+            inOperationQueue: operationQueue,
+            runningCallbackIn: .main
+        ) { [weak self] result in
+            if case let .failure(error) = result {
+                self?.logger.error("Toggle favourite failed: \(error)")
+            }
         }
     }
 }

--- a/novawallet/Modules/WalletsList/Manage/WalletManagePresenter.swift
+++ b/novawallet/Modules/WalletsList/Manage/WalletManagePresenter.swift
@@ -176,6 +176,15 @@ extension WalletManagePresenter: WalletManagePresenterProtocol {
         }
     }
 
+    func toggleFavourite(at index: Int, section: Int) {
+        guard viewModels.count > section, viewModels[section].items.count > index else { return }
+        let identifier = viewModels[section].items[index].identifier
+        guard let wallet = walletsList.allItems.first(where: { $0.identifier == identifier }) else { return }
+        // Goes through the dedicated favourite repository (not WalletUpdateMediator)
+        // so the cloud backup pipeline is not triggered for a local-only flag.
+        interactor?.toggleFavourite(metaId: wallet.info.metaId)
+    }
+
     func activateAddWallet() {
         guard let view = view else {
             return

--- a/novawallet/Modules/WalletsList/Manage/WalletManageProtocols.swift
+++ b/novawallet/Modules/WalletsList/Manage/WalletManageProtocols.swift
@@ -9,12 +9,14 @@ protocol WalletManagePresenterProtocol: WalletsListPresenterProtocol {
     func moveItem(at startIndex: Int, to finalIndex: Int, section: Int)
     func canDeleteItem(at index: Int, section: Int) -> Bool
     func removeItem(at index: Int, section: Int)
+    func toggleFavourite(at index: Int, section: Int)
     func activateAddWallet()
 }
 
 protocol WalletManageInteractorInputProtocol: WalletsListInteractorInputProtocol {
     func save(items: [ManagedMetaAccountModel])
     func remove(item: ManagedMetaAccountModel)
+    func toggleFavourite(metaId: MetaAccountModel.Id)
 }
 
 protocol WalletManageInteractorOutputProtocol: WalletsListInteractorOutputProtocol {

--- a/novawallet/Modules/WalletsList/Manage/WalletManageTableViewCell.swift
+++ b/novawallet/Modules/WalletsList/Manage/WalletManageTableViewCell.swift
@@ -1,8 +1,37 @@
 import UIKit
 import UIKit_iOS
 
+private enum WalletManageTableViewCellConstants {
+    static let favouriteButtonSize: CGFloat = 28
+    static let favouriteButtonContentSpacing: CGFloat = 8
+    // Pulls the wallet content slightly closer to the delete control in edit
+    // mode so row alignment matches the prod (no-favourite-button) layout.
+    // Empirically tuned against the prod build.
+    static let reorderingContentLeadingOffset: CGFloat = -11
+}
+
 final class WalletManageTableViewCell<V: WalletViewProtocol>: WalletsListTableViewCell<V, UIImageView> {
+    private typealias Constants = WalletManageTableViewCellConstants
+
     private lazy var reorderingAnimator = BlockViewAnimator()
+
+    let favouriteButton: UIButton = {
+        let button = UIButton(type: .custom)
+        let normalIcon = UIImage(systemName: "star")?.withTintColor(
+            R.color.colorTextSecondary() ?? .gray,
+            renderingMode: .alwaysOriginal
+        )
+        let selectedIcon = UIImage(systemName: "star.fill")?.withTintColor(
+            R.color.colorIconAccent() ?? .systemYellow,
+            renderingMode: .alwaysOriginal
+        )
+        button.setImage(normalIcon, for: .normal)
+        button.setImage(selectedIcon, for: .selected)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    var onFavouriteTapped: (() -> Void)?
 
     var disclosureIndicatorView: UIImageView { contentDisplayView.valueView }
 
@@ -15,9 +44,53 @@ final class WalletManageTableViewCell<V: WalletViewProtocol>: WalletsListTableVi
         disclosureIndicatorView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     }
 
+    override func setupLayout() {
+        contentView.addSubview(favouriteButton)
+        favouriteButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(UIConstants.horizontalInset)
+            make.centerY.equalToSuperview()
+            make.height.equalTo(Constants.favouriteButtonSize)
+            make.width.equalTo(Constants.favouriteButtonSize)
+        }
+
+        contentView.addSubview(contentDisplayView)
+        contentDisplayView.snp.makeConstraints { make in
+            make.leading.equalTo(favouriteButton.snp.trailing).offset(Constants.favouriteButtonContentSpacing)
+            make.top.bottom.equalToSuperview()
+            make.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
+        }
+
+        favouriteButton.addTarget(self, action: #selector(handleFavouriteTap), for: .touchUpInside)
+    }
+
+    private func updateContentLeading(reordering: Bool) {
+        contentDisplayView.snp.updateConstraints { make in
+            let offset = reordering
+                ? Constants.reorderingContentLeadingOffset
+                : Constants.favouriteButtonContentSpacing
+            make.leading.equalTo(favouriteButton.snp.trailing).offset(offset)
+        }
+    }
+
+    @objc private func handleFavouriteTap() {
+        onFavouriteTapped?()
+    }
+
+    override func bind(viewModel: WalletsListViewModel) {
+        super.bind(viewModel: viewModel)
+        favouriteButton.isSelected = viewModel.isFavourite
+    }
+
     func setReordering(_ reordering: Bool, animated: Bool) {
+        favouriteButton.snp.updateConstraints { make in
+            make.width.equalTo(reordering ? 0 : Constants.favouriteButtonSize)
+        }
+        updateContentLeading(reordering: reordering)
+
         let closure = {
             self.disclosureIndicatorView.alpha = reordering ? 0.0 : 1.0
+            self.favouriteButton.alpha = reordering ? 0.0 : 1.0
+            self.contentView.layoutIfNeeded()
         }
 
         if animated {

--- a/novawallet/Modules/WalletsList/Manage/WalletManageViewController.swift
+++ b/novawallet/Modules/WalletsList/Manage/WalletManageViewController.swift
@@ -20,10 +20,15 @@ final class WalletManageViewController: WalletsListViewController<
     }
 
     override func setupLocalization() {
-        title = R.string(preferredLanguages: selectedLocale.rLanguages).localizable.profileWalletsTitle()
+        let languages = selectedLocale.rLanguages
+        title = R.string(preferredLanguages: languages).localizable.profileWalletsTitle()
+
+        rootView.searchTextField.placeholder = R.string(
+            preferredLanguages: languages
+        ).localizable.commonSearchWalletsPlaceholder()
 
         rootView.addWalletButton.imageWithTitleView?.title = R.string(
-            preferredLanguages: selectedLocale.rLanguages
+            preferredLanguages: languages
         ).localizable.walletAddButtonTitle()
 
         rootView.addWalletButton.invalidateLayout()
@@ -49,6 +54,11 @@ final class WalletManageViewController: WalletsListViewController<
 
     private func setupHandlers() {
         rootView.addWalletButton.addTarget(self, action: #selector(actionAddWallet), for: .touchUpInside)
+        rootView.searchTextField.addTarget(self, action: #selector(searchChanged), for: .editingChanged)
+    }
+
+    @objc private func searchChanged() {
+        presenter?.search(query: rootView.searchTextField.text ?? "")
     }
 
     @objc private func actionAddWallet() {
@@ -71,7 +81,15 @@ final class WalletManageViewController: WalletsListViewController<
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = super.tableView(tableView, cellForRowAt: indexPath)
 
-        (cell as? WalletManageTableViewCell<WalletView>)?.setReordering(tableView.isEditing, animated: false)
+        if let walletCell = cell as? WalletManageTableViewCell<WalletView> {
+            walletCell.setReordering(tableView.isEditing, animated: false)
+            walletCell.onFavouriteTapped = { [weak self, weak tableView, weak walletCell] in
+                guard let tableView = tableView,
+                      let walletCell = walletCell,
+                      let path = tableView.indexPath(for: walletCell) else { return }
+                self?.presenter?.toggleFavourite(at: path.row, section: path.section)
+            }
+        }
 
         return cell
     }

--- a/novawallet/Modules/WalletsList/Manage/WalletManageViewFactory.swift
+++ b/novawallet/Modules/WalletsList/Manage/WalletManageViewFactory.swift
@@ -66,11 +66,14 @@ final class WalletManageViewFactory {
             operationQueue: operationQueue
         )
 
+        let walletFavouriteRepository = WalletFavouriteRepository(repository: repository)
+
         return WalletManageInteractor(
             cloudBackupSyncService: CloudBackupSyncMediatorFacade.sharedMediator.syncService,
             balancesStore: balancesStore,
             walletListLocalSubscriptionFactory: WalletListLocalSubscriptionFactory.shared,
             walletUpdateMediator: walletUpdateMediator,
+            walletFavouriteRepository: walletFavouriteRepository,
             eventCenter: EventCenter.shared,
             operationQueue: OperationManagerFacade.sharedDefaultQueue,
             logger: Logger.shared

--- a/novawallet/Modules/WalletsList/Manage/WalletManageViewLayout.swift
+++ b/novawallet/Modules/WalletsList/Manage/WalletManageViewLayout.swift
@@ -1,6 +1,17 @@
 import UIKit
 
 class WalletManageViewLayout: WalletsListViewLayout {
+    let searchTextField: UITextField = {
+        let field = UITextField()
+        field.placeholder = R.string.localizable.commonSearchWalletsPlaceholder(preferredLanguages: [])
+        field.borderStyle = .roundedRect
+        field.clearButtonMode = .whileEditing
+        field.autocorrectionType = .no
+        field.autocapitalizationType = .none
+        field.returnKeyType = .search
+        return field
+    }()
+
     let addWalletButton: TriangularedButton = {
         let button = TriangularedButton()
         button.applyDefaultStyle()
@@ -24,7 +35,18 @@ class WalletManageViewLayout: WalletsListViewLayout {
     }()
 
     override func setupLayout() {
-        super.setupLayout()
+        addSubview(searchTextField)
+        searchTextField.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide.snp.top).offset(8)
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.height.equalTo(36)
+        }
+
+        addSubview(tableView)
+        tableView.snp.makeConstraints { make in
+            make.top.equalTo(searchTextField.snp.bottom).offset(8)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
 
         addSubview(addWalletButton)
         addWalletButton.snp.makeConstraints { make in

--- a/novawallet/Modules/WalletsList/Selection/WalletSelectionViewController.swift
+++ b/novawallet/Modules/WalletsList/Selection/WalletSelectionViewController.swift
@@ -15,6 +15,16 @@ final class WalletSelectionViewController: WalletsListViewController<
         setupSettingsItems()
 
         super.viewDidLoad()
+
+        rootView.searchTextField.addTarget(
+            self,
+            action: #selector(searchChanged),
+            for: .editingChanged
+        )
+    }
+
+    @objc private func searchChanged() {
+        presenter?.search(query: rootView.searchTextField.text ?? "")
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -24,7 +34,11 @@ final class WalletSelectionViewController: WalletsListViewController<
     }
 
     override func setupLocalization() {
-        title = R.string(preferredLanguages: selectedLocale.rLanguages).localizable.commonSelectWallet()
+        let languages = selectedLocale.rLanguages
+        title = R.string(preferredLanguages: languages).localizable.commonSelectWallet()
+        rootView.searchTextField.placeholder = R.string(
+            preferredLanguages: languages
+        ).localizable.commonSearchWalletsPlaceholder()
     }
 
     private func setupSettingsItems() {

--- a/novawallet/Modules/WalletsList/Selection/WalletSelectionViewLayout.swift
+++ b/novawallet/Modules/WalletsList/Selection/WalletSelectionViewLayout.swift
@@ -6,4 +6,30 @@ class WalletSelectionViewLayout: WalletsListViewLayout {
         button.image = R.image.iconSettings()
         return button
     }()
+
+    let searchTextField: UITextField = {
+        let field = UITextField()
+        field.placeholder = R.string.localizable.commonSearchWalletsPlaceholder(preferredLanguages: [])
+        field.borderStyle = .roundedRect
+        field.clearButtonMode = .whileEditing
+        field.autocorrectionType = .no
+        field.autocapitalizationType = .none
+        field.returnKeyType = .search
+        return field
+    }()
+
+    override func setupLayout() {
+        addSubview(searchTextField)
+        searchTextField.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide.snp.top).offset(8)
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.height.equalTo(36)
+        }
+
+        addSubview(tableView)
+        tableView.snp.makeConstraints { make in
+            make.top.equalTo(searchTextField.snp.bottom).offset(8)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
+    }
 }

--- a/novawallet/en.lproj/Localizable.strings
+++ b/novawallet/en.lproj/Localizable.strings
@@ -1852,9 +1852,14 @@
 "wallet.migrate.accept.message" = "You’re almost there! 🎉\n Just tap below to complete the setup and start using your accounts seamlessly in both the Polkadot App and Nova Wallet";
 "wallet.migration.successful.alert.title" = "Accounts migrated successfully";
 "swap.failure.cannot.receive.insufficient.asset.out" = "You must have at least %@ on %@ to receive %@ token";
+"common.favourites" = "Favourites";
 "common.multisig" = "Multisig";
 "common.proxied" = "Proxied";
+"common.proxy" = "Proxy";
+"common.search.results" = "Search results";
+"common.search.wallets.placeholder" = "Search wallets...";
 "common.signatory" = "Signatory";
+"common.wallets" = "Wallets";
 "multisig.details.hint" = "Transactions from this wallet require approval from multiple signatories. Your account is one of the signatories:";
 "multisig.signing.title" = "Multisig transaction";
 "multisig.signing.message" = "The multisig transaction will be initiated by %@. The initiator pays the network fee and reserves a multisig deposit, which will be unreserved once the transaction is executed.";

--- a/novawallet/es.lproj/Localizable.strings
+++ b/novawallet/es.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "Introduce al menos una dirección...";
 "asset.list.watch.only.balance" = "Saldo solo de visualización";
 "create.watch.only.subtitle" = "Sigue la actividad de la cartera sin una clave privada.\nNo podrás realizar ninguna transacción.";
+"common.favourites" = "Favoritos";
+"common.wallets" = "Billeteras";
+"common.search.results" = "Resultados de búsqueda";
+"common.search.wallets.placeholder" = "Buscar billeteras…";
+"common.proxy" = "Proxy";

--- a/novawallet/fr.lproj/Localizable.strings
+++ b/novawallet/fr.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "Entrez au moins une adresse...";
 "asset.list.watch.only.balance" = "Solde en consultation seulement";
 "create.watch.only.subtitle" = "Suivez l'activité du portefeuille sans clé privée.\nVous ne pourrez effectuer aucune transaction.";
+"common.favourites" = "Favoris";
+"common.wallets" = "Portefeuilles";
+"common.search.results" = "Résultats de recherche";
+"common.search.wallets.placeholder" = "Rechercher des portefeuilles…";
+"common.proxy" = "Proxy";

--- a/novawallet/hu.lproj/Localizable.strings
+++ b/novawallet/hu.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "Adjon meg legalább egy címet...";
 "asset.list.watch.only.balance" = "Csak-figyelési egyenleg";
 "create.watch.only.subtitle" = "Pénztárca aktivitás nyomon követése privát kulcs nélkül.\nNem lesz képes tranzakciók végrehajtására.";
+"common.favourites" = "Kedvencek";
+"common.wallets" = "Tárcák";
+"common.search.results" = "Találatok";
+"common.search.wallets.placeholder" = "Tárcák keresése…";
+"common.proxy" = "Proxy";

--- a/novawallet/id.lproj/Localizable.strings
+++ b/novawallet/id.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "Masukkan setidaknya satu alamat...";
 "asset.list.watch.only.balance" = "Saldo untuk dilihat saja";
 "create.watch.only.subtitle" = "Lacak aktivitas dompet tanpa kunci privat.\nAnda tidak akan dapat melakukan transaksi apapun.";
+"common.favourites" = "Favorit";
+"common.wallets" = "Dompet";
+"common.search.results" = "Hasil pencarian";
+"common.search.wallets.placeholder" = "Cari dompet…";
+"common.proxy" = "Proxy";

--- a/novawallet/it.lproj/Localizable.strings
+++ b/novawallet/it.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "Inserisci almeno un indirizzo...";
 "asset.list.watch.only.balance" = "Saldo solo visualizzazione";
 "create.watch.only.subtitle" = "Tieni traccia dell’attività del portafoglio senza una chiave privata.\nNon potrai eseguire alcuna transazione.";
+"common.favourites" = "Preferiti";
+"common.wallets" = "Portafogli";
+"common.search.results" = "Risultati di ricerca";
+"common.search.wallets.placeholder" = "Cerca portafogli…";
+"common.proxy" = "Proxy";

--- a/novawallet/ja.lproj/Localizable.strings
+++ b/novawallet/ja.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "少なくとも1つのアドレスを入力してください...";
 "asset.list.watch.only.balance" = "ウォッチオンリーバランス";
 "create.watch.only.subtitle" = "秘密鍵を使わずにウォレットのアクティビティを追跡することができます。\nトランザクションを実行することはできません。";
+"common.favourites" = "お気に入り";
+"common.wallets" = "ウォレット";
+"common.search.results" = "検索結果";
+"common.search.wallets.placeholder" = "ウォレットを検索…";
+"common.proxy" = "プロキシ";

--- a/novawallet/ko.lproj/Localizable.strings
+++ b/novawallet/ko.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "최소 하나의 주소를 입력하세요...";
 "asset.list.watch.only.balance" = "보기 전용 잔액";
 "create.watch.only.subtitle" = "비공개 키 없이 지갑 활동을 추적합니다.\n어떠한 거래도 수행할 수 없습니다.";
+"common.favourites" = "즐겨찾기";
+"common.wallets" = "지갑";
+"common.search.results" = "검색 결과";
+"common.search.wallets.placeholder" = "지갑 검색…";
+"common.proxy" = "프록시";

--- a/novawallet/pl.lproj/Localizable.strings
+++ b/novawallet/pl.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "Wprowadź co najmniej jeden adres...";
 "asset.list.watch.only.balance" = "Saldo tylko do obserwacji";
 "create.watch.only.subtitle" = "Śledź aktywność portfela bez klucza prywatnego.\nNie będziesz w stanie przeprowadzać żadnych transakcji.";
+"common.favourites" = "Ulubione";
+"common.wallets" = "Portfele";
+"common.search.results" = "Wyniki wyszukiwania";
+"common.search.wallets.placeholder" = "Szukaj portfeli…";
+"common.proxy" = "Proxy";

--- a/novawallet/pt-PT.lproj/Localizable.strings
+++ b/novawallet/pt-PT.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "Insira pelo menos um endereço...";
 "asset.list.watch.only.balance" = "Saldo somente de visualização";
 "create.watch.only.subtitle" = "Acompanhe a atividade da carteira sem uma chave privada.\nVocê não poderá realizar transações.";
+"common.favourites" = "Favoritos";
+"common.wallets" = "Carteiras";
+"common.search.results" = "Resultados da pesquisa";
+"common.search.wallets.placeholder" = "Pesquisar carteiras…";
+"common.proxy" = "Proxy";

--- a/novawallet/ru.lproj/Localizable.strings
+++ b/novawallet/ru.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "Введите хотя бы один адрес...";
 "asset.list.watch.only.balance" = "Только просмотр баланса";
 "create.watch.only.subtitle" = "Отслеживание активности кошелька без приватного ключа.\nВы не сможете выполнить никакие транзакции.";
+"common.favourites" = "Избранное";
+"common.wallets" = "Кошельки";
+"common.search.results" = "Результаты поиска";
+"common.search.wallets.placeholder" = "Поиск кошельков…";
+"common.proxy" = "Прокси";

--- a/novawallet/tr.lproj/Localizable.strings
+++ b/novawallet/tr.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "En az bir adres girin...";
 "asset.list.watch.only.balance" = "Sadece-izleme bakiyesi";
 "create.watch.only.subtitle" = "Cüzdan aktivitesini özel anahtar olmadan izleyin.\nHerhangi bir işlem gerçekleştiremezsiniz.";
+"common.favourites" = "Favoriler";
+"common.wallets" = "Cüzdanlar";
+"common.search.results" = "Arama sonuçları";
+"common.search.wallets.placeholder" = "Cüzdan ara…";
+"common.proxy" = "Proxy";

--- a/novawallet/vi.lproj/Localizable.strings
+++ b/novawallet/vi.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "Nhập ít nhất một địa chỉ...";
 "asset.list.watch.only.balance" = "Số dư chỉ theo dõi";
 "create.watch.only.subtitle" = "Theo dõi hoạt động ví mà không cần khóa riêng.\nBạn sẽ không thể thực hiện bất kỳ giao dịch nào.";
+"common.favourites" = "Yêu thích";
+"common.wallets" = "Ví";
+"common.search.results" = "Kết quả tìm kiếm";
+"common.search.wallets.placeholder" = "Tìm kiếm ví…";
+"common.proxy" = "Proxy";

--- a/novawallet/zh-Hans.lproj/Localizable.strings
+++ b/novawallet/zh-Hans.lproj/Localizable.strings
@@ -2035,3 +2035,8 @@
 "create.watch.only.missing.any.address" = "请输入至少一个地址...";
 "asset.list.watch.only.balance" = "仅观察余额";
 "create.watch.only.subtitle" = "在没有私钥的情况下跟踪钱包活动。\n您将无法执行任何交易。";
+"common.favourites" = "收藏";
+"common.wallets" = "钱包";
+"common.search.results" = "搜索结果";
+"common.search.wallets.placeholder" = "搜索钱包…";
+"common.proxy" = "代理";

--- a/novawalletTests/Common/Migration/StorageLocationMigrationTests.swift
+++ b/novawalletTests/Common/Migration/StorageLocationMigrationTests.swift
@@ -22,6 +22,62 @@ final class StorageLocationMigrationTests: XCTestCase {
         sharedDatabaseDirectory.appendingPathComponent(databaseName)
     }
 
+    func testIsFavouriteDefaultsToFalseAfterV20ToV21Migration() {
+        do {
+            let oldSettings = CoreDataPersistentSettings(
+                databaseDirectory: deprecatedDatabaseDirectory,
+                databaseName: databaseName,
+                incompatibleModelStrategy: .ignore
+            )
+
+            let newSettings = CoreDataPersistentSettings(
+                databaseDirectory: sharedDatabaseDirectory,
+                databaseName: databaseName,
+                incompatibleModelStrategy: .ignore
+            )
+
+            let walletsCount = 3
+            let expectedMetaIds = try createOldEntities(
+                for: walletsCount,
+                version: .version21,
+                persistentSettings: oldSettings
+            )
+
+            let migrator = createMigrator()
+            try migrator.migrate()
+
+            let dbService = createCoreDataService(
+                for: .version22,
+                persistentSettings: newSettings
+            )
+            let semaphore = DispatchSemaphore(value: 0)
+            var favourites: [Bool] = []
+            var fetchedIds = Set<MetaAccountModel.Id>()
+
+            dbService.performAsync { context, _ in
+                defer { semaphore.signal() }
+                let request = NSFetchRequest<NSManagedObject>(entityName: "CDMetaAccount")
+                let results = try! context?.fetch(request)
+                results?.forEach { entity in
+                    if let metaId = entity.value(forKey: "metaId") as? MetaAccountModel.Id {
+                        fetchedIds.insert(metaId)
+                    }
+                    if let isFav = entity.value(forKey: "isFavourite") as? Bool {
+                        favourites.append(isFav)
+                    }
+                }
+            }
+            semaphore.wait()
+            try dbService.close()
+
+            XCTAssertEqual(fetchedIds, expectedMetaIds)
+            XCTAssertEqual(favourites.count, walletsCount)
+            XCTAssertTrue(favourites.allSatisfy { $0 == false })
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
     func testMigrationFromSingleAppToGroup() {
         do {
             let oldSettings = CoreDataPersistentSettings(


### PR DESCRIPTION
Introduces a per-wallet isFavourite flag so users can pin wallets to a Favourites section at the top of the wallet selection screen, plus a search bar that filters wallets by name, address, chain name, and proxy type. The favourite state is toggled via a star button on the wallet management screen.

- CoreData user store migrated from v20 to v21 to add the isFavourite column on ManagedMetaAccount
- New WalletFavouriteRepository writes the flag directly to the local store, bypassing the cloud-backup pipeline since favourites are a device-local preference
- WalletsListViewModelFactory groups favourites into a dedicated section and applies the search predicate across wallet metadata and resolved chain accounts
- Wallet management screen gains a star toggle cell accessory
- Localizable.strings updated for all 13 supported locales