### PR TITLE
Add mandatory consent banner for wallet creation and existing-user upgrade

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		0B2B9C6E2BA2E924D6A54F4B /* CrowdloanListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E78D69E8EBC3EB4D01F8EF /* CrowdloanListInteractor.swift */; };
 		0B48B02E973CB304B765BBC9 /* ReferendumDetailsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ABAD23C0039AFA8351C650 /* ReferendumDetailsProtocols.swift */; };
 		0B65DAE0327678679CACE0B1 /* GovernanceDelegateInfoViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E894D4633D04AD4415CE1F2 /* GovernanceDelegateInfoViewFactory.swift */; };
+		0BA43B89F0D693D262B4570F /* ConsentBannerUpgradeViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB7161EBADDA0B25DC33F63 /* ConsentBannerUpgradeViewLayout.swift */; };
 		0BB2E3FF30B1700D321C526A /* TransferNetworkSelectionViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA463769D0F411429780D7D /* TransferNetworkSelectionViewFactory.swift */; };
 		0C028E6E2DC910520060A0E8 /* RampPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C028E572DC910520060A0E8 /* RampPresenter.swift */; };
 		0C028E6F2DC910520060A0E8 /* MercuryoOffRampResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C028E412DC910520060A0E8 /* MercuryoOffRampResponseHandler.swift */; };
@@ -1602,6 +1603,7 @@
 		2C494C6A25DF77F8ADB9BC69 /* DelegatedSignValidationProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D7C74EC42DCCF9F2D4EA4E /* DelegatedSignValidationProtocols.swift */; };
 		2C9A416905C692DCFA74A0D6 /* DAppListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750C8C7940C944DA4C8CB95F /* DAppListInteractor.swift */; };
 		2CB0411DAB3CE25911B6B64A /* BackupMnemonicCardInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3946892F9E6BC45259B0833 /* BackupMnemonicCardInteractor.swift */; };
+		2CC026B99BFEA27AD56360D3 /* ConsentBannerUpgradePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0519016CBEE943039181A9E /* ConsentBannerUpgradePresenter.swift */; };
 		2CEFF4C2574F0AABE0E9BF89 /* BaseReferendumVoteSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A058D4A585F253CBF2968D /* BaseReferendumVoteSetupViewController.swift */; };
 		2D00796C020EF6B890BC307C /* MythosStakingSetupWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20F07FA0A20885454D9C001 /* MythosStakingSetupWireframe.swift */; };
 		2D008A612CC11E4600BFEE99 /* AssetListCustomLayoutAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D008A602CC11E4600BFEE99 /* AssetListCustomLayoutAttributes.swift */; };
@@ -2901,6 +2903,7 @@
 		63185C6D67EAEB2867069AB9 /* ParitySignerWelcomeProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CBB8745F8C36BB107625E8F /* ParitySignerWelcomeProtocols.swift */; };
 		6362476898582D2118E96447 /* StakingProxyManagementInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211CEE2D931F177676D280DC /* StakingProxyManagementInteractor.swift */; };
 		63C96BADE7BF632D81AFB565 /* MythosStkClaimRewardsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1764F0D73F5D0564BA7C30 /* MythosStkClaimRewardsInteractor.swift */; };
+		6405BC650A2D0CF8FB63ACD2 /* ConsentBannerUpgradeViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 868F31D37DDAEDEBE3E48EE6 /* ConsentBannerUpgradeViewFactory.swift */; };
 		640A79BD1335394818E70366 /* WalletHistoryFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6884DFC1AA1B995C21C274C /* WalletHistoryFilterViewController.swift */; };
 		640EC907607A3D5F633D26A7 /* NotificationsManagementInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE878F83551D3FD5FF2E21CC /* NotificationsManagementInteractor.swift */; };
 		641D7CF89F37B1890516015E /* ParitySignerTxScanProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F10F130391C4B3652FE8F59 /* ParitySignerTxScanProtocols.swift */; };
@@ -5799,6 +5802,7 @@
 		8A19EC93E6A6972327116D80 /* ParaStkStakeConfirmProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1139FB38E7D8D25A36726089 /* ParaStkStakeConfirmProtocols.swift */; };
 		8A23DD1F4146639EA2F7AEF6 /* LocksViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B81B239BD9C150BFE9A82B0 /* LocksViewFactory.swift */; };
 		8A2486E62C3915CB6D1FDED8 /* DelegationReferendumVotersInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A813E09FA3047357C7A75564 /* DelegationReferendumVotersInteractor.swift */; };
+		8A938D22DBA781077E8BDCF0 /* ConsentBannerUpgradeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FD71F759CAB48F910DD11C /* ConsentBannerUpgradeProtocol.swift */; };
 		8AEF593AFE8F59F7DC0A5753 /* CustomValidatorListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 365CAE2753E7D5F9B9DB7D1F /* CustomValidatorListInteractor.swift */; };
 		8B53466F5239B852F20F0C4E /* AssetOperationNetworkListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891FBCE49A51A9120ED9F861 /* AssetOperationNetworkListViewController.swift */; };
 		8BB2AB5B4E97FAE0D27A4B60 /* SwapExecutionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501E16B2A68FEAEC039E8604 /* SwapExecutionViewLayout.swift */; };
@@ -5828,9 +5832,11 @@
 		91530F7301CA39654E008580 /* DAppBrowserInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A4DFCC4236D25A3D59F809 /* DAppBrowserInteractor.swift */; };
 		916E7A1B6B0CADBD5AB56353 /* DAppFavoritesWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7E51DA2F76E0AE3690B5C2 /* DAppFavoritesWireframe.swift */; };
 		91A1286763617DE022BD495F /* LedgerInstructionsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B08ACC71BE679A48A7B66E /* LedgerInstructionsPresenter.swift */; };
+		91AFA48D7499A27039AA5C9D /* ConsentBannerUpgradeWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8D60F776C70156F271C7D3 /* ConsentBannerUpgradeWireframe.swift */; };
 		91E4653DFEDBE6605E241144 /* NotificationsSetupViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7300E64DC3C8B3FD476A1D1 /* NotificationsSetupViewLayout.swift */; };
 		920007949A0004A5D91C3F96 /* CloudBackupAddWalletWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703B7D980A748F1B9F51611D /* CloudBackupAddWalletWireframe.swift */; };
 		9202CBF07DA49C807A8687FA /* CloudBackupAddWalletViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA49EE64DC450755353E482 /* CloudBackupAddWalletViewFactory.swift */; };
+		924A282CE7398070C675A9C2 /* ConsentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C9B69DB685745E1F7596E3 /* ConsentService.swift */; };
 		924BADB89E7FA2DC54BF1A02 /* NPoolsClaimRewardsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F1F933F624B01855AA3BA5 /* NPoolsClaimRewardsInteractor.swift */; };
 		92984DFE797C52644C084377 /* SwapSetupProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53775773F2060B4B7F6D62DA /* SwapSetupProtocols.swift */; };
 		92B880FEDD0AE45A36898308 /* PayCardViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731F3692859677E2B67AE629 /* PayCardViewFactory.swift */; };
@@ -6092,6 +6098,7 @@
 		B1A789A7E8D60223F18AA407 /* StakingSetupProxyPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B882BFEED7C8CB1EA5A853D /* StakingSetupProxyPresenter.swift */; };
 		B1BB78684B059A113AB3AD30 /* DAppPhishingViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AE1C39767C4CBE3229089D /* DAppPhishingViewFactory.swift */; };
 		B1CCC5B7BF30F6ACA309B112 /* StakingRedeemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7F5F9B54BE4234C5682BDE /* StakingRedeemViewController.swift */; };
+		B1E28902A557946C55C0B9ED /* ConsentBannerConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843A79EE58190665ED2B8448 /* ConsentBannerConstants.swift */; };
 		B1F2C2241D9020687D469A27 /* WalletConnectSessionsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82445792D5EF0120B5233767 /* WalletConnectSessionsPresenter.swift */; };
 		B1F86CA723BB4D69C5EF989D /* ParaStkStakeSetupProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D8246CDA02F544AF9DA2B11 /* ParaStkStakeSetupProtocols.swift */; };
 		B250372B290223A660169E10 /* DAppBrowserWidgetViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C57B5C83F5A27949AAE9A87 /* DAppBrowserWidgetViewLayout.swift */; };
@@ -6323,6 +6330,7 @@
 		DD5B5692C208F627E2597D31 /* SwipeGovVotingConfirmPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25666B9BBEA7F5086B37BE5A /* SwipeGovVotingConfirmPresenter.swift */; };
 		DD7554F36497B3CFA4D4E6AA /* CloudBackupCreateViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD26E02E5EA85D22062142CD /* CloudBackupCreateViewFactory.swift */; };
 		DDA07514BEF3E2FD6EE1BB4E /* InAppUpdatesViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06268C2A9EAC65722D6E8947 /* InAppUpdatesViewLayout.swift */; };
+		DE035D3DCF8D9CC601910B67 /* ConsentBannerUpgradeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4581189043C1A02944A1079E /* ConsentBannerUpgradeViewController.swift */; };
 		DE03CA5AD7F1D0B80DFF13B6 /* DAppBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1855972C88E512AED37FD312 /* DAppBrowserViewController.swift */; };
 		DE52F23521D54A07F558EB1B /* ReferendumVoteConfirmInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1A35F4D82F97C9663F1CD4 /* ReferendumVoteConfirmInteractor.swift */; };
 		DEA5D2AB0D4CAEFE26327996 /* TokensManageAddPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5696D203FE1D56D20BA4DA52 /* TokensManageAddPresenter.swift */; };
@@ -6653,6 +6661,7 @@
 		09E4E9A052F9F04A92F158D6 /* GovernanceDelegateSetupWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceDelegateSetupWireframe.swift; sourceTree = "<group>"; };
 		0A32FFD76AF24DFF3AE7F09B /* NotificationsManagementWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationsManagementWireframe.swift; sourceTree = "<group>"; };
 		0A42FD5E0D98EFE83883EC56 /* AssetDetailsViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetDetailsViewFactory.swift; sourceTree = "<group>"; };
+		0A8D60F776C70156F271C7D3 /* ConsentBannerUpgradeWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentBannerUpgradeWireframe.swift; sourceTree = "<group>"; };
 		0AB10C8DA56E92C280D66BE8 /* WalletHistoryFilterViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletHistoryFilterViewFactory.swift; sourceTree = "<group>"; };
 		0AC34A44F63EFAE6E804BDE9 /* WalletConnectSessionsViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletConnectSessionsViewFactory.swift; sourceTree = "<group>"; };
 		0B5072E250B7277F605855B3 /* AccountManagementProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountManagementProtocols.swift; sourceTree = "<group>"; };
@@ -9100,6 +9109,7 @@
 		44AA632DE49B746BC38B959F /* NominationPoolSearchInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NominationPoolSearchInteractor.swift; sourceTree = "<group>"; };
 		44EAF50AAF6C23225E06C16C /* AssetsSearchInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetsSearchInteractor.swift; sourceTree = "<group>"; };
 		45299DA08B8E5C2D5A5BB94B /* CustomNetworkWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomNetworkWireframe.swift; sourceTree = "<group>"; };
+		4581189043C1A02944A1079E /* ConsentBannerUpgradeViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentBannerUpgradeViewController.swift; sourceTree = "<group>"; };
 		45C0B1C175A2470AAA50DAC5 /* DAppSettingsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppSettingsViewController.swift; sourceTree = "<group>"; };
 		461A9E7672D247C9CCF0B45D /* GovernanceRevokeDelegationTracksWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceRevokeDelegationTracksWireframe.swift; sourceTree = "<group>"; };
 		461B7FAD84690F82070E4431 /* StakingRebagConfirmPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingRebagConfirmPresenter.swift; sourceTree = "<group>"; };
@@ -9206,6 +9216,7 @@
 		5B882BFEED7C8CB1EA5A853D /* StakingSetupProxyPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingSetupProxyPresenter.swift; sourceTree = "<group>"; };
 		5B8B0940B2CB25AD9C36206E /* SelectValidatorsConfirmViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SelectValidatorsConfirmViewController.swift; sourceTree = "<group>"; };
 		5BA3C305F49A4E609C7A5C14 /* GovernanceDelegateConfirmViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceDelegateConfirmViewController.swift; sourceTree = "<group>"; };
+		5BB7161EBADDA0B25DC33F63 /* ConsentBannerUpgradeViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentBannerUpgradeViewLayout.swift; sourceTree = "<group>"; };
 		5BC9AC96424DB8AB8038ED59 /* WalletConnectPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletConnectPresenter.swift; sourceTree = "<group>"; };
 		5BCDAB970C17F9798AC79B08 /* DAppTxDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppTxDetailsViewController.swift; sourceTree = "<group>"; };
 		5BD404C38853563206BB2694 /* MythosStkYourCollatorsInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MythosStkYourCollatorsInteractor.swift; sourceTree = "<group>"; };
@@ -10148,6 +10159,7 @@
 		843A2C7026A85B5B00266F53 /* GenericTitleValueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericTitleValueView.swift; sourceTree = "<group>"; };
 		843A2C7226A8641400266F53 /* MultiValueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiValueView.swift; sourceTree = "<group>"; };
 		843A2C7626A86FD000266F53 /* TitleStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleStatusView.swift; sourceTree = "<group>"; };
+		843A79EE58190665ED2B8448 /* ConsentBannerConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentBannerConstants.swift; sourceTree = "<group>"; };
 		843ADAC22A3C30A1003AE2B5 /* Decimal+Fiat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Fiat.swift"; sourceTree = "<group>"; };
 		843B1D79263EED5C00AF8957 /* StakingUnbondConfirmLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingUnbondConfirmLayout.swift; sourceTree = "<group>"; };
 		843B6F4E28EEEF610086D4E0 /* Gov2OperationFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gov2OperationFactoryTests.swift; sourceTree = "<group>"; };
@@ -11792,6 +11804,7 @@
 		8602E65CC4E81A7BE1727CE3 /* VotesViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VotesViewLayout.swift; sourceTree = "<group>"; };
 		862545D6BD501914AE04D776 /* NPoolsRedeemViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NPoolsRedeemViewController.swift; sourceTree = "<group>"; };
 		8632A6D9689942DE89F174FA /* SwapExecutionInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwapExecutionInteractor.swift; sourceTree = "<group>"; };
+		868F31D37DDAEDEBE3E48EE6 /* ConsentBannerUpgradeViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentBannerUpgradeViewFactory.swift; sourceTree = "<group>"; };
 		86DCB6F3977BDE1BDC7BC3F9 /* ParaStkUnstakeConfirmPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParaStkUnstakeConfirmPresenter.swift; sourceTree = "<group>"; };
 		86F7A369E31DCB9ABD556EE9 /* CrowdloanListPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CrowdloanListPresenter.swift; sourceTree = "<group>"; };
 		86F7ACFB151C31B3A5044DCD /* StakingSelectPoolInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingSelectPoolInteractor.swift; sourceTree = "<group>"; };
@@ -12403,6 +12416,7 @@
 		B03974ECD8AEF39FDCA277D7 /* LedgerNetworkSelectionViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LedgerNetworkSelectionViewFactory.swift; sourceTree = "<group>"; };
 		B08478AD9E9AF78370BC7E87 /* AssetPriceChartViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetPriceChartViewLayout.swift; sourceTree = "<group>"; };
 		B0B2C32E11E2F7F3D4A1D3AB /* ParaStkStakeSetupWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParaStkStakeSetupWireframe.swift; sourceTree = "<group>"; };
+		B0FD71F759CAB48F910DD11C /* ConsentBannerUpgradeProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentBannerUpgradeProtocol.swift; sourceTree = "<group>"; };
 		B14339E7BE9FE045C6A2AB52 /* WalletConnectSessionDetailsInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletConnectSessionDetailsInteractor.swift; sourceTree = "<group>"; };
 		B14E9691A7628B66958F8744 /* LedgerInstructionsProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LedgerInstructionsProtocols.swift; sourceTree = "<group>"; };
 		B179EA3EF793684717BA9D68 /* ReferendumSearchViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumSearchViewFactory.swift; sourceTree = "<group>"; };
@@ -12606,6 +12620,7 @@
 		D8A5632D4768BC5039EE8276 /* TokensManageAddViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokensManageAddViewLayout.swift; sourceTree = "<group>"; };
 		D8A759A20A4A39B3B0E2A735 /* DAppAddFavoriteViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppAddFavoriteViewLayout.swift; sourceTree = "<group>"; };
 		D8C4C48E50DC14085258AB6D /* NftDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NftDetailsViewController.swift; sourceTree = "<group>"; };
+		D8C9B69DB685745E1F7596E3 /* ConsentService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentService.swift; sourceTree = "<group>"; };
 		D8DE2583C0D36ECDB0F012EB /* AssetPriceChartInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetPriceChartInteractor.swift; sourceTree = "<group>"; };
 		D927D2CCA2C24FE116D7CE5C /* StakingSetupProxyViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingSetupProxyViewController.swift; sourceTree = "<group>"; };
 		D99E687F7D5A3862643BF533 /* WalletMigrateAcceptViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletMigrateAcceptViewLayout.swift; sourceTree = "<group>"; };
@@ -12640,6 +12655,7 @@
 		DF715CEF29477B59119520F1 /* PVAddressesInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PVAddressesInteractor.swift; sourceTree = "<group>"; };
 		DFC561E5FF0A0CBF93038316 /* GiftPrepareShareViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiftPrepareShareViewController.swift; sourceTree = "<group>"; };
 		DFF58EC3A44E4DDDFB4B5C84 /* ParaStkYieldBoostStopViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParaStkYieldBoostStopViewLayout.swift; sourceTree = "<group>"; };
+		E0519016CBEE943039181A9E /* ConsentBannerUpgradePresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentBannerUpgradePresenter.swift; sourceTree = "<group>"; };
 		E0B67F8F7D79D9546B1B92FA /* SwipeGovVotingConfirmViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwipeGovVotingConfirmViewFactory.swift; sourceTree = "<group>"; };
 		E0D139E39F5ECE929FF724B8 /* SwapExecutionViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwapExecutionViewController.swift; sourceTree = "<group>"; };
 		E0DB5EA5195D9433A4B90793 /* AdvancedWalletWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AdvancedWalletWireframe.swift; sourceTree = "<group>"; };
@@ -21174,6 +21190,7 @@
 				0C85FF2B2B6D23D600FC0014 /* ObservableSubscriptionSyncState.swift */,
 				0C0F6DC32D3FEDC800943A7C /* BaseObservableStateStore.swift */,
 				0CE862142D64B61C00245992 /* ObservableSubscriptionStateStore.swift */,
+				D81F12CD0A3F05E75441426A /* ConsentBanner */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -24011,6 +24028,7 @@
 				0274F684DCFA6D2AFEA43CF5 /* AssetPriceChart */,
 				028384EC1D6B48710C2236A2 /* UnifiedAddressPopup */,
 				F969E89D4A7D83173147E818 /* AHMInfo */,
+				F4A22DA253BA8FF561EF005C /* ConsentBannerUpgrade */,
 			);
 			path = Modules;
 			sourceTree = "<group>";
@@ -29457,6 +29475,16 @@
 			path = MythosStakingConfirm;
 			sourceTree = "<group>";
 		};
+		D81F12CD0A3F05E75441426A /* ConsentBanner */ = {
+			isa = PBXGroup;
+			children = (
+				D8C9B69DB685745E1F7596E3 /* ConsentService.swift */,
+				843A79EE58190665ED2B8448 /* ConsentBannerConstants.swift */,
+			);
+			name = ConsentBanner;
+			path = ConsentBanner;
+			sourceTree = "<group>";
+		};
 		D9BFD42DC43BEF657BE541DC /* NftDetails */ = {
 			isa = PBXGroup;
 			children = (
@@ -29988,6 +30016,20 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		F4A22DA253BA8FF561EF005C /* ConsentBannerUpgrade */ = {
+			isa = PBXGroup;
+			children = (
+				B0FD71F759CAB48F910DD11C /* ConsentBannerUpgradeProtocol.swift */,
+				5BB7161EBADDA0B25DC33F63 /* ConsentBannerUpgradeViewLayout.swift */,
+				4581189043C1A02944A1079E /* ConsentBannerUpgradeViewController.swift */,
+				E0519016CBEE943039181A9E /* ConsentBannerUpgradePresenter.swift */,
+				0A8D60F776C70156F271C7D3 /* ConsentBannerUpgradeWireframe.swift */,
+				868F31D37DDAEDEBE3E48EE6 /* ConsentBannerUpgradeViewFactory.swift */,
+			);
+			name = ConsentBannerUpgrade;
+			path = ConsentBannerUpgrade;
+			sourceTree = "<group>";
+		};
 		F4B06BFE26451AD2003214D5 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -30341,7 +30383,7 @@
 				0C8FCEA02E672BB000034ED3 /* XCRemoteSwiftPackageReference "UIKit-iOS" */,
 				0C8FCEA62E672BFB00034ED3 /* XCRemoteSwiftPackageReference "Foundation-iOS" */,
 				0C8FCEA92E672C5500034ED3 /* XCRemoteSwiftPackageReference "SwiftyBeaver" */,
-				0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability" */,
+				0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability.swift" */,
 				0C8FCEAF2E672CFA00034ED3 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				0C8FCEB22E672D3900034ED3 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				0C8FCEB52E672D8100034ED3 /* XCRemoteSwiftPackageReference "SwiftDraw" */,
@@ -30353,7 +30395,7 @@
 				0C8FCEC72E6734E900034ED3 /* XCRemoteSwiftPackageReference "ZMarkupParser" */,
 				0C8FCECA2E6735F300034ED3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				0C8FCED32E67363000034ED3 /* XCRemoteSwiftPackageReference "metadata-shortener-ios" */,
-				0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */,
+				0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */,
 				0CF8F68E2E673E73007E41C4 /* XCRemoteSwiftPackageReference "Cuckoo" */,
 				0C32522B2E67477700E322DB /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */,
 				0C2BAA1B2E677B6E008157E7 /* XCRemoteSwiftPackageReference "web3swift" */,
@@ -36845,6 +36887,14 @@
 				33096BCF84A6ABA8416678FF /* CrowdloanUnlockViewController.swift in Sources */,
 				F170C0900DB942030B2107C7 /* CrowdloanUnlockViewLayout.swift in Sources */,
 				6B19F3A772108FBED12A7260 /* CrowdloanUnlockViewFactory.swift in Sources */,
+				924A282CE7398070C675A9C2 /* ConsentService.swift in Sources */,
+				B1E28902A557946C55C0B9ED /* ConsentBannerConstants.swift in Sources */,
+				8A938D22DBA781077E8BDCF0 /* ConsentBannerUpgradeProtocol.swift in Sources */,
+				0BA43B89F0D693D262B4570F /* ConsentBannerUpgradeViewLayout.swift in Sources */,
+				DE035D3DCF8D9CC601910B67 /* ConsentBannerUpgradeViewController.swift in Sources */,
+				2CC026B99BFEA27AD56360D3 /* ConsentBannerUpgradePresenter.swift in Sources */,
+				91AFA48D7499A27039AA5C9D /* ConsentBannerUpgradeWireframe.swift in Sources */,
+				6405BC650A2D0CF8FB63ACD2 /* ConsentBannerUpgradeViewFactory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -37035,15 +37085,15 @@
 /* Begin PBXTargetDependency section */
 		0C1995CB2E6B2DE600E0B909 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 0C1995CA2E6B2DE600E0B909 /* RswiftGenerateInternalResources */;
+			productRef = 0C1995CA2E6B2DE600E0B909 /* plugin:RswiftGenerateInternalResources */;
 		};
 		0C1A0F502E69C04E00254E20 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 0C1A0F4F2E69C04E00254E20 /* CuckooPluginSingleFile */;
+			productRef = 0C1A0F4F2E69C04E00254E20 /* plugin:CuckooPluginSingleFile */;
 		};
 		0C6A9E2D2E6B1FC40088C2BA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 0C6A9E2C2E6B1FC40088C2BA /* RswiftGenerateInternalResources */;
+			productRef = 0C6A9E2C2E6B1FC40088C2BA /* plugin:RswiftGenerateInternalResources */;
 		};
 		77CAF4352B8E96A400E4297C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -38037,7 +38087,7 @@
 				version = 2.1.1;
 			};
 		};
-		0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability" */ = {
+		0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ashleymills/Reachability.swift";
 			requirement = {
@@ -38133,7 +38183,7 @@
 				version = 0.2.1;
 			};
 		};
-		0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */ = {
+		0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mac-cain13/R.swift";
 			requirement = {
@@ -38192,24 +38242,24 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0C1995CA2E6B2DE600E0B909 /* RswiftGenerateInternalResources */ = {
+		0C1995CA2E6B2DE600E0B909 /* plugin:RswiftGenerateInternalResources */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = "plugin:RswiftGenerateInternalResources";
 		};
 		0C1A0F472E68E01C00254E20 /* RswiftLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = RswiftLibrary;
 		};
-		0C1A0F4F2E69C04E00254E20 /* CuckooPluginSingleFile */ = {
+		0C1A0F4F2E69C04E00254E20 /* plugin:CuckooPluginSingleFile */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0CF8F68E2E673E73007E41C4 /* XCRemoteSwiftPackageReference "Cuckoo" */;
 			productName = "plugin:CuckooPluginSingleFile";
 		};
 		0C1A0F562E69EC5C00254E20 /* RswiftLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = RswiftLibrary;
 		};
 		0C2BAA1C2E677B6E008157E7 /* web3swift */ = {
@@ -38224,7 +38274,7 @@
 		};
 		0C2BAA332E67841C008157E7 /* RswiftLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = RswiftLibrary;
 		};
 		0C2BAA552E687BD0008157E7 /* HydraMathApi */ = {
@@ -38262,9 +38312,9 @@
 			package = 0C8FCE972E6725D700034ED3 /* XCRemoteSwiftPackageReference "web3swift" */;
 			productName = web3swift;
 		};
-		0C6A9E2C2E6B1FC40088C2BA /* RswiftGenerateInternalResources */ = {
+		0C6A9E2C2E6B1FC40088C2BA /* plugin:RswiftGenerateInternalResources */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = "plugin:RswiftGenerateInternalResources";
 		};
 		0C8FCE752E65ED3400034ED3 /* DGCharts */ = {
@@ -38309,7 +38359,7 @@
 		};
 		0C8FCEAD2E672CB000034ED3 /* Reachability */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability" */;
+			package = 0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability.swift" */;
 			productName = Reachability;
 		};
 		0C8FCEB02E672CFA00034ED3 /* SnapKit */ = {

--- a/novawallet/Common/Services/ConsentBanner/ConsentBannerConstants.swift
+++ b/novawallet/Common/Services/ConsentBanner/ConsentBannerConstants.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Static configuration for the mandatory ToS / Privacy Notice consent banner
+/// required by Aurum (Nova's legal counsel) on every wallet creation / import flow.
+///
+/// The hosted novasama.io URLs depend on rollout action items C-01 / C-02 and are not
+/// yet live. Until they are, the placeholders below are intentionally invalid so that
+/// any accidental release before the URLs land will be immediately visible.
+enum ConsentBannerConstants {
+    /// Bump this when a new ToS / Privacy Notice revision ships and existing acceptances
+    /// must be re-collected. The persisted `consentAcceptedVersion` is compared against
+    /// this value to decide whether the user has accepted the current revision.
+    static let currentConsentVersion: Int = 1
+
+    /// Placeholder until rollout action item C-01 lands the canonical novasama.io page.
+    /// MUST be replaced before merging to the upstream develop branch.
+    static let termsOfServiceURL = URL(string: "https://novasama.io/TODO_CONSENT_URL_TERMS")!
+
+    /// Placeholder until rollout action item C-02 lands the canonical novasama.io page.
+    /// MUST be replaced before merging to the upstream develop branch.
+    static let privacyNoticeURL = URL(string: "https://novasama.io/TODO_CONSENT_URL_PRIVACY")!
+}

--- a/novawallet/Common/Services/ConsentBanner/ConsentService.swift
+++ b/novawallet/Common/Services/ConsentBanner/ConsentService.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Keystore_iOS
+
+protocol ConsentServiceProtocol {
+    var currentConsentVersion: Int { get }
+    var acceptedConsentVersion: Int? { get }
+    var hasAcceptedCurrentVersion: Bool { get }
+
+    func acceptCurrentConsent()
+}
+
+final class ConsentService: ConsentServiceProtocol {
+    private enum Keys {
+        static let acceptedVersion = "consentAcceptedVersion"
+    }
+
+    let currentConsentVersion: Int
+
+    private let settingsManager: SettingsManagerProtocol
+
+    init(
+        settingsManager: SettingsManagerProtocol = SettingsManager.shared,
+        currentConsentVersion: Int = ConsentBannerConstants.currentConsentVersion
+    ) {
+        self.settingsManager = settingsManager
+        self.currentConsentVersion = currentConsentVersion
+    }
+
+    var acceptedConsentVersion: Int? {
+        settingsManager.integer(for: Keys.acceptedVersion)
+    }
+
+    var hasAcceptedCurrentVersion: Bool {
+        guard let accepted = acceptedConsentVersion else {
+            return false
+        }
+
+        return accepted >= currentConsentVersion
+    }
+
+    func acceptCurrentConsent() {
+        settingsManager.set(value: currentConsentVersion, for: Keys.acceptedVersion)
+    }
+}

--- a/novawallet/Common/ViewModel/AttributedStringDecorator+Terms.swift
+++ b/novawallet/Common/ViewModel/AttributedStringDecorator+Terms.swift
@@ -29,4 +29,37 @@ extension CompoundAttributedStringDecorator {
 
         return CompoundAttributedStringDecorator(decorators: [rangeDecorator, replacementDecorator])
     }
+
+    /// Decorator for the mandatory consent banner on wallet creation/import flows.
+    /// Uses dedicated strings ("Terms of Service" / "Privacy Notice") per Aurum's
+    /// verbatim wording requirement. Underlined link spans match the standard
+    /// hyperlink visual treatment required by the lawyer.
+    static func consentBanner(for locale: Locale?, marker: String) -> AttributedStringDecoratorProtocol {
+        let bodyAttributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: R.color.colorTextSecondary()!,
+            .font: UIFont.regularFootnote
+        ]
+
+        let rangeDecorator = RangeAttributedStringDecorator(attributes: bodyAttributes)
+
+        let linkAttributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: R.color.colorTextPrimary()!,
+            .font: UIFont.regularFootnote,
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
+
+        let termsOfService = R.string(preferredLanguages: locale.rLanguages).localizable
+            .consentBannerTermsOfService()
+
+        let privacyNotice = R.string(preferredLanguages: locale.rLanguages).localizable
+            .consentBannerPrivacyNotice()
+
+        let replacementDecorator = AttributedReplacementStringDecorator(
+            pattern: marker,
+            replacements: [termsOfService, privacyNotice],
+            attributes: linkAttributes
+        )
+
+        return CompoundAttributedStringDecorator(decorators: [rangeDecorator, replacementDecorator])
+    }
 }

--- a/novawallet/Modules/ConsentBannerUpgrade/ConsentBannerUpgradePresenter.swift
+++ b/novawallet/Modules/ConsentBannerUpgrade/ConsentBannerUpgradePresenter.swift
@@ -1,0 +1,44 @@
+import Foundation
+import UIKit
+
+final class ConsentBannerUpgradePresenter {
+    weak var view: ConsentBannerUpgradeViewProtocol?
+    let wireframe: ConsentBannerUpgradeWireframeProtocol
+    let consentService: ConsentServiceProtocol
+    let onAcceptance: () -> Void
+
+    init(
+        wireframe: ConsentBannerUpgradeWireframeProtocol,
+        consentService: ConsentServiceProtocol,
+        onAcceptance: @escaping () -> Void
+    ) {
+        self.wireframe = wireframe
+        self.consentService = consentService
+        self.onAcceptance = onAcceptance
+    }
+}
+
+extension ConsentBannerUpgradePresenter: ConsentBannerUpgradePresenterProtocol {
+    func setup() {}
+
+    func acceptConsent() {
+        consentService.acceptCurrentConsent()
+
+        // Defer onAcceptance until after the dismissal animation completes so
+        // any subsequent OnLaunchAction modal isn't presented over a still-
+        // animating dismiss transition.
+        wireframe.close(view: view) { [weak self] in
+            self?.onAcceptance()
+        }
+    }
+
+    func activateTerms() {
+        // Per Aurum mandate, the consent banner ToS link opens in the system
+        // browser (not the in-app SFSafariViewController used elsewhere).
+        UIApplication.shared.open(ConsentBannerConstants.termsOfServiceURL)
+    }
+
+    func activatePrivacy() {
+        UIApplication.shared.open(ConsentBannerConstants.privacyNoticeURL)
+    }
+}

--- a/novawallet/Modules/ConsentBannerUpgrade/ConsentBannerUpgradeProtocol.swift
+++ b/novawallet/Modules/ConsentBannerUpgrade/ConsentBannerUpgradeProtocol.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Foundation_iOS
+
+protocol ConsentBannerUpgradeViewProtocol: ControllerBackedProtocol {}
+
+protocol ConsentBannerUpgradePresenterProtocol: AnyObject {
+    func setup()
+    func acceptConsent()
+    func activateTerms()
+    func activatePrivacy()
+}
+
+protocol ConsentBannerUpgradeWireframeProtocol: AnyObject {
+    func close(view: ConsentBannerUpgradeViewProtocol?, completion: (() -> Void)?)
+}
+
+protocol ConsentBannerUpgradeViewFactoryProtocol {
+    static func createView(completion: @escaping () -> Void) -> ConsentBannerUpgradeViewProtocol?
+}

--- a/novawallet/Modules/ConsentBannerUpgrade/ConsentBannerUpgradeViewController.swift
+++ b/novawallet/Modules/ConsentBannerUpgrade/ConsentBannerUpgradeViewController.swift
@@ -1,0 +1,119 @@
+import UIKit
+import Foundation_iOS
+import UIKit_iOS
+
+final class ConsentBannerUpgradeViewController: UIViewController, ViewHolder {
+    typealias RootViewType = ConsentBannerUpgradeViewLayout
+
+    let presenter: ConsentBannerUpgradePresenterProtocol
+
+    init(
+        presenter: ConsentBannerUpgradePresenterProtocol,
+        localizationManager: LocalizationManagerProtocol
+    ) {
+        self.presenter = presenter
+
+        super.init(nibName: nil, bundle: nil)
+
+        self.localizationManager = localizationManager
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = ConsentBannerUpgradeViewLayout()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupLocalization()
+        setupHandlers()
+        applyConsentState()
+
+        presenter.setup()
+    }
+
+    private func setupLocalization() {
+        let languages = selectedLocale.rLanguages
+
+        rootView.titleLabel.text = R.string(preferredLanguages: languages).localizable.consentBannerUpgradeTitle()
+        rootView.descriptionLabel.text = R.string(preferredLanguages: languages).localizable.consentBannerUpgradeDescription()
+        rootView.acceptButton.imageWithTitleView?.title = R.string(preferredLanguages: languages).localizable.consentBannerUpgradeAccept()
+
+        let marker = AttributedReplacementStringDecorator.marker
+        let consentText = R.string(preferredLanguages: languages).localizable.consentBannerTextTemplate(
+            marker,
+            marker
+        )
+
+        let consentDecorator = CompoundAttributedStringDecorator.consentBanner(
+            for: selectedLocale,
+            marker: marker
+        )
+        let attributedText = NSAttributedString(string: consentText)
+        rootView.consentLabel.attributedText = consentDecorator.decorate(attributedString: attributedText)
+    }
+
+    private func setupHandlers() {
+        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(actionTerms(gestureRecognizer:)))
+        rootView.consentLabel.addGestureRecognizer(tapRecognizer)
+
+        rootView.consentCheckbox.addTarget(self, action: #selector(actionToggleConsent), for: .touchUpInside)
+        rootView.acceptButton.addTarget(self, action: #selector(actionAccept), for: .touchUpInside)
+    }
+
+    private func applyConsentState() {
+        let isAccepted = rootView.consentCheckbox.isSelected
+        rootView.acceptButton.isEnabled = isAccepted
+    }
+
+    @objc private func actionToggleConsent() {
+        rootView.consentCheckbox.isSelected.toggle()
+        applyConsentState()
+    }
+
+    @objc private func actionAccept() {
+        presenter.acceptConsent()
+    }
+
+    @objc private func actionTerms(gestureRecognizer: UITapGestureRecognizer) {
+        guard gestureRecognizer.state == .ended else { return }
+
+        // Same y-axis line detection heuristic as the welcome screen — the
+        // Aurum-mandated text wraps with "Terms of Service" on line 1 and
+        // "Privacy Notice" on line 2 in English.
+        let location = gestureRecognizer.location(in: rootView.consentLabel)
+        let labelHeight = rootView.consentLabel.bounds.height
+
+        if location.y < labelHeight / 2 {
+            presenter.activateTerms()
+        } else {
+            presenter.activatePrivacy()
+        }
+    }
+}
+
+extension ConsentBannerUpgradeViewController: ConsentBannerUpgradeViewProtocol {}
+
+extension ConsentBannerUpgradeViewController: Localizable {
+    func applyLocalization() {
+        if isViewLoaded {
+            setupLocalization()
+        }
+    }
+}
+
+extension ConsentBannerUpgradeViewController: ModalCardPresentationControllerDelegate {
+    // The consent banner is a legal compliance gate. The user MUST tap the
+    // Accept button after checking the consent box — they cannot dismiss it
+    // via swipe-down or any other gesture. Returning false here causes
+    // ModalCardPresentationController.finishPresentation to cancel any
+    // interactive dismissal attempt.
+    func presentationControllerShouldDismiss(_: UIPresentationController) -> Bool {
+        false
+    }
+}

--- a/novawallet/Modules/ConsentBannerUpgrade/ConsentBannerUpgradeViewFactory.swift
+++ b/novawallet/Modules/ConsentBannerUpgrade/ConsentBannerUpgradeViewFactory.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Foundation_iOS
+
+final class ConsentBannerUpgradeViewFactory: ConsentBannerUpgradeViewFactoryProtocol {
+    static func createView(completion: @escaping () -> Void) -> ConsentBannerUpgradeViewProtocol? {
+        let wireframe = ConsentBannerUpgradeWireframe()
+
+        let presenter = ConsentBannerUpgradePresenter(
+            wireframe: wireframe,
+            consentService: ConsentService(),
+            onAcceptance: completion
+        )
+
+        let view = ConsentBannerUpgradeViewController(
+            presenter: presenter,
+            localizationManager: LocalizationManager.shared
+        )
+
+        presenter.view = view
+
+        return view
+    }
+}

--- a/novawallet/Modules/ConsentBannerUpgrade/ConsentBannerUpgradeViewLayout.swift
+++ b/novawallet/Modules/ConsentBannerUpgrade/ConsentBannerUpgradeViewLayout.swift
@@ -1,0 +1,97 @@
+import UIKit
+import UIKit_iOS
+
+final class ConsentBannerUpgradeViewLayout: UIView {
+    let titleLabel: UILabel = .create { label in
+        label.font = .boldTitle2
+        label.textColor = R.color.colorTextPrimary()
+        label.numberOfLines = 0
+        label.textAlignment = .center
+    }
+
+    let descriptionLabel: UILabel = .create { label in
+        label.font = .regularSubheadline
+        label.textColor = R.color.colorTextSecondary()
+        label.numberOfLines = 0
+        label.textAlignment = .center
+    }
+
+    let consentLabel: UILabel = .create { label in
+        label.isUserInteractionEnabled = true
+        label.numberOfLines = 0
+        label.textAlignment = .natural
+    }
+
+    let consentCheckbox: UIButton = .create { button in
+        button.setImage(R.image.iconCheckboxEmpty(), for: .normal)
+        button.setImage(R.image.iconCheckbox(), for: .selected)
+        button.contentHorizontalAlignment = .center
+        button.contentVerticalAlignment = .center
+        button.accessibilityIdentifier = "consentBannerUpgradeCheckbox"
+    }
+
+    let acceptButton: TriangularedButton = .create { button in
+        button.applyDefaultStyle()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = R.color.colorSecondaryScreenBackground()
+
+        setupLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide).offset(Constants.titleTopInset)
+            make.leading.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
+        }
+
+        addSubview(descriptionLabel)
+        descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(Constants.descriptionTopGap)
+            make.leading.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
+        }
+
+        addSubview(acceptButton)
+        acceptButton.snp.makeConstraints { make in
+            make.bottom.equalTo(safeAreaLayoutGuide).offset(-Constants.acceptBottomInset)
+            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
+            make.height.equalTo(UIConstants.actionHeight)
+        }
+
+        addSubview(consentLabel)
+        consentLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(Constants.consentLeadingInset)
+            make.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
+            make.bottom.equalTo(acceptButton.snp.top).offset(-Constants.consentBottomGap)
+        }
+
+        addSubview(consentCheckbox)
+        consentCheckbox.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(UIConstants.horizontalInset)
+            make.top.equalTo(consentLabel.snp.top)
+            make.width.height.equalTo(Constants.checkboxSize)
+        }
+    }
+}
+
+private extension ConsentBannerUpgradeViewLayout {
+    enum Constants {
+        static let titleTopInset: CGFloat = 32
+        static let descriptionTopGap: CGFloat = 16
+        static let consentBottomGap: CGFloat = 24
+        static let acceptBottomInset: CGFloat = 16
+        static let checkboxSize: CGFloat = 24
+        // 16 (screen inset) + 24 (checkbox) + 12 (gap) = 52
+        static let consentLeadingInset: CGFloat = 52
+    }
+}

--- a/novawallet/Modules/ConsentBannerUpgrade/ConsentBannerUpgradeWireframe.swift
+++ b/novawallet/Modules/ConsentBannerUpgrade/ConsentBannerUpgradeWireframe.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+final class ConsentBannerUpgradeWireframe: ConsentBannerUpgradeWireframeProtocol {
+    func close(view: ConsentBannerUpgradeViewProtocol?, completion: (() -> Void)?) {
+        view?.controller.dismiss(animated: true, completion: completion)
+    }
+}

--- a/novawallet/Modules/MainTabBar/MainTabBarInteractor.swift
+++ b/novawallet/Modules/MainTabBar/MainTabBarInteractor.swift
@@ -20,11 +20,15 @@ final class MainTabBarInteractor: AnyProviderAutoCleaning {
     let pushScreenOpenService: PushNotificationOpenScreenFacadeProtocol
     let cloudBackupMediator: CloudBackupSyncMediating
     let settingsManager: SettingsManagerProtocol
+    let consentService: ConsentServiceProtocol
     let operationQueue: OperationQueue
     let logger: LoggerProtocol
 
     let onLaunchQueue = OnLaunchActionsQueue(
+        // ConsentBannerUpgrade is FIRST — legal compliance must be obtained
+        // before the user interacts with anything else.
         possibleActions: [
+            OnLaunchAction.ConsentBannerUpgrade(),
             OnLaunchAction.PushNotificationsSetup(),
             OnLaunchAction.AHMInfoSetup(),
             OnLaunchAction.MultisigNotificationsPromo()
@@ -49,6 +53,7 @@ final class MainTabBarInteractor: AnyProviderAutoCleaning {
         securedLayer: SecurityLayerServiceProtocol,
         inAppUpdatesService: SyncServiceProtocol,
         settingsManager: SettingsManagerProtocol,
+        consentService: ConsentServiceProtocol,
         operationQueue: OperationQueue,
         logger: LoggerProtocol
     ) {
@@ -65,6 +70,7 @@ final class MainTabBarInteractor: AnyProviderAutoCleaning {
         self.securedLayer = securedLayer
         self.inAppUpdatesService = inAppUpdatesService
         self.settingsManager = settingsManager
+        self.consentService = consentService
         self.operationQueue = operationQueue
         self.logger = logger
 
@@ -112,6 +118,17 @@ private extension MainTabBarInteractor {
             presenter?.didRequestImportAccount(source: .keystore)
         case .mnemonic:
             presenter?.didRequestImportAccount(source: .mnemonic(.appDefault))
+        }
+    }
+
+    func showConsentBannerUpgradeOrNextAction() {
+        guard !consentService.hasAcceptedCurrentVersion else {
+            onLaunchQueue.runNext()
+            return
+        }
+
+        securedLayer.scheduleExecutionIfAuthorized { [weak self] in
+            self?.presenter?.didRequestConsentBannerUpgradeOpen()
         }
     }
 
@@ -348,6 +365,10 @@ extension MainTabBarInteractor: CloudBackupSynсUIPresenting {
 // MARK: - OnLaunchActionsQueueDelegate
 
 extension MainTabBarInteractor: OnLaunchActionsQueueDelegate {
+    func onLaunchProcessConsentBannerUpgrade(_: OnLaunchAction.ConsentBannerUpgrade) {
+        showConsentBannerUpgradeOrNextAction()
+    }
+
     func onLaunchProccessPushNotificationsSetup(_: OnLaunchAction.PushNotificationsSetup) {
         showPushNotificationsSetupOrNextAction()
     }

--- a/novawallet/Modules/MainTabBar/MainTabBarPresenter.swift
+++ b/novawallet/Modules/MainTabBar/MainTabBarPresenter.swift
@@ -134,6 +134,15 @@ extension MainTabBarPresenter: MainTabBarInteractorOutputProtocol {
         )
     }
 
+    func didRequestConsentBannerUpgradeOpen() {
+        wireframe.presentConsentBannerUpgrade(
+            on: view,
+            flowCompletion: { [weak self] in
+                self?.interactor.requestNextOnLaunchAction()
+            }
+        )
+    }
+
     func didReceiveCloudSync(status: CloudBackupSyncMonitorStatus?) {
         switch status {
         case .noFile, .synced:

--- a/novawallet/Modules/MainTabBar/MainTabBarProtocol.swift
+++ b/novawallet/Modules/MainTabBar/MainTabBarProtocol.swift
@@ -37,6 +37,7 @@ protocol MainTabBarInteractorOutputProtocol: AnyObject {
     func didRequestPushNotificationsSetupOpen()
     func didRequestMultisigNotificationsPromoOpen(with params: MultisigNotificationsPromoParams)
     func didRequestAHMInfoOpen(with info: [AHMRemoteData])
+    func didRequestConsentBannerUpgradeOpen()
     func didSyncCloudBackup(on purpose: CloudBackupSynсPurpose)
     func didReceiveCloudSync(status: CloudBackupSyncMonitorStatus?)
 }
@@ -89,6 +90,11 @@ protocol MainTabBarWireframeProtocol: AlertPresentable,
     func presentAssetHubMigrationInfoScreen(
         in view: MainTabBarViewProtocol?,
         with info: [AHMRemoteData]
+    )
+
+    func presentConsentBannerUpgrade(
+        on view: MainTabBarViewProtocol?,
+        flowCompletion: @escaping () -> Void
     )
 }
 

--- a/novawallet/Modules/MainTabBar/MainTabBarViewFactory.swift
+++ b/novawallet/Modules/MainTabBar/MainTabBarViewFactory.swift
@@ -101,6 +101,7 @@ private extension MainTabBarViewFactory {
             securedLayer: securedLayer,
             inAppUpdatesService: inAppUpdatesService,
             settingsManager: settingsManager,
+            consentService: ConsentService(),
             operationQueue: operationQueue,
             logger: logger
         )

--- a/novawallet/Modules/MainTabBar/MainTabBarWireframe.swift
+++ b/novawallet/Modules/MainTabBar/MainTabBarWireframe.swift
@@ -465,6 +465,27 @@ extension MainTabBarWireframe: MainTabBarWireframeProtocol {
         )
     }
 
+    func presentConsentBannerUpgrade(
+        on view: MainTabBarViewProtocol?,
+        flowCompletion: @escaping () -> Void
+    ) {
+        guard let consentView = ConsentBannerUpgradeViewFactory.createView(
+            completion: flowCompletion
+        ) else {
+            return
+        }
+
+        // Block all dismissal paths (swipe, tap-outside) — the consent must
+        // be acquired via the explicit Accept button, never bypassed.
+        consentView.controller.isModalInPresentation = true
+
+        view?.controller.presentWithCardLayout(
+            consentView.controller,
+            animated: true,
+            completion: nil
+        )
+    }
+
     func presentCloudBackupUnsyncedChanges(
         from view: MainTabBarViewProtocol?,
         onReviewUpdates: @escaping () -> Void

--- a/novawallet/Modules/MainTabBar/OnLauchAction.swift
+++ b/novawallet/Modules/MainTabBar/OnLauchAction.swift
@@ -5,6 +5,12 @@ protocol OnLaunchActionProtocol {
 }
 
 enum OnLaunchAction {
+    struct ConsentBannerUpgrade: OnLaunchActionProtocol {
+        func accept(visitor: OnLaunchActionsQueueDelegate) {
+            visitor.onLaunchProcessConsentBannerUpgrade(self)
+        }
+    }
+
     struct PushNotificationsSetup: OnLaunchActionProtocol {
         func accept(visitor: OnLaunchActionsQueueDelegate) {
             visitor.onLaunchProccessPushNotificationsSetup(self)

--- a/novawallet/Modules/MainTabBar/OnLaunchActionsQueue.swift
+++ b/novawallet/Modules/MainTabBar/OnLaunchActionsQueue.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 protocol OnLaunchActionsQueueDelegate: AnyObject {
+    func onLaunchProcessConsentBannerUpgrade(_ event: OnLaunchAction.ConsentBannerUpgrade)
     func onLaunchProccessPushNotificationsSetup(_ event: OnLaunchAction.PushNotificationsSetup)
     func onLaunchProcessMultisigNotificationPromo(_ event: OnLaunchAction.MultisigNotificationsPromo)
     func onLaunchProcessAHMInfoSetup(_ event: OnLaunchAction.AHMInfoSetup)

--- a/novawallet/Modules/Onboarding/Start/OnboardingMainPresenter.swift
+++ b/novawallet/Modules/Onboarding/Start/OnboardingMainPresenter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Foundation_iOS
 
 final class OnboardingMainPresenter {
@@ -7,6 +8,7 @@ final class OnboardingMainPresenter {
     let interactor: OnboardingMainInteractorInputProtocol
 
     let legalData: LegalData
+    let consentService: ConsentServiceProtocol
 
     let locale: Locale
 
@@ -14,11 +16,13 @@ final class OnboardingMainPresenter {
         interactor: OnboardingMainInteractorInputProtocol,
         wireframe: OnboardingMainWireframeProtocol,
         legalData: LegalData,
+        consentService: ConsentServiceProtocol,
         locale: Locale
     ) {
         self.interactor = interactor
         self.wireframe = wireframe
         self.legalData = legalData
+        self.consentService = consentService
         self.locale = locale
     }
 }
@@ -29,30 +33,29 @@ extension OnboardingMainPresenter: OnboardingMainPresenterProtocol {
     }
 
     func activateTerms() {
-        if let view = view {
-            wireframe.showWeb(
-                url: legalData.termsUrl,
-                from: view,
-                style: .modal
-            )
-        }
+        // Per Aurum mandate, the consent banner ToS link opens in the system
+        // browser (not the in-app SFSafariViewController used elsewhere) so the
+        // user reads the document outside of the app's wallet creation flow.
+        UIApplication.shared.open(legalData.termsUrl)
     }
 
     func activatePrivacy() {
-        if let view = view {
-            wireframe.showWeb(
-                url: legalData.privacyPolicyUrl,
-                from: view,
-                style: .modal
-            )
-        }
+        // Per Aurum mandate, the consent banner Privacy Notice link opens in the
+        // system browser (not the in-app SFSafariViewController used elsewhere).
+        UIApplication.shared.open(legalData.privacyPolicyUrl)
     }
 
     func activateSignup() {
+        // The view enforces that the consent checkbox is checked before this
+        // method can be invoked. Persist the acceptance now so subsequent
+        // wallet operations and the existing-user upgrade modal both observe
+        // the recorded version.
+        consentService.acceptCurrentConsent()
         wireframe.showSignup(from: view)
     }
 
     func activateAccountRestore() {
+        consentService.acceptCurrentConsent()
         wireframe.showAccountRestore(from: view)
     }
 }

--- a/novawallet/Modules/Onboarding/Start/OnboardingMainViewController.swift
+++ b/novawallet/Modules/Onboarding/Start/OnboardingMainViewController.swift
@@ -32,8 +32,15 @@ final class OnboardingMainViewController: UIViewController, ViewHolder {
 
         setupLocalization()
         setupHandlers()
+        applyConsentState()
 
         presenter.setup()
+    }
+
+    private func applyConsentState() {
+        let isAccepted = rootView.consentCheckbox.isSelected
+        rootView.createButton.isEnabled = isAccepted
+        rootView.importButton.isEnabled = isAccepted
     }
 
     private func setupLocalization() {
@@ -46,22 +53,31 @@ final class OnboardingMainViewController: UIViewController, ViewHolder {
         rootView.importButton.imageWithTitleView?.title = importTitle
 
         let marker = AttributedReplacementStringDecorator.marker
-        let termsText = R.string(preferredLanguages: languages).localizable.onboardingTermsAndConditions1_v2_2_0(
+        let consentText = R.string(preferredLanguages: languages).localizable.consentBannerTextTemplate(
             marker,
             marker
         )
 
-        let termDecorator = CompoundAttributedStringDecorator.legal(for: selectedLocale, marker: marker)
-        let attributedText = NSAttributedString(string: termsText)
-        rootView.termsLabel.attributedText = termDecorator.decorate(attributedString: attributedText)
+        let consentDecorator = CompoundAttributedStringDecorator.consentBanner(
+            for: selectedLocale,
+            marker: marker
+        )
+        let attributedText = NSAttributedString(string: consentText)
+        rootView.termsLabel.attributedText = consentDecorator.decorate(attributedString: attributedText)
     }
 
     private func setupHandlers() {
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(actionTerms(gestureRecognizer:)))
         rootView.termsLabel.addGestureRecognizer(tapRecognizer)
 
+        rootView.consentCheckbox.addTarget(self, action: #selector(actionToggleConsent), for: .touchUpInside)
         rootView.createButton.addTarget(self, action: #selector(actionSignup), for: .touchUpInside)
         rootView.importButton.addTarget(self, action: #selector(actionRestoreAccess), for: .touchUpInside)
+    }
+
+    @objc private func actionToggleConsent() {
+        rootView.consentCheckbox.isSelected.toggle()
+        applyConsentState()
     }
 
     @objc private func actionSignup() {
@@ -73,14 +89,19 @@ final class OnboardingMainViewController: UIViewController, ViewHolder {
     }
 
     @objc private func actionTerms(gestureRecognizer: UITapGestureRecognizer) {
-        if gestureRecognizer.state == .ended {
-            let location = gestureRecognizer.location(in: rootView.termsLabel.superview)
+        guard gestureRecognizer.state == .ended else { return }
 
-            if location.x < rootView.termsLabel.center.x {
-                presenter.activateTerms()
-            } else {
-                presenter.activatePrivacy()
-            }
+        // The Aurum-mandated text wraps such that "Terms of Service" lands on the
+        // first line and "Privacy Notice" on the second. We detect which link the
+        // user tapped using vertical position. If the wording is ever revised so
+        // that wrapping changes, this heuristic must be revisited.
+        let location = gestureRecognizer.location(in: rootView.termsLabel)
+        let labelHeight = rootView.termsLabel.bounds.height
+
+        if location.y < labelHeight / 2 {
+            presenter.activateTerms()
+        } else {
+            presenter.activatePrivacy()
         }
     }
 }

--- a/novawallet/Modules/Onboarding/Start/OnboardingMainViewFactory.swift
+++ b/novawallet/Modules/Onboarding/Start/OnboardingMainViewFactory.swift
@@ -30,11 +30,13 @@ final class OnboardingMainViewFactory: OnboardingMainViewFactoryProtocol {
             return nil
         }
 
-        let applicationConfig: ApplicationConfigProtocol = ApplicationConfig.shared
-
+        // The consent banner uses dedicated novasama.io URLs (placeholder until
+        // the canonical pages land — see ConsentBannerConstants). The legacy
+        // ApplicationConfig.termsURL / privacyPolicyURL still point at the OLD
+        // novawallet.io documents and must NOT be reused here.
         let legalData = LegalData(
-            termsUrl: applicationConfig.termsURL,
-            privacyPolicyUrl: applicationConfig.privacyPolicyURL
+            termsUrl: ConsentBannerConstants.termsOfServiceURL,
+            privacyPolicyUrl: ConsentBannerConstants.privacyNoticeURL
         )
 
         let interactor = OnboardingMainInteractor(
@@ -46,6 +48,7 @@ final class OnboardingMainViewFactory: OnboardingMainViewFactoryProtocol {
             interactor: interactor,
             wireframe: wireframe,
             legalData: legalData,
+            consentService: ConsentService(),
             locale: LocalizationManager.shared.selectedLocale
         )
 

--- a/novawallet/Modules/Onboarding/Start/OnboardingMainViewLayout.swift
+++ b/novawallet/Modules/Onboarding/Start/OnboardingMainViewLayout.swift
@@ -15,7 +15,15 @@ final class OnboardingMainViewLayout: UIView, AdaptiveDesignable {
     let termsLabel: UILabel = .create { label in
         label.isUserInteractionEnabled = true
         label.numberOfLines = 0
-        label.textAlignment = .center
+        label.textAlignment = .natural
+    }
+
+    let consentCheckbox: UIButton = .create { button in
+        button.setImage(R.image.iconCheckboxEmpty(), for: .normal)
+        button.setImage(R.image.iconCheckbox(), for: .selected)
+        button.contentHorizontalAlignment = .center
+        button.contentVerticalAlignment = .center
+        button.accessibilityIdentifier = "consentCheckbox"
     }
 
     let createButton: TriangularedButton = .create { button in
@@ -54,15 +62,9 @@ final class OnboardingMainViewLayout: UIView, AdaptiveDesignable {
 
         logo.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
 
-        addSubview(termsLabel)
-        termsLabel.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(20)
-            make.bottom.equalTo(safeAreaLayoutGuide).offset(-16)
-        }
-
         addSubview(importButton)
         importButton.snp.makeConstraints { make in
-            make.bottom.equalTo(termsLabel.snp.top).offset(-24)
+            make.bottom.equalTo(safeAreaLayoutGuide).offset(-16)
             make.centerX.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
             make.height.equalTo(UIConstants.actionHeight)
@@ -75,5 +77,28 @@ final class OnboardingMainViewLayout: UIView, AdaptiveDesignable {
             make.leading.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
             make.height.equalTo(UIConstants.actionHeight)
         }
+
+        addSubview(termsLabel)
+        termsLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(Constants.consentLeadingInset)
+            make.trailing.equalToSuperview().inset(20)
+            make.bottom.equalTo(createButton.snp.top).offset(-Constants.consentBottomGap)
+        }
+
+        addSubview(consentCheckbox)
+        consentCheckbox.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(20)
+            make.top.equalTo(termsLabel.snp.top)
+            make.width.height.equalTo(Constants.consentCheckboxSize)
+        }
+    }
+}
+
+private extension OnboardingMainViewLayout {
+    enum Constants {
+        static let consentCheckboxSize: CGFloat = 24
+        // 20 (screen inset) + 24 (checkbox) + 12 (gap) = 56
+        static let consentLeadingInset: CGFloat = 56
+        static let consentBottomGap: CGFloat = 20
     }
 }

--- a/novawallet/en.lproj/Localizable.strings
+++ b/novawallet/en.lproj/Localizable.strings
@@ -589,6 +589,12 @@
 "connection.error.message_v2_2_0" = "Please, check your connection or try again later";
 "common.invalid.derivation.path.message_v2_2_0" = "Your derivation path contains unsupported symbols or has incorrect structure";
 "onboarding.terms.and.conditions.1_v2_2_0" = "By continuing, you agree to our \n%@ and %@";
+"consent.banner.text.template" = "I agree to the %@, and acknowledge the %@.";
+"consent.banner.terms.of.service" = "Terms of Service";
+"consent.banner.privacy.notice" = "Privacy Notice";
+"consent.banner.upgrade.title" = "Updated Terms";
+"consent.banner.upgrade.description" = "We've updated our Terms of Service and Privacy Notice. Please review and accept the updated documents to continue using Nova Wallet.";
+"consent.banner.upgrade.accept" = "Accept and Continue";
 "wallet.receive.description_v2_2_0" = "Let sender scan this QR code";
 "wallet.receive.title.format" = "Receive %@";
 "wallet.receive.share.title" = "Share QR code";


### PR DESCRIPTION
> ⚠️ **Requires approved ToS & Privacy Notice + URLs of ToS & Privacy Notice on novasama.io before merging**

## Purpose

Adds a mandatory ToS / Privacy Notice consent mechanism. Users must
affirmatively accept before creating or connecting a wallet. Existing
users are prompted on first launch after the update.

Companion Android PR: novasamatech/nova-wallet-android#2277

## Solution

### New-user flow (Welcome screen)
- Consent checkbox with required text placed above the Create / Already
  Have buttons
- Both buttons disabled until the checkbox is checked
- "Terms of Service" and "Privacy Notice" are underlined hyperlinks that
  open the system browser (not in-app SFSafariViewController)
- Acceptance persisted via `ConsentService` wrapping `SettingsManager`
  with a versioned integer key (`consentAcceptedVersion`)

### Existing-user upgrade flow
- New `OnLaunchAction.ConsentBannerUpgrade` — first action in the queue,
  runs before push notifications or AHM info
- Gated behind `securedLayer.scheduleExecutionIfAuthorized` (after PIN)
- Presents a card-style modal via `ModalCardPresentationController`
- Non-dismissable: `ModalCardPresentationControllerDelegate` returns
  `false` from `presentationControllerShouldDismiss`
- On accept, writes consent version and advances the launch queue

### Privacy compliance
- Consent state is **device-local only** (UserDefaults). No PostHog, no
  Branch, no server-side log.
- Placeholder URLs (`TODO_CONSENT_URL_*`) must be replaced with the
  canonical novasama.io pages before merging (dependent on rollout
  action items C-01 / C-02)

### Unrelated observation
During QA, a pre-existing crash was found in the WalletConnect dependency
(`novasamatech/WalletConnectSwiftV2` v1.9.9, rev `1d9d78b5e3`):

**`ProposalExpiryWatcher.swift:26`** — `Timer.scheduledTimer` captures
`[unowned self]` but no `deinit` invalidates the timer. When all wallets
are deleted and the WC session is torn down, the timer fires on a
deallocated watcher → `swift_abortRetainUnowned` crash.

Repro: create wallet → delete it (0 wallets remain) → crash within ~3s.
Fix: `[unowned self]` → `[weak self]` + add `deinit { checkTimer?.invalidate() }`.
Suggest a separate PR against the WC fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)