### PR TITLE
Staking: demote 7 networks + per-chain notice system

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -4362,6 +4362,7 @@
 		847449512891F3B00042FD80 /* WalletSwitchControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847449502891F3B00042FD80 /* WalletSwitchControl.swift */; };
 		84744953289268770042FD80 /* WalletSwitchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84744952289268770042FD80 /* WalletSwitchViewModel.swift */; };
 		84744955289284F50042FD80 /* StakingMainViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84744954289284F50042FD80 /* StakingMainViewLayout.swift */; };
+		C1C65F63ABA4EA410BA9A98B /* StakingNoticeBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6521517DD9A8185C032DFB /* StakingNoticeBlockView.swift */; };
 		84746B3028153E4C002642F4 /* GradientBannerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84746B2F28153E4C002642F4 /* GradientBannerModel.swift */; };
 		84754C852510A1A400854599 /* ModalAlertPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84754C842510A1A400854599 /* ModalAlertPresenting.swift */; };
 		84754C882510BAFE00854599 /* ModalAlertFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84754C872510BAFE00854599 /* ModalAlertFactory.swift */; };
@@ -10636,6 +10637,7 @@
 		847449502891F3B00042FD80 /* WalletSwitchControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSwitchControl.swift; sourceTree = "<group>"; };
 		84744952289268770042FD80 /* WalletSwitchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSwitchViewModel.swift; sourceTree = "<group>"; };
 		84744954289284F50042FD80 /* StakingMainViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingMainViewLayout.swift; sourceTree = "<group>"; };
+		6B6521517DD9A8185C032DFB /* StakingNoticeBlockView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNoticeBlockView.swift; sourceTree = "<group>"; };
 		84746B2F28153E4C002642F4 /* GradientBannerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientBannerModel.swift; sourceTree = "<group>"; };
 		84754C842510A1A400854599 /* ModalAlertPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalAlertPresenting.swift; sourceTree = "<group>"; };
 		84754C872510BAFE00854599 /* ModalAlertFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalAlertFactory.swift; sourceTree = "<group>"; };
@@ -29147,9 +29149,26 @@
 			path = AssetOperationNetworkList;
 			sourceTree = "<group>";
 		};
+		1FDD840983ED062936C0279F /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				21F3B1AC0F656C99BC4699B7 /* Views */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		21F3B1AC0F656C99BC4699B7 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				6B6521517DD9A8185C032DFB /* StakingNoticeBlockView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		B7B0681CCE8F8F0127E8676C /* StakingMain */ = {
 			isa = PBXGroup;
 			children = (
+				1FDD840983ED062936C0279F /* Common */,
 				8F7A1E3EDBEE67AC353B846D /* Mythos */,
 				0C9C642E2A8D675B004DC078 /* NominationPools */,
 				841E5543282D78ED00C8438F /* Parachain */,
@@ -35207,6 +35226,7 @@
 				2BBA744323AA0BF6FE53C212 /* CollatorStakingSelectProtocols.swift in Sources */,
 				880059E128EF0A5C00E87B9B /* VotingProgressView.swift in Sources */,
 				84744955289284F50042FD80 /* StakingMainViewLayout.swift in Sources */,
+				C1C65F63ABA4EA410BA9A98B /* StakingNoticeBlockView.swift in Sources */,
 				88D02FF229431FC900E26390 /* AssetDetailsLocksViewModel.swift in Sources */,
 				2D54215F2EAB69BC0020E64B /* GiftTransferInteractor.swift in Sources */,
 				84ABB3382A16164200B5E95A /* HistoryRewardContext.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -5847,6 +5847,7 @@
 		94B0F0C84AF74B3CD7223C3A /* AccountConfirmPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7306D50F278F6CC90DC88F27 /* AccountConfirmPresenter.swift */; };
 		94B234EE404088B077DB6411 /* DAppListProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F3CCA5BA57C68D5AE2B42F /* DAppListProtocols.swift */; };
 		94C5557889830B223206A937 /* GenericLedgerWalletInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CCDB2256863350F2236C2C0 /* GenericLedgerWalletInteractor.swift */; };
+		952413819436984409450819 /* StakingDashboardBuilderDemotionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70949B5D9B0DE71569F3884 /* StakingDashboardBuilderDemotionTests.swift */; };
 		9550165DF9EF3C32A63FC581 /* NetworkNodeWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D7528CB09D28F392C10EBC /* NetworkNodeWireframe.swift */; };
 		955209300EF9643EC1241B12 /* AHMInfoProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FCC7D490906498F89DAE535 /* AHMInfoProtocols.swift */; };
 		9565BEB636E6D386B0C0FBE5 /* StakingPayoutConfirmationViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE0492B98AB9C1540846B39 /* StakingPayoutConfirmationViewFactory.swift */; };
@@ -6520,6 +6521,7 @@
 		F656EA6D54BF90FBBE6471D8 /* DAppBrowserTabListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D69D7EC1BD4295192633F /* DAppBrowserTabListPresenter.swift */; };
 		F65CC130E018157C0778B074 /* DelegationListWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF16BF87D3DEA31E6003C969 /* DelegationListWireframe.swift */; };
 		F690C666F5A95D0C8A48BD45 /* NPoolsClaimRewardsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B213965350582497E2F86E26 /* NPoolsClaimRewardsPresenter.swift */; };
+		F6E167B893C1C2971A392C43 /* StakingDashboardTierConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899C0910B5F8F38004732121 /* StakingDashboardTierConfig.swift */; };
 		F6F23360B56E938B31D1ECF0 /* ExportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD12F1DC3720B6C172357E4 /* ExportViewController.swift */; };
 		F6F73F4862779FE0B58A7931 /* ParaStkRebondInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1BCCE09BB15106FDC02495 /* ParaStkRebondInteractor.swift */; };
 		F75C2AAA76C49EDB8174B590 /* CollatorStakingSelectFiltersWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038B1C35376B62CFE28C403D /* CollatorStakingSelectFiltersWireframe.swift */; };
@@ -12081,6 +12083,7 @@
 		894A6BB613EA991A09976B30 /* NominationPoolBondMoreConfirmProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NominationPoolBondMoreConfirmProtocols.swift; sourceTree = "<group>"; };
 		8963C0A6A643F8ABD19AD6B3 /* GovernanceNotificationsInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceNotificationsInteractor.swift; sourceTree = "<group>"; };
 		899686C7351A2600FFA08371 /* TransferConfirmOnChainViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransferConfirmOnChainViewFactory.swift; sourceTree = "<group>"; };
+		899C0910B5F8F38004732121 /* StakingDashboardTierConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingDashboardTierConfig.swift; sourceTree = "<group>"; };
 		89AAAF09837D225A05769A7D /* DelegatedSignFeeValidationPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DelegatedSignFeeValidationPresenter.swift; sourceTree = "<group>"; };
 		89CFED2E01AB638656E251AF /* NftListProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NftListProtocols.swift; sourceTree = "<group>"; };
 		8A3DA31DE8C8AD1D82D66DEF /* SwapRouteDetailsViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwapRouteDetailsViewFactory.swift; sourceTree = "<group>"; };
@@ -12675,6 +12678,7 @@
 		E697F5EF3AD8EE7281FBF6CB /* WalletConnectSessionsViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletConnectSessionsViewLayout.swift; sourceTree = "<group>"; };
 		E6DDBA4DD86CEFAAE236B23B /* GovernanceDelegateSetupPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceDelegateSetupPresenter.swift; sourceTree = "<group>"; };
 		E6FE9E98CB265815986BE909 /* ReferendumVotersProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumVotersProtocols.swift; sourceTree = "<group>"; };
+		E70949B5D9B0DE71569F3884 /* StakingDashboardBuilderDemotionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingDashboardBuilderDemotionTests.swift; sourceTree = "<group>"; };
 		E765FD856EB60BBF344205F3 /* TokensAddSelectNetworkWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokensAddSelectNetworkWireframe.swift; sourceTree = "<group>"; };
 		E7B01586B548A0AB92695B40 /* CommonDelegationTracksViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CommonDelegationTracksViewController.swift; sourceTree = "<group>"; };
 		E7B77D655A395946E9405285 /* GovernanceNotificationsProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceNotificationsProtocols.swift; sourceTree = "<group>"; };
@@ -19924,6 +19928,14 @@
 			path = StakingSetupAmount;
 			sourceTree = "<group>";
 		};
+		712E58E9FBB81162E73689F4 /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				E70949B5D9B0DE71569F3884 /* StakingDashboardBuilderDemotionTests.swift */,
+			);
+			name = Dashboard;
+			sourceTree = "<group>";
+		};
 		71E66F0C5FF36EBFFEA3D807 /* DelegationReferendumVoters */ = {
 			isa = PBXGroup;
 			children = (
@@ -21624,6 +21636,7 @@
 				842E9E9C2A2C591C00759972 /* StakingDashboardInteractorError.swift */,
 				0CBC29C72A42AE2F00F7B1F7 /* StakingDashboardBuilderResult.swift */,
 				842E9EA32A2DC71000759972 /* StakingDashboardModel.swift */,
+				899C0910B5F8F38004732121 /* StakingDashboardTierConfig.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -25748,6 +25761,7 @@
 				84B7C6EA289BFA79001A3566 /* StakingUnbondConfirm */,
 				84B7C6EC289BFA79001A3566 /* StakingRewardPayouts */,
 				84B7C6EF289BFA79001A3566 /* StakingRebondConfirmation */,
+				712E58E9FBB81162E73689F4 /* Dashboard */,
 			);
 			path = Staking;
 			sourceTree = "<group>";
@@ -30341,7 +30355,7 @@
 				0C8FCEA02E672BB000034ED3 /* XCRemoteSwiftPackageReference "UIKit-iOS" */,
 				0C8FCEA62E672BFB00034ED3 /* XCRemoteSwiftPackageReference "Foundation-iOS" */,
 				0C8FCEA92E672C5500034ED3 /* XCRemoteSwiftPackageReference "SwiftyBeaver" */,
-				0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability" */,
+				0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability.swift" */,
 				0C8FCEAF2E672CFA00034ED3 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				0C8FCEB22E672D3900034ED3 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				0C8FCEB52E672D8100034ED3 /* XCRemoteSwiftPackageReference "SwiftDraw" */,
@@ -30353,7 +30367,7 @@
 				0C8FCEC72E6734E900034ED3 /* XCRemoteSwiftPackageReference "ZMarkupParser" */,
 				0C8FCECA2E6735F300034ED3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				0C8FCED32E67363000034ED3 /* XCRemoteSwiftPackageReference "metadata-shortener-ios" */,
-				0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */,
+				0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */,
 				0CF8F68E2E673E73007E41C4 /* XCRemoteSwiftPackageReference "Cuckoo" */,
 				0C32522B2E67477700E322DB /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */,
 				0C2BAA1B2E677B6E008157E7 /* XCRemoteSwiftPackageReference "web3swift" */,
@@ -36845,6 +36859,7 @@
 				33096BCF84A6ABA8416678FF /* CrowdloanUnlockViewController.swift in Sources */,
 				F170C0900DB942030B2107C7 /* CrowdloanUnlockViewLayout.swift in Sources */,
 				6B19F3A772108FBED12A7260 /* CrowdloanUnlockViewFactory.swift in Sources */,
+				F6E167B893C1C2971A392C43 /* StakingDashboardTierConfig.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -37027,6 +37042,7 @@
 				84AA004326C5DFD800BCB4DC /* RuntimeSyncServiceTests.swift in Sources */,
 				8413B27A29507F3A00F8E2E4 /* DataProviderRepositoryStub.swift in Sources */,
 				F4897BB126AED13D0075F291 /* EraCountdownOperationFactoryStub.swift in Sources */,
+				952413819436984409450819 /* StakingDashboardBuilderDemotionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -37035,15 +37051,15 @@
 /* Begin PBXTargetDependency section */
 		0C1995CB2E6B2DE600E0B909 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 0C1995CA2E6B2DE600E0B909 /* RswiftGenerateInternalResources */;
+			productRef = 0C1995CA2E6B2DE600E0B909 /* plugin:RswiftGenerateInternalResources */;
 		};
 		0C1A0F502E69C04E00254E20 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 0C1A0F4F2E69C04E00254E20 /* CuckooPluginSingleFile */;
+			productRef = 0C1A0F4F2E69C04E00254E20 /* plugin:CuckooPluginSingleFile */;
 		};
 		0C6A9E2D2E6B1FC40088C2BA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 0C6A9E2C2E6B1FC40088C2BA /* RswiftGenerateInternalResources */;
+			productRef = 0C6A9E2C2E6B1FC40088C2BA /* plugin:RswiftGenerateInternalResources */;
 		};
 		77CAF4352B8E96A400E4297C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -38037,7 +38053,7 @@
 				version = 2.1.1;
 			};
 		};
-		0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability" */ = {
+		0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ashleymills/Reachability.swift";
 			requirement = {
@@ -38133,7 +38149,7 @@
 				version = 0.2.1;
 			};
 		};
-		0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */ = {
+		0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mac-cain13/R.swift";
 			requirement = {
@@ -38192,24 +38208,24 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0C1995CA2E6B2DE600E0B909 /* RswiftGenerateInternalResources */ = {
+		0C1995CA2E6B2DE600E0B909 /* plugin:RswiftGenerateInternalResources */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = "plugin:RswiftGenerateInternalResources";
 		};
 		0C1A0F472E68E01C00254E20 /* RswiftLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = RswiftLibrary;
 		};
-		0C1A0F4F2E69C04E00254E20 /* CuckooPluginSingleFile */ = {
+		0C1A0F4F2E69C04E00254E20 /* plugin:CuckooPluginSingleFile */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0CF8F68E2E673E73007E41C4 /* XCRemoteSwiftPackageReference "Cuckoo" */;
 			productName = "plugin:CuckooPluginSingleFile";
 		};
 		0C1A0F562E69EC5C00254E20 /* RswiftLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = RswiftLibrary;
 		};
 		0C2BAA1C2E677B6E008157E7 /* web3swift */ = {
@@ -38224,7 +38240,7 @@
 		};
 		0C2BAA332E67841C008157E7 /* RswiftLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = RswiftLibrary;
 		};
 		0C2BAA552E687BD0008157E7 /* HydraMathApi */ = {
@@ -38262,9 +38278,9 @@
 			package = 0C8FCE972E6725D700034ED3 /* XCRemoteSwiftPackageReference "web3swift" */;
 			productName = web3swift;
 		};
-		0C6A9E2C2E6B1FC40088C2BA /* RswiftGenerateInternalResources */ = {
+		0C6A9E2C2E6B1FC40088C2BA /* plugin:RswiftGenerateInternalResources */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = "plugin:RswiftGenerateInternalResources";
 		};
 		0C8FCE752E65ED3400034ED3 /* DGCharts */ = {
@@ -38309,7 +38325,7 @@
 		};
 		0C8FCEAD2E672CB000034ED3 /* Reachability */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability" */;
+			package = 0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability.swift" */;
 			productName = Reachability;
 		};
 		0C8FCEB02E672CFA00034ED3 /* SnapKit */ = {

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -6114,6 +6114,7 @@
 		B58BBAC3FFFA5037C970F14A /* WalletMigrateAcceptProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9A1BBDF1BE41D7E7A43423C /* WalletMigrateAcceptProtocols.swift */; };
 		B5998094F5FFAC894512CD12 /* StakingSetupAmountViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD38E012F7837AC692CA2C41 /* StakingSetupAmountViewLayout.swift */; };
 		B61457C5248F3B0E88A7990E /* ParaStkRebondPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F49B3B261FBA0B568A5320 /* ParaStkRebondPresenter.swift */; };
+		B615CBEDC7E7A5DE545A86D2 /* StakingNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5A431B31A14A4340E059AB /* StakingNotice.swift */; };
 		B65F3304C17AF5D15F0EA150 /* TransactionHistoryPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C67AB2EC2E4E8CB4358CA13 /* TransactionHistoryPresenter.swift */; };
 		B6D4C073B3F984FE0348B7D4 /* ParaStkYieldBoostStartInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0988D8EC0768B03BA7C55612 /* ParaStkYieldBoostStartInteractor.swift */; };
 		B6DB30A8D1BF84158CAC635D /* OperationDetailsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661356CFE77B978610397907 /* OperationDetailsInteractor.swift */; };
@@ -6535,6 +6536,7 @@
 		F85F1BCAD47F0596FBFBA110 /* ParaStkRebondWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2B583DB30C6C818B0F952D /* ParaStkRebondWireframe.swift */; };
 		F8617BB83CE091445E5087AD /* NetworkDetailsWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13222F73DF179169827365D5 /* NetworkDetailsWireframe.swift */; };
 		F88D85C73094F6A1FC494D87 /* DAppSearchWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A191B92AD171FDDDD8C30E2 /* DAppSearchWireframe.swift */; };
+		F8B173A791896A2B2D63E59F /* StakingNoticeDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A83B4F6B0C569E7056708A /* StakingNoticeDecodingTests.swift */; };
 		F8C0CA3DDBCB5E509295F099 /* MarkdownDescriptionViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF9ED27CF12B7DA8B1378CF /* MarkdownDescriptionViewFactory.swift */; };
 		F92E73C24AB577F37B35649E /* WalletConnectSessionDetailsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14339E7BE9FE045C6A2AB52 /* WalletConnectSessionDetailsInteractor.swift */; };
 		F9540A5C434F7E3CE6ED4EB4 /* NetworkManageNodePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78268D2C88E26B680F5CD09D /* NetworkManageNodePresenter.swift */; };
@@ -8141,6 +8143,7 @@
 		23CC3812E4DFC26484324D57 /* ReferendumVotersInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumVotersInteractor.swift; sourceTree = "<group>"; };
 		23EF6FA61F2B7E3B2ADD3200 /* NPoolsRedeemViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NPoolsRedeemViewLayout.swift; sourceTree = "<group>"; };
 		245DED717B5B3FC380C24E3D /* ChainAddressDetailsWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChainAddressDetailsWireframe.swift; sourceTree = "<group>"; };
+		24A83B4F6B0C569E7056708A /* StakingNoticeDecodingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNoticeDecodingTests.swift; sourceTree = "<group>"; };
 		24B23BAD22C87DA5F324B44F /* DAppAuthSettingsWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppAuthSettingsWireframe.swift; sourceTree = "<group>"; };
 		24D9C3BC1E7FECB8F51D78C6 /* MythosStkYourCollatorsViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MythosStkYourCollatorsViewFactory.swift; sourceTree = "<group>"; };
 		2501054499E73D89D5BFEB8E /* GenericLedgerAddEvmPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericLedgerAddEvmPresenter.swift; sourceTree = "<group>"; };
@@ -9670,6 +9673,7 @@
 		7C70EBF83B2547452417E588 /* StakingRewardDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingRewardDetailsViewController.swift; sourceTree = "<group>"; };
 		7CBA1296E4C6E04EC9C5CA98 /* ParaStkUnstakePresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParaStkUnstakePresenter.swift; sourceTree = "<group>"; };
 		7CD1FBC9C063951E2520265D /* SwapConfirmWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwapConfirmWireframe.swift; sourceTree = "<group>"; };
+		7D5A431B31A14A4340E059AB /* StakingNotice.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNotice.swift; sourceTree = "<group>"; };
 		7D8A9948F319AD0D154D1EC4 /* DelegationListViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DelegationListViewFactory.swift; sourceTree = "<group>"; };
 		7DDEB59CB3BDF9BDAAC4E3C5 /* StakingProxyManagementViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingProxyManagementViewFactory.swift; sourceTree = "<group>"; };
 		7DEDFCF115BB1015C928F3B2 /* PVWelcomeViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PVWelcomeViewLayout.swift; sourceTree = "<group>"; };
@@ -19911,6 +19915,14 @@
 			path = GovernanceNotifications;
 			sourceTree = "<group>";
 		};
+		7048CF740AEE4DA86903EEA1 /* StakingNotices */ = {
+			isa = PBXGroup;
+			children = (
+				7D5A431B31A14A4340E059AB /* StakingNotice.swift */,
+			);
+			path = StakingNotices;
+			sourceTree = "<group>";
+		};
 		7066B343B912F72345D541F2 /* StakingSetupAmount */ = {
 			isa = PBXGroup;
 			children = (
@@ -21186,6 +21198,7 @@
 				0C85FF2B2B6D23D600FC0014 /* ObservableSubscriptionSyncState.swift */,
 				0C0F6DC32D3FEDC800943A7C /* BaseObservableStateStore.swift */,
 				0CE862142D64B61C00245992 /* ObservableSubscriptionStateStore.swift */,
+				7048CF740AEE4DA86903EEA1 /* StakingNotices */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -22271,6 +22284,7 @@
 				84300B2D26C110C400D64514 /* ChainRegistry */,
 				8454C2822632FC2500657DAD /* ExtrinsicProcessingTests.swift */,
 				881BA30629DBCD6300EB8C48 /* Web3NameIntegrityVerifierTests.swift */,
+				BC608FF6BE344E75CD8DDE54 /* StakingNotices */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -29173,6 +29187,14 @@
 				88FB7DC9295070FC00784E08 /* Container */,
 			);
 			path = AssetDetails;
+			sourceTree = "<group>";
+		};
+		BC608FF6BE344E75CD8DDE54 /* StakingNotices */ = {
+			isa = PBXGroup;
+			children = (
+				24A83B4F6B0C569E7056708A /* StakingNoticeDecodingTests.swift */,
+			);
+			path = StakingNotices;
 			sourceTree = "<group>";
 		};
 		BCA8C0E50D704DA8031D1648 /* TransferNetworkSelection */ = {
@@ -36860,6 +36882,7 @@
 				F170C0900DB942030B2107C7 /* CrowdloanUnlockViewLayout.swift in Sources */,
 				6B19F3A772108FBED12A7260 /* CrowdloanUnlockViewFactory.swift in Sources */,
 				F6E167B893C1C2971A392C43 /* StakingDashboardTierConfig.swift in Sources */,
+				B615CBEDC7E7A5DE545A86D2 /* StakingNotice.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -37043,6 +37066,7 @@
 				8413B27A29507F3A00F8E2E4 /* DataProviderRepositoryStub.swift in Sources */,
 				F4897BB126AED13D0075F291 /* EraCountdownOperationFactoryStub.swift in Sources */,
 				952413819436984409450819 /* StakingDashboardBuilderDemotionTests.swift in Sources */,
+				F8B173A791896A2B2D63E59F /* StakingNoticeDecodingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1555,6 +1555,7 @@
 		270C21973CB61F0BF3D2D1E3 /* CrowdloanListProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ACCC85B2CCF3D9392CA9B4 /* CrowdloanListProtocols.swift */; };
 		2736BAABAE1389260A0B28D6 /* AssetListViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B754B68D6F1D1ED5C8577A5 /* AssetListViewFactory.swift */; };
 		27B7E98E6C41791F0DB7812F /* StakingNoticesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3372CF3A8A4C1B619AE35177 /* StakingNoticesProvider.swift */; };
+		AE4505AE363A49849F75E088 /* StakingNoticesFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED08394BFC7A40E781DD8133 /* StakingNoticesFacade.swift */; };
 		27B8E1662E12A34D00EB1F5B /* UniqueNftSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B8E15A2E12A34D00EB1F5B /* UniqueNftSyncService.swift */; };
 		27B8E16A2E12A5FA00EB1F5B /* UniqueDetailsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B8E1692E12A5F600EB1F5B /* UniqueDetailsInteractor.swift */; };
 		27B8E16C2E12B04400EB1F5B /* UniqueNftOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B8E16B2E12B04200EB1F5B /* UniqueNftOperationFactory.swift */; };
@@ -9017,6 +9018,7 @@
 		335E8C17DCB794733476AAE3 /* CollatorStakingConfirmViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollatorStakingConfirmViewController.swift; sourceTree = "<group>"; };
 		336395FFC4B2104A9651A2DE /* StakingRewardPayoutsViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingRewardPayoutsViewFactory.swift; sourceTree = "<group>"; };
 		3372CF3A8A4C1B619AE35177 /* StakingNoticesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNoticesProvider.swift; sourceTree = "<group>"; };
+		ED08394BFC7A40E781DD8133 /* StakingNoticesFacade.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNoticesFacade.swift; sourceTree = "<group>"; };
 		337EC62037D657258BCBC02F /* DAppWalletAuthInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppWalletAuthInteractor.swift; sourceTree = "<group>"; };
 		33A3AA54AA204AE7A1D71881 /* CustomNetworkViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomNetworkViewController.swift; sourceTree = "<group>"; };
 		33DFAA0EEEA7F99C6D1CF4B1 /* ReferendumFullDetailsPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumFullDetailsPresenter.swift; sourceTree = "<group>"; };
@@ -19957,6 +19959,7 @@
 				7D5A431B31A14A4340E059AB /* StakingNotice.swift */,
 				CBF099C2ABFD38C77D6133B8 /* StakingNoticesProviderProtocol.swift */,
 				3372CF3A8A4C1B619AE35177 /* StakingNoticesProvider.swift */,
+				ED08394BFC7A40E781DD8133 /* StakingNoticesFacade.swift */,
 			);
 			path = StakingNotices;
 			sourceTree = "<group>";
@@ -36933,6 +36936,7 @@
 				B615CBEDC7E7A5DE545A86D2 /* StakingNotice.swift in Sources */,
 				335EFDB7D2137F266E13B6B8 /* StakingNoticesProviderProtocol.swift in Sources */,
 				27B7E98E6C41791F0DB7812F /* StakingNoticesProvider.swift in Sources */,
+				AE4505AE363A49849F75E088 /* StakingNoticesFacade.swift in Sources */,
 				6039E27966BEC34A604AA853 /* StartStakingCriticalNoticeSheetProtocols.swift in Sources */,
 				1C8977A706F69B75E0FE0A49 /* StartStakingCriticalNoticeSheetViewLayout.swift in Sources */,
 				E360DB6581DF55686BF6B570 /* StartStakingCriticalNoticeSheetViewController.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1555,7 +1555,6 @@
 		270C21973CB61F0BF3D2D1E3 /* CrowdloanListProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ACCC85B2CCF3D9392CA9B4 /* CrowdloanListProtocols.swift */; };
 		2736BAABAE1389260A0B28D6 /* AssetListViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B754B68D6F1D1ED5C8577A5 /* AssetListViewFactory.swift */; };
 		27B7E98E6C41791F0DB7812F /* StakingNoticesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3372CF3A8A4C1B619AE35177 /* StakingNoticesProvider.swift */; };
-		AE4505AE363A49849F75E088 /* StakingNoticesFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED08394BFC7A40E781DD8133 /* StakingNoticesFacade.swift */; };
 		27B8E1662E12A34D00EB1F5B /* UniqueNftSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B8E15A2E12A34D00EB1F5B /* UniqueNftSyncService.swift */; };
 		27B8E16A2E12A5FA00EB1F5B /* UniqueDetailsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B8E1692E12A5F600EB1F5B /* UniqueDetailsInteractor.swift */; };
 		27B8E16C2E12B04400EB1F5B /* UniqueNftOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B8E16B2E12B04200EB1F5B /* UniqueNftOperationFactory.swift */; };
@@ -3424,6 +3423,7 @@
 		7E8C10658FEAD469F5DFEDFA /* GiftPrepareSharePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636452DDE0D956DE05A73278 /* GiftPrepareSharePresenter.swift */; };
 		7F09593FCC1F032F7B8DF90F /* DAppBrowserWidgetViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22987F2F731F702564980965 /* DAppBrowserWidgetViewFactory.swift */; };
 		7F5B03517FD0144F7EDE1015 /* YourWalletsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7A019F89C6CD418AEEE79C /* YourWalletsPresenter.swift */; };
+		7FC84DA52FB74CFCBEC91D02 /* StartStakingInfoCriticalNoticeInterceptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8931422713BDCABCDDE84978 /* StartStakingInfoCriticalNoticeInterceptTests.swift */; };
 		7FF2D6FEDD352AC51E1DBB3B /* OperationDetailsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2A26EC9537BD4275A03272 /* OperationDetailsPresenter.swift */; };
 		7FFC31C4522B008864CB0B99 /* CloudBackupSettingsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8CE3D9F9EFB6852E99B972 /* CloudBackupSettingsProtocols.swift */; };
 		800FCAF66DC8A24020D16A9C /* AccountExportPasswordInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194C9BFEE9BA8C9E448D79AA /* AccountExportPasswordInteractor.swift */; };
@@ -5995,6 +5995,7 @@
 		AE3983A2272C08AE00BC8A85 /* BaseAccountImportPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3983A1272C08AD00BC8A85 /* BaseAccountImportPresenter.swift */; };
 		AE3983A5272C0BC800BC8A85 /* ImportChainAccount+AccountImportPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3983A4272C0BC800BC8A85 /* ImportChainAccount+AccountImportPresenter.swift */; };
 		AE416368E5CDCEE35181660B /* BackupMnemonicCardProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3CA17CF05C4F6C396AEA9D3 /* BackupMnemonicCardProtocols.swift */; };
+		AE4505AE363A49849F75E088 /* StakingNoticesFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED08394BFC7A40E781DD8133 /* StakingNoticesFacade.swift */; };
 		AE4A71D42607B1440017C663 /* NetworkStakingInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE4A71D32607B1440017C663 /* NetworkStakingInfoViewModel.swift */; };
 		AE4C53E5268C6F8300B03CE8 /* ValidatorListFilterSortCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE4C53E4268C6F8300B03CE8 /* ValidatorListFilterSortCell.swift */; };
 		AE528E4D26852C380058935A /* ValidatorSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE528E4C26852C380058935A /* ValidatorSearchViewModel.swift */; };
@@ -9018,7 +9019,6 @@
 		335E8C17DCB794733476AAE3 /* CollatorStakingConfirmViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollatorStakingConfirmViewController.swift; sourceTree = "<group>"; };
 		336395FFC4B2104A9651A2DE /* StakingRewardPayoutsViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingRewardPayoutsViewFactory.swift; sourceTree = "<group>"; };
 		3372CF3A8A4C1B619AE35177 /* StakingNoticesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNoticesProvider.swift; sourceTree = "<group>"; };
-		ED08394BFC7A40E781DD8133 /* StakingNoticesFacade.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNoticesFacade.swift; sourceTree = "<group>"; };
 		337EC62037D657258BCBC02F /* DAppWalletAuthInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppWalletAuthInteractor.swift; sourceTree = "<group>"; };
 		33A3AA54AA204AE7A1D71881 /* CustomNetworkViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomNetworkViewController.swift; sourceTree = "<group>"; };
 		33DFAA0EEEA7F99C6D1CF4B1 /* ReferendumFullDetailsPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumFullDetailsPresenter.swift; sourceTree = "<group>"; };
@@ -12099,6 +12099,7 @@
 		88FF5C7B29C8360400D1CB5D /* Caip19+ParseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Caip19+ParseError.swift"; sourceTree = "<group>"; };
 		88FF5C7E29C8364500D1CB5D /* Caip2+ParseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Caip2+ParseError.swift"; sourceTree = "<group>"; };
 		891FBCE49A51A9120ED9F861 /* AssetOperationNetworkListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetOperationNetworkListViewController.swift; sourceTree = "<group>"; };
+		8931422713BDCABCDDE84978 /* StartStakingInfoCriticalNoticeInterceptTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StartStakingInfoCriticalNoticeInterceptTests.swift; sourceTree = "<group>"; };
 		894A6BB613EA991A09976B30 /* NominationPoolBondMoreConfirmProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NominationPoolBondMoreConfirmProtocols.swift; sourceTree = "<group>"; };
 		8963C0A6A643F8ABD19AD6B3 /* GovernanceNotificationsInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceNotificationsInteractor.swift; sourceTree = "<group>"; };
 		899686C7351A2600FFA08371 /* TransferConfirmOnChainViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransferConfirmOnChainViewFactory.swift; sourceTree = "<group>"; };
@@ -12732,6 +12733,7 @@
 		ECB223B6CC6ADD2A804FC2CD /* NotificationsSetupViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationsSetupViewController.swift; sourceTree = "<group>"; };
 		ECB56DD69C433B473E65C7EB /* AssetReceiveViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetReceiveViewController.swift; sourceTree = "<group>"; };
 		ED010772D7CE0450BDF30707 /* CollatorStakingSelectFiltersViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollatorStakingSelectFiltersViewFactory.swift; sourceTree = "<group>"; };
+		ED08394BFC7A40E781DD8133 /* StakingNoticesFacade.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNoticesFacade.swift; sourceTree = "<group>"; };
 		ED5CED3C58CD433B19978EC4 /* TransferOnChainConfirmInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransferOnChainConfirmInteractor.swift; sourceTree = "<group>"; };
 		ED66939D92756F608FA11520 /* DAppListPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppListPresenter.swift; sourceTree = "<group>"; };
 		EDB9EDB05686DF11958145E1 /* ControllerAccountWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ControllerAccountWireframe.swift; sourceTree = "<group>"; };
@@ -19357,6 +19359,15 @@
 			path = YourDelegations;
 			sourceTree = "<group>";
 		};
+		36AA9297111A6044D7A3EE6C /* StartStakingInfo */ = {
+			isa = PBXGroup;
+			children = (
+				8931422713BDCABCDDE84978 /* StartStakingInfoCriticalNoticeInterceptTests.swift */,
+			);
+			name = StartStakingInfo;
+			path = StartStakingInfo;
+			sourceTree = "<group>";
+		};
 		37A08AC22D31094D2909AC22 /* MythosStkUnstakeConfirm */ = {
 			isa = PBXGroup;
 			children = (
@@ -25823,6 +25834,7 @@
 				84B7C6EC289BFA79001A3566 /* StakingRewardPayouts */,
 				84B7C6EF289BFA79001A3566 /* StakingRebondConfirmation */,
 				712E58E9FBB81162E73689F4 /* Dashboard */,
+				36AA9297111A6044D7A3EE6C /* StartStakingInfo */,
 			);
 			path = Staking;
 			sourceTree = "<group>";
@@ -37127,6 +37139,7 @@
 				952413819436984409450819 /* StakingDashboardBuilderDemotionTests.swift in Sources */,
 				F8B173A791896A2B2D63E59F /* StakingNoticeDecodingTests.swift in Sources */,
 				9D7946C0DFCBF68F3C7B74CA /* StakingNoticesProviderTests.swift in Sources */,
+				7FC84DA52FB74CFCBEC91D02 /* StartStakingInfoCriticalNoticeInterceptTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -19933,7 +19933,7 @@
 			children = (
 				E70949B5D9B0DE71569F3884 /* StakingDashboardBuilderDemotionTests.swift */,
 			);
-			name = Dashboard;
+			path = Dashboard;
 			sourceTree = "<group>";
 		};
 		71E66F0C5FF36EBFFEA3D807 /* DelegationReferendumVoters */ = {

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -4896,6 +4896,7 @@
 		84B24FAC2A2F25FF00F9BF59 /* StakingDashboardActiveDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B24FAB2A2F25FF00F9BF59 /* StakingDashboardActiveDetailsView.swift */; };
 		84B24FAE2A2F6BEB00F9BF59 /* StakingDashboardInactiveCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B24FAD2A2F6BEB00F9BF59 /* StakingDashboardInactiveCell.swift */; };
 		84B24FB02A2F7B6F00F9BF59 /* StakingDashboardMoreOptionsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B24FAF2A2F7B6F00F9BF59 /* StakingDashboardMoreOptionsCell.swift */; };
+		2D93243F18EC4C2AB35F8DA7 /* NoticeStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5B2AAF21454A168DBD07C3 /* NoticeStripView.swift */; };
 		84B28FC428C54441007A1006 /* OnChainTransferAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B28FC328C54441007A1006 /* OnChainTransferAmount.swift */; };
 		84B5DE53283F7BE500193ED3 /* CollatorsSortType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B5DE52283F7BE500193ED3 /* CollatorsSortType.swift */; };
 		84B5DE56283F7C8500193ED3 /* CollatorSelectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B5DE55283F7C8500193ED3 /* CollatorSelectionCell.swift */; };
@@ -11178,6 +11179,7 @@
 		84B24FAB2A2F25FF00F9BF59 /* StakingDashboardActiveDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingDashboardActiveDetailsView.swift; sourceTree = "<group>"; };
 		84B24FAD2A2F6BEB00F9BF59 /* StakingDashboardInactiveCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingDashboardInactiveCell.swift; sourceTree = "<group>"; };
 		84B24FAF2A2F7B6F00F9BF59 /* StakingDashboardMoreOptionsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingDashboardMoreOptionsCell.swift; sourceTree = "<group>"; };
+		EA5B2AAF21454A168DBD07C3 /* NoticeStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStripView.swift; sourceTree = "<group>"; };
 		84B28FC328C54441007A1006 /* OnChainTransferAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChainTransferAmount.swift; sourceTree = "<group>"; };
 		84B5DE52283F7BE500193ED3 /* CollatorsSortType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollatorsSortType.swift; sourceTree = "<group>"; };
 		84B5DE55283F7C8500193ED3 /* CollatorSelectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollatorSelectionCell.swift; sourceTree = "<group>"; };
@@ -25552,6 +25554,7 @@
 				84B24FAB2A2F25FF00F9BF59 /* StakingDashboardActiveDetailsView.swift */,
 				84B24FAD2A2F6BEB00F9BF59 /* StakingDashboardInactiveCell.swift */,
 				84B24FAF2A2F7B6F00F9BF59 /* StakingDashboardMoreOptionsCell.swift */,
+				EA5B2AAF21454A168DBD07C3 /* NoticeStripView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -33347,6 +33350,7 @@
 				2D0C96F32EC9F2300034F9F8 /* GiftsLocalStorageSubscriber.swift in Sources */,
 				843612BD278FE54D00DC739E /* DAppOperationConfirmInteractor+Protocol.swift in Sources */,
 				84B24FA62A2F232700F9BF59 /* StakingDashboardActiveCell.swift in Sources */,
+				2D93243F18EC4C2AB35F8DA7 /* NoticeStripView.swift in Sources */,
 				0CCA70732CD0A4FD0082A9C8 /* CrosschainExchangeAtomicOperation.swift in Sources */,
 				84E0EE0A292D3CB4008B2953 /* GovernanceChainSelectionWireframe.swift in Sources */,
 				844DBC5E274D1B13009F8351 /* IconWithTitleSubtitleTableViewCell.swift in Sources */,

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1511,6 +1511,7 @@
 		1C50003ECAFD943EB67B092D /* BannersWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D0CB9381AF203E5730CD35 /* BannersWireframe.swift */; };
 		1C57B1089303D97A92A5EE85 /* ManualBackupWalletListProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F3840B111A3B0234F0C7FA /* ManualBackupWalletListProtocols.swift */; };
 		1C601EB98E9DA39FA808D83B /* GenericLedgerAddEvmWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF47A33418B791076057967 /* GenericLedgerAddEvmWireframe.swift */; };
+		1C8977A706F69B75E0FE0A49 /* StartStakingCriticalNoticeSheetViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD74A31C819BDADA5062CF5 /* StartStakingCriticalNoticeSheetViewLayout.swift */; };
 		1C8D1041448B8FB9DD9BBCF1 /* YourWalletsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C5AF7E89A8C6CFF5AE03B1 /* YourWalletsProtocols.swift */; };
 		1C9EA26D4E4BA6BAE147B374 /* GovernanceDelegateConfirmWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43F25AF006B7B19281AC7B1 /* GovernanceDelegateConfirmWireframe.swift */; };
 		1CD99FC2F2D45A3BF6AA1E00 /* CloudBackupAddWalletInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E32BD0DD899F0FA996D02C55 /* CloudBackupAddWalletInteractor.swift */; };
@@ -1595,6 +1596,7 @@
 		2B0B3DE595860BCA13DD745E /* SwipeGovReferendumDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD4A85869898653E7FF8BAA0 /* SwipeGovReferendumDetailsViewController.swift */; };
 		2B287EEF431ED9FE9510BAA4 /* ReferendumFullDetailsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DFAA0EEEA7F99C6D1CF4B1 /* ReferendumFullDetailsPresenter.swift */; };
 		2B574C3229CE5DFC5DCCEEF3 /* StakingRewardsNotificationsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC2769454CA2CE2529278ED /* StakingRewardsNotificationsInteractor.swift */; };
+		2B6075191F708013ABA4C7E9 /* StartStakingCriticalNoticeSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E254B4D1CF9B035B9287B3CA /* StartStakingCriticalNoticeSheetPresenter.swift */; };
 		2B682D343F75EBEB8A1E65BD /* DAppAuthSettingsViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C144CEF4852B97149A1848 /* DAppAuthSettingsViewLayout.swift */; };
 		2BB0D54988107FA0C484C530 /* ParaStkSelectCollatorsWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BE9DEF100A373868EDD03F /* ParaStkSelectCollatorsWireframe.swift */; };
 		2BBA744323AA0BF6FE53C212 /* CollatorStakingSelectProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20878E303E9332322655F008 /* CollatorStakingSelectProtocols.swift */; };
@@ -2069,6 +2071,7 @@
 		2D8FDEB12D06F22F008D0E28 /* DAppListViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8FDEB02D06F22F008D0E28 /* DAppListViewController+DataSource.swift */; };
 		2D8FF9D02C9AA54000089F53 /* BaseReferendumVoteConfirmPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8FF9CF2C9AA54000089F53 /* BaseReferendumVoteConfirmPresenter.swift */; };
 		2D8FF9D32C9BD67500089F53 /* SwipeGovAlertPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8FF9D22C9BD67500089F53 /* SwipeGovAlertPresentable.swift */; };
+		2D93243F18EC4C2AB35F8DA7 /* NoticeStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5B2AAF21454A168DBD07C3 /* NoticeStripView.swift */; };
 		2D94C26D2E58CE4D0057A887 /* MultisigNotificationAccounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D94C26C2E58CE4D0057A887 /* MultisigNotificationAccounts.swift */; };
 		2D94C26E2E58CE6F0057A887 /* MultisigNotificationAccounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D94C26C2E58CE4D0057A887 /* MultisigNotificationAccounts.swift */; };
 		2D95DF5D2C6F9129009BB063 /* HydraExtrinsicFeeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D95DF5C2C6F9129009BB063 /* HydraExtrinsicFeeInstaller.swift */; };
@@ -2881,6 +2884,7 @@
 		5FE687B860FC10AB08518A6E /* WalletHistoryFilterPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9150FEC66FC503CF1BD1D0 /* WalletHistoryFilterPresenter.swift */; };
 		5FF13D27B596CD7B0CA20671 /* NominationPoolBondMoreSetupViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF2717F0CC0A4529C925814 /* NominationPoolBondMoreSetupViewLayout.swift */; };
 		6003DF3EBB77510EFB70B4E4 /* MessageSheetProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C797A5B5863A026E84062AE /* MessageSheetProtocols.swift */; };
+		6039E27966BEC34A604AA853 /* StartStakingCriticalNoticeSheetProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74D4E8CE2D40A7FF8F5AA9B /* StartStakingCriticalNoticeSheetProtocols.swift */; };
 		60461B20A5DA9E9E3AF0BB84 /* WalletHistoryFilterWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78670B0926E92B75088D2D7B /* WalletHistoryFilterWireframe.swift */; };
 		605E6155151906B249D6EBBB /* GiftClaimInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4F448C77878443102B9D90 /* GiftClaimInteractor.swift */; };
 		607DA34F14C0A894D4D16216 /* BackupMnemonicCardViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DD6F8FF5A73F29F7980D4F /* BackupMnemonicCardViewLayout.swift */; };
@@ -3414,6 +3418,7 @@
 		7DB7E81CC2F880E4736DE062 /* GovernanceUnlockConfirmViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE81AE154A736A93FF3812B /* GovernanceUnlockConfirmViewLayout.swift */; };
 		7E1A03082260E0D31AD394CA /* StakingRewardDetailsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF891BE39D442C2D06DDF3BB /* StakingRewardDetailsProtocols.swift */; };
 		7E5ACF8DDF17C054E6E1B3D5 /* ParaStkYieldBoostSetupWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2B3C9875FDA7EE8D168900 /* ParaStkYieldBoostSetupWireframe.swift */; };
+		7E5ADAB8DC8E0E42E9ABF4FD /* StartStakingCriticalNoticeSheetViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAE32504DE539FF5B3A35C /* StartStakingCriticalNoticeSheetViewFactory.swift */; };
 		7E710E6BE9C41940ACFA3B8C /* CloudBackupSettingsViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E39B6469E7FF5F830E6063 /* CloudBackupSettingsViewLayout.swift */; };
 		7E8C10658FEAD469F5DFEDFA /* GiftPrepareSharePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636452DDE0D956DE05A73278 /* GiftPrepareSharePresenter.swift */; };
 		7F09593FCC1F032F7B8DF90F /* DAppBrowserWidgetViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22987F2F731F702564980965 /* DAppBrowserWidgetViewFactory.swift */; };
@@ -4362,7 +4367,6 @@
 		847449512891F3B00042FD80 /* WalletSwitchControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847449502891F3B00042FD80 /* WalletSwitchControl.swift */; };
 		84744953289268770042FD80 /* WalletSwitchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84744952289268770042FD80 /* WalletSwitchViewModel.swift */; };
 		84744955289284F50042FD80 /* StakingMainViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84744954289284F50042FD80 /* StakingMainViewLayout.swift */; };
-		C1C65F63ABA4EA410BA9A98B /* StakingNoticeBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6521517DD9A8185C032DFB /* StakingNoticeBlockView.swift */; };
 		84746B3028153E4C002642F4 /* GradientBannerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84746B2F28153E4C002642F4 /* GradientBannerModel.swift */; };
 		84754C852510A1A400854599 /* ModalAlertPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84754C842510A1A400854599 /* ModalAlertPresenting.swift */; };
 		84754C882510BAFE00854599 /* ModalAlertFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84754C872510BAFE00854599 /* ModalAlertFactory.swift */; };
@@ -4897,7 +4901,6 @@
 		84B24FAC2A2F25FF00F9BF59 /* StakingDashboardActiveDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B24FAB2A2F25FF00F9BF59 /* StakingDashboardActiveDetailsView.swift */; };
 		84B24FAE2A2F6BEB00F9BF59 /* StakingDashboardInactiveCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B24FAD2A2F6BEB00F9BF59 /* StakingDashboardInactiveCell.swift */; };
 		84B24FB02A2F7B6F00F9BF59 /* StakingDashboardMoreOptionsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B24FAF2A2F7B6F00F9BF59 /* StakingDashboardMoreOptionsCell.swift */; };
-		2D93243F18EC4C2AB35F8DA7 /* NoticeStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5B2AAF21454A168DBD07C3 /* NoticeStripView.swift */; };
 		84B28FC428C54441007A1006 /* OnChainTransferAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B28FC328C54441007A1006 /* OnChainTransferAmount.swift */; };
 		84B5DE53283F7BE500193ED3 /* CollatorsSortType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B5DE52283F7BE500193ED3 /* CollatorsSortType.swift */; };
 		84B5DE56283F7C8500193ED3 /* CollatorSelectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B5DE55283F7C8500193ED3 /* CollatorSelectionCell.swift */; };
@@ -6174,6 +6177,7 @@
 		C122F2FE976FEE9A609A1A93 /* DAppOperationConfirmPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C50BB281AD6DB3CF1493958 /* DAppOperationConfirmPresenter.swift */; };
 		C18124044388698CB0BE8947 /* ParaStkStakeConfirmWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CB6BF970620958C9DDD037 /* ParaStkStakeConfirmWireframe.swift */; };
 		C19EF49636E698D87D5D18FA /* ParaStkYieldBoostSetupViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63ECD1205B2CCCDA2E66A1E /* ParaStkYieldBoostSetupViewLayout.swift */; };
+		C1C65F63ABA4EA410BA9A98B /* StakingNoticeBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6521517DD9A8185C032DFB /* StakingNoticeBlockView.swift */; };
 		C1E74FC31BFB401B1745C2E8 /* GovernanceRemoveVotesConfirmInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9035D0F739C88CCBE11E886 /* GovernanceRemoveVotesConfirmInteractor.swift */; };
 		C21129B2B8D8B33BCBD5843E /* StakingRedeemViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8821119C96944A0E3526E93A /* StakingRedeemViewFactory.swift */; };
 		C25AA1549353E61CAED8E3D4 /* NetworksListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7FAF5A236F05902A612A70 /* NetworksListInteractor.swift */; };
@@ -6350,6 +6354,7 @@
 		E2F3E726280823CF00CF31B5 /* ETHAccountInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F3E725280823CF00CF31B5 /* ETHAccountInjection.swift */; };
 		E2F9D7BDDE961B162EF100AB /* StakingMainViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A825B6368073B06F32D7C8F /* StakingMainViewFactory.swift */; };
 		E325FBFE10A037E58525DA66 /* DAppSearchViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF9C192200F9B998724FC6C /* DAppSearchViewFactory.swift */; };
+		E360DB6581DF55686BF6B570 /* StartStakingCriticalNoticeSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1E07729D701623B0B8AB2E /* StartStakingCriticalNoticeSheetViewController.swift */; };
 		E3765FB9E68018936E951FBD /* TokensManageViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B778B6EC447C0B55110638 /* TokensManageViewLayout.swift */; };
 		E37BB7A393FFEFC350B4EA3D /* AdvancedWalletProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0043E77B2DBB3546A9E54C4B /* AdvancedWalletProtocols.swift */; };
 		E4021A6E90432CC5C797A647 /* ReferendumVotersWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FBF368FBB46AD4DE606DB1 /* ReferendumVotersWireframe.swift */; };
@@ -9284,9 +9289,11 @@
 		6A6BCE8F8DB7576E1E5B5974 /* SwapSetupViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwapSetupViewFactory.swift; sourceTree = "<group>"; };
 		6A7302440137F083F7AEC64E /* StakingClaimRewardsViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingClaimRewardsViewLayout.swift; sourceTree = "<group>"; };
 		6A825B6368073B06F32D7C8F /* StakingMainViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingMainViewFactory.swift; sourceTree = "<group>"; };
+		6AD74A31C819BDADA5062CF5 /* StartStakingCriticalNoticeSheetViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StartStakingCriticalNoticeSheetViewLayout.swift; sourceTree = "<group>"; };
 		6AD8B98AB03AAF06AA891695 /* TransferConfirmViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransferConfirmViewLayout.swift; sourceTree = "<group>"; };
 		6B0DCF5B544D9B2719CAECF8 /* MythosStkYourCollatorsProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MythosStkYourCollatorsProtocols.swift; sourceTree = "<group>"; };
 		6B60728FCFBC8A9BE4C7B50B /* YourValidatorListInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = YourValidatorListInteractor.swift; sourceTree = "<group>"; };
+		6B6521517DD9A8185C032DFB /* StakingNoticeBlockView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNoticeBlockView.swift; sourceTree = "<group>"; };
 		6BA14E9659FC44A438FFEEB5 /* ParitySignerTxQrWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParitySignerTxQrWireframe.swift; sourceTree = "<group>"; };
 		6C1179A25C22AF0875A1ADCD /* AssetReceiveWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetReceiveWireframe.swift; sourceTree = "<group>"; };
 		6C1CBCD5B3AE3E88244C50F5 /* BannersPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BannersPresenter.swift; sourceTree = "<group>"; };
@@ -10637,7 +10644,6 @@
 		847449502891F3B00042FD80 /* WalletSwitchControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSwitchControl.swift; sourceTree = "<group>"; };
 		84744952289268770042FD80 /* WalletSwitchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSwitchViewModel.swift; sourceTree = "<group>"; };
 		84744954289284F50042FD80 /* StakingMainViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingMainViewLayout.swift; sourceTree = "<group>"; };
-		6B6521517DD9A8185C032DFB /* StakingNoticeBlockView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNoticeBlockView.swift; sourceTree = "<group>"; };
 		84746B2F28153E4C002642F4 /* GradientBannerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientBannerModel.swift; sourceTree = "<group>"; };
 		84754C842510A1A400854599 /* ModalAlertPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalAlertPresenting.swift; sourceTree = "<group>"; };
 		84754C872510BAFE00854599 /* ModalAlertFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalAlertFactory.swift; sourceTree = "<group>"; };
@@ -11181,7 +11187,6 @@
 		84B24FAB2A2F25FF00F9BF59 /* StakingDashboardActiveDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingDashboardActiveDetailsView.swift; sourceTree = "<group>"; };
 		84B24FAD2A2F6BEB00F9BF59 /* StakingDashboardInactiveCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingDashboardInactiveCell.swift; sourceTree = "<group>"; };
 		84B24FAF2A2F7B6F00F9BF59 /* StakingDashboardMoreOptionsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingDashboardMoreOptionsCell.swift; sourceTree = "<group>"; };
-		EA5B2AAF21454A168DBD07C3 /* NoticeStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStripView.swift; sourceTree = "<group>"; };
 		84B28FC328C54441007A1006 /* OnChainTransferAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChainTransferAmount.swift; sourceTree = "<group>"; };
 		84B5DE52283F7BE500193ED3 /* CollatorsSortType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollatorsSortType.swift; sourceTree = "<group>"; };
 		84B5DE55283F7C8500193ED3 /* CollatorSelectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollatorSelectionCell.swift; sourceTree = "<group>"; };
@@ -12297,6 +12302,7 @@
 		ACE1E9C7AE1788A0E4A45A88 /* AddDelegationViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddDelegationViewFactory.swift; sourceTree = "<group>"; };
 		AD0186D779597EAA44B8B188 /* LedgerWalletAccountConfirmationInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LedgerWalletAccountConfirmationInteractor.swift; sourceTree = "<group>"; };
 		AD1CAB4467C76E4139ECB1B7 /* ReferendumVoteConfirmViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumVoteConfirmViewFactory.swift; sourceTree = "<group>"; };
+		AD1E07729D701623B0B8AB2E /* StartStakingCriticalNoticeSheetViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StartStakingCriticalNoticeSheetViewController.swift; sourceTree = "<group>"; };
 		AD26E02E5EA85D22062142CD /* CloudBackupCreateViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudBackupCreateViewFactory.swift; sourceTree = "<group>"; };
 		AD4A85869898653E7FF8BAA0 /* SwipeGovReferendumDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwipeGovReferendumDetailsViewController.swift; sourceTree = "<group>"; };
 		ADBC3405EEB1F8941FB19BAA /* TokenManageSingleViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenManageSingleViewController.swift; sourceTree = "<group>"; };
@@ -12486,6 +12492,7 @@
 		BD6328AE79C92A96D9E8C04B /* WalletImportOptionsPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletImportOptionsPresenter.swift; sourceTree = "<group>"; };
 		BD70B47DF7F9DE75CE7AE33F /* ParitySignerTxQrProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParitySignerTxQrProtocols.swift; sourceTree = "<group>"; };
 		BD8D3BC1137332FA3CC1FEF2 /* ReferendumSearchViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumSearchViewController.swift; sourceTree = "<group>"; };
+		BDDAE32504DE539FF5B3A35C /* StartStakingCriticalNoticeSheetViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StartStakingCriticalNoticeSheetViewFactory.swift; sourceTree = "<group>"; };
 		BDDF93DE09809357AA1AC13D /* ManualBackupWalletListPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualBackupWalletListPresenter.swift; sourceTree = "<group>"; };
 		BE0F7D4389B932A1F2E17361 /* DAppSearchViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppSearchViewLayout.swift; sourceTree = "<group>"; };
 		BE103341935B2A4B8C32B966 /* WalletConnectSessionDetailsViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletConnectSessionDetailsViewFactory.swift; sourceTree = "<group>"; };
@@ -12523,6 +12530,7 @@
 		C686D9318F0F6ED2F1E4883A /* WalletMigrateAcceptWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletMigrateAcceptWireframe.swift; sourceTree = "<group>"; };
 		C6A61D7A529DB2412430DA1C /* StakingProxyManagementPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingProxyManagementPresenter.swift; sourceTree = "<group>"; };
 		C74A2166B054240BD5D925B6 /* UsernameSetupViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UsernameSetupViewFactory.swift; sourceTree = "<group>"; };
+		C74D4E8CE2D40A7FF8F5AA9B /* StartStakingCriticalNoticeSheetProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StartStakingCriticalNoticeSheetProtocols.swift; sourceTree = "<group>"; };
 		C7639361A3B8C325C29EBF4B /* MythosStakingConfirmWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MythosStakingConfirmWireframe.swift; sourceTree = "<group>"; };
 		C7713623A2DBA76A1D31A557 /* DelegatedSignValidationPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DelegatedSignValidationPresenter.swift; sourceTree = "<group>"; };
 		C7F910E56C2CC7AA5224BD21 /* SwapSetupWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwapSetupWireframe.swift; sourceTree = "<group>"; };
@@ -12668,6 +12676,7 @@
 		E1E60EF37AC0A7646ED8FE64 /* AccountImportViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountImportViewFactory.swift; sourceTree = "<group>"; };
 		E20124142C4011901EF55AAA /* HardwareWalletAddressesViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HardwareWalletAddressesViewLayout.swift; sourceTree = "<group>"; };
 		E245CA0789F68382248F42C1 /* OnboardingWalletReadyViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingWalletReadyViewController.swift; sourceTree = "<group>"; };
+		E254B4D1CF9B035B9287B3CA /* StartStakingCriticalNoticeSheetPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StartStakingCriticalNoticeSheetPresenter.swift; sourceTree = "<group>"; };
 		E283DABBC3BA910B8FC92271 /* NetworkManageNodeViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkManageNodeViewLayout.swift; sourceTree = "<group>"; };
 		E29DAC8F2DB0F7BF909812FA /* DAppTxDetailsViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppTxDetailsViewLayout.swift; sourceTree = "<group>"; };
 		E2E005960E331E8882A8C6FD /* StakingRebagConfirmWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingRebagConfirmWireframe.swift; sourceTree = "<group>"; };
@@ -12711,6 +12720,7 @@
 		E9C562B800791237E371456F /* NotificationsSetupProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationsSetupProtocols.swift; sourceTree = "<group>"; };
 		E9F49B3B261FBA0B568A5320 /* ParaStkRebondPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParaStkRebondPresenter.swift; sourceTree = "<group>"; };
 		E9FBF368FBB46AD4DE606DB1 /* ReferendumVotersWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumVotersWireframe.swift; sourceTree = "<group>"; };
+		EA5B2AAF21454A168DBD07C3 /* NoticeStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStripView.swift; sourceTree = "<group>"; };
 		EAF2717F0CC0A4529C925814 /* NominationPoolBondMoreSetupViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NominationPoolBondMoreSetupViewLayout.swift; sourceTree = "<group>"; };
 		EB1764F0D73F5D0564BA7C30 /* MythosStkClaimRewardsInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MythosStkClaimRewardsInteractor.swift; sourceTree = "<group>"; };
 		EB8605FD90D8C3553A9897B4 /* AccountImportPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountImportPresenter.swift; sourceTree = "<group>"; };
@@ -16480,6 +16490,22 @@
 				0C0F6E0C2D43C85400943A7C /* CollatorStakingInfoViewFactory+Mythos.swift */,
 			);
 			path = CollatorInfo;
+			sourceTree = "<group>";
+		};
+		1FDD840983ED062936C0279F /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				21F3B1AC0F656C99BC4699B7 /* Views */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		21F3B1AC0F656C99BC4699B7 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				6B6521517DD9A8185C032DFB /* StakingNoticeBlockView.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		22EC1C74711D9EF8A3277AF7 /* SwipeGov */ = {
@@ -20762,6 +20788,11 @@
 				77F1893F2A49972300E8B933 /* UILabel+bind.swift */,
 				77F189432A49974A00E8B933 /* UITextView+bind.swift */,
 				B9D4A8C06D94C748124E6AA5 /* StartStakingInfoViewLayout.swift */,
+				C74D4E8CE2D40A7FF8F5AA9B /* StartStakingCriticalNoticeSheetProtocols.swift */,
+				6AD74A31C819BDADA5062CF5 /* StartStakingCriticalNoticeSheetViewLayout.swift */,
+				AD1E07729D701623B0B8AB2E /* StartStakingCriticalNoticeSheetViewController.swift */,
+				E254B4D1CF9B035B9287B3CA /* StartStakingCriticalNoticeSheetPresenter.swift */,
+				BDDAE32504DE539FF5B3A35C /* StartStakingCriticalNoticeSheetViewFactory.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -29149,22 +29180,6 @@
 			path = AssetOperationNetworkList;
 			sourceTree = "<group>";
 		};
-		1FDD840983ED062936C0279F /* Common */ = {
-			isa = PBXGroup;
-			children = (
-				21F3B1AC0F656C99BC4699B7 /* Views */,
-			);
-			path = Common;
-			sourceTree = "<group>";
-		};
-		21F3B1AC0F656C99BC4699B7 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				6B6521517DD9A8185C032DFB /* StakingNoticeBlockView.swift */,
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
 		B7B0681CCE8F8F0127E8676C /* StakingMain */ = {
 			isa = PBXGroup;
 			children = (
@@ -36918,6 +36933,11 @@
 				B615CBEDC7E7A5DE545A86D2 /* StakingNotice.swift in Sources */,
 				335EFDB7D2137F266E13B6B8 /* StakingNoticesProviderProtocol.swift in Sources */,
 				27B7E98E6C41791F0DB7812F /* StakingNoticesProvider.swift in Sources */,
+				6039E27966BEC34A604AA853 /* StartStakingCriticalNoticeSheetProtocols.swift in Sources */,
+				1C8977A706F69B75E0FE0A49 /* StartStakingCriticalNoticeSheetViewLayout.swift in Sources */,
+				E360DB6581DF55686BF6B570 /* StartStakingCriticalNoticeSheetViewController.swift in Sources */,
+				2B6075191F708013ABA4C7E9 /* StartStakingCriticalNoticeSheetPresenter.swift in Sources */,
+				7E5ADAB8DC8E0E42E9ABF4FD /* StartStakingCriticalNoticeSheetViewFactory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1553,6 +1553,7 @@
 		26FFA7D4465596728AA9C55F /* NetworkNodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D56AAF0DE08FFC0BA83B74E /* NetworkNodeViewController.swift */; };
 		270C21973CB61F0BF3D2D1E3 /* CrowdloanListProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ACCC85B2CCF3D9392CA9B4 /* CrowdloanListProtocols.swift */; };
 		2736BAABAE1389260A0B28D6 /* AssetListViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B754B68D6F1D1ED5C8577A5 /* AssetListViewFactory.swift */; };
+		27B7E98E6C41791F0DB7812F /* StakingNoticesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3372CF3A8A4C1B619AE35177 /* StakingNoticesProvider.swift */; };
 		27B8E1662E12A34D00EB1F5B /* UniqueNftSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B8E15A2E12A34D00EB1F5B /* UniqueNftSyncService.swift */; };
 		27B8E16A2E12A5FA00EB1F5B /* UniqueDetailsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B8E1692E12A5F600EB1F5B /* UniqueDetailsInteractor.swift */; };
 		27B8E16C2E12B04400EB1F5B /* UniqueNftOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B8E16B2E12B04200EB1F5B /* UniqueNftOperationFactory.swift */; };
@@ -2660,6 +2661,7 @@
 		331186FCF0903BA793C6D930 /* DelegationListViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8A9948F319AD0D154D1EC4 /* DelegationListViewFactory.swift */; };
 		33431341505ABC30172D34E3 /* GovernanceRevokeDelegationTracksWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461A9E7672D247C9CCF0B45D /* GovernanceRevokeDelegationTracksWireframe.swift */; };
 		3349B35F5D5DDD2D46FF2E48 /* LedgerInstructionsViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F9B478321689D963F51C4E /* LedgerInstructionsViewFactory.swift */; };
+		335EFDB7D2137F266E13B6B8 /* StakingNoticesProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF099C2ABFD38C77D6133B8 /* StakingNoticesProviderProtocol.swift */; };
 		3365A9A04208C1FA0F99B5EC /* ManualBackupKeyListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA7AD4DAF33E6758420BBD6 /* ManualBackupKeyListInteractor.swift */; };
 		3365B7C300AB4AC432F1BED0 /* StakingSetupProxyWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1399884D5F4905DA0BD1E5C3 /* StakingSetupProxyWireframe.swift */; };
 		33991FF16853D0F885C520A5 /* GovernanceRevokeDelegationConfirmViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67544C56A83D617405414E28 /* GovernanceRevokeDelegationConfirmViewLayout.swift */; };
@@ -5888,6 +5890,7 @@
 		9D16EC7C162525087A0F86BD /* MythosStakingConfirmPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35ADC43550D6DE65A50C132E /* MythosStakingConfirmPresenter.swift */; };
 		9D509AD640B01CAB872E0E71 /* NominationPoolSearchViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AC3897EC736F5096949BBC /* NominationPoolSearchViewFactory.swift */; };
 		9D5926790B055C56FB74B282 /* AccountManagementProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5072E250B7277F605855B3 /* AccountManagementProtocols.swift */; };
+		9D7946C0DFCBF68F3C7B74CA /* StakingNoticesProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962A2FA7A93960A8A64A3AAB /* StakingNoticesProviderTests.swift */; };
 		9DE1757D047A4D1E97913774 /* GovernanceUnlockConfirmProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3FE2CE7F9F2836755DBA63 /* GovernanceUnlockConfirmProtocols.swift */; };
 		9DED20EB20A872E682CB402A /* ReferendumFullDetailsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6DA24E0481A3678F2EF809 /* ReferendumFullDetailsProtocols.swift */; };
 		9DFB37659A6B911A4D54623E /* AccountConfirmInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E992CCDC1D581F7E9D3F1CA /* AccountConfirmInteractor.swift */; };
@@ -9006,6 +9009,7 @@
 		334A9D6E2BA7EE096D564FEF /* UnifiedAddressPopupProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UnifiedAddressPopupProtocols.swift; sourceTree = "<group>"; };
 		335E8C17DCB794733476AAE3 /* CollatorStakingConfirmViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollatorStakingConfirmViewController.swift; sourceTree = "<group>"; };
 		336395FFC4B2104A9651A2DE /* StakingRewardPayoutsViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingRewardPayoutsViewFactory.swift; sourceTree = "<group>"; };
+		3372CF3A8A4C1B619AE35177 /* StakingNoticesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNoticesProvider.swift; sourceTree = "<group>"; };
 		337EC62037D657258BCBC02F /* DAppWalletAuthInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppWalletAuthInteractor.swift; sourceTree = "<group>"; };
 		33A3AA54AA204AE7A1D71881 /* CustomNetworkViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomNetworkViewController.swift; sourceTree = "<group>"; };
 		33DFAA0EEEA7F99C6D1CF4B1 /* ReferendumFullDetailsPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumFullDetailsPresenter.swift; sourceTree = "<group>"; };
@@ -12146,6 +12150,7 @@
 		95E4AF529B896F7E58671A74 /* GovernanceUnlockSetupViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceUnlockSetupViewFactory.swift; sourceTree = "<group>"; };
 		95FCFE42BD09D48D07215216 /* CrowdloanUnlockViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CrowdloanUnlockViewFactory.swift; sourceTree = "<group>"; };
 		9622C6C3102EF12BEE78D63D /* ChainAssetSelectionViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChainAssetSelectionViewFactory.swift; sourceTree = "<group>"; };
+		962A2FA7A93960A8A64A3AAB /* StakingNoticesProviderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNoticesProviderTests.swift; sourceTree = "<group>"; };
 		96340EDDE0EAA7F9B6D33E96 /* LedgerWalletConfirmInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LedgerWalletConfirmInteractor.swift; sourceTree = "<group>"; };
 		9638E6EDBA41A5772E0033AE /* GovernanceUnlockConfirmInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceUnlockConfirmInteractor.swift; sourceTree = "<group>"; };
 		96BD67826AED0B073E044D10 /* StakingConfirmProxyWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingConfirmProxyWireframe.swift; sourceTree = "<group>"; };
@@ -12532,6 +12537,7 @@
 		CB441F15E16B07196DD9CE9D /* ParaStkUnstakeProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParaStkUnstakeProtocols.swift; sourceTree = "<group>"; };
 		CB5FCE21D2C05E8DDB55A78C /* OnboardingWalletReadyPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingWalletReadyPresenter.swift; sourceTree = "<group>"; };
 		CB9150FEC66FC503CF1BD1D0 /* WalletHistoryFilterPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletHistoryFilterPresenter.swift; sourceTree = "<group>"; };
+		CBF099C2ABFD38C77D6133B8 /* StakingNoticesProviderProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingNoticesProviderProtocol.swift; sourceTree = "<group>"; };
 		CC17D12DCD0CDAF0BC13D80D /* StakingUnbondSetupViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingUnbondSetupViewController.swift; sourceTree = "<group>"; };
 		CC2FE7131747C08259EB98AC /* StakingMoreOptionsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingMoreOptionsViewController.swift; sourceTree = "<group>"; };
 		CC5083A5751A1A3CC95F4F6F /* StakingUnbondSetupWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingUnbondSetupWireframe.swift; sourceTree = "<group>"; };
@@ -19919,6 +19925,8 @@
 			isa = PBXGroup;
 			children = (
 				7D5A431B31A14A4340E059AB /* StakingNotice.swift */,
+				CBF099C2ABFD38C77D6133B8 /* StakingNoticesProviderProtocol.swift */,
+				3372CF3A8A4C1B619AE35177 /* StakingNoticesProvider.swift */,
 			);
 			path = StakingNotices;
 			sourceTree = "<group>";
@@ -29193,6 +29201,7 @@
 			isa = PBXGroup;
 			children = (
 				24A83B4F6B0C569E7056708A /* StakingNoticeDecodingTests.swift */,
+				962A2FA7A93960A8A64A3AAB /* StakingNoticesProviderTests.swift */,
 			);
 			path = StakingNotices;
 			sourceTree = "<group>";
@@ -36883,6 +36892,8 @@
 				6B19F3A772108FBED12A7260 /* CrowdloanUnlockViewFactory.swift in Sources */,
 				F6E167B893C1C2971A392C43 /* StakingDashboardTierConfig.swift in Sources */,
 				B615CBEDC7E7A5DE545A86D2 /* StakingNotice.swift in Sources */,
+				335EFDB7D2137F266E13B6B8 /* StakingNoticesProviderProtocol.swift in Sources */,
+				27B7E98E6C41791F0DB7812F /* StakingNoticesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -37067,6 +37078,7 @@
 				F4897BB126AED13D0075F291 /* EraCountdownOperationFactoryStub.swift in Sources */,
 				952413819436984409450819 /* StakingDashboardBuilderDemotionTests.swift in Sources */,
 				F8B173A791896A2B2D63E59F /* StakingNoticeDecodingTests.swift in Sources */,
+				9D7946C0DFCBF68F3C7B74CA /* StakingNoticesProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/novawallet/Common/Configs/ApplicationConfigs.swift
+++ b/novawallet/Common/Configs/ApplicationConfigs.swift
@@ -48,6 +48,7 @@ protocol ApplicationConfigProtocol {
     var inAppUpdatesEntrypointURL: URL { get }
     var inAppUpdatesChangelogsURL: URL { get }
     var slip44URL: URL { get }
+    var stakingNoticesURL: URL { get }
     var wikiURL: URL { get }
     var whiteAppearanceIconsPath: String { get }
     var coloredAppearanceIconsPath: String { get }
@@ -320,6 +321,10 @@ extension ApplicationConfig: ApplicationConfigProtocol {
 
     var slip44URL: URL {
         URL(string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/assets/slip44.json")!
+    }
+
+    var stakingNoticesURL: URL {
+        URL(string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/notices/staking_notices.json")!
     }
 
     var wikiURL: URL {

--- a/novawallet/Common/Model/KnownChainIds.swift
+++ b/novawallet/Common/Model/KnownChainIds.swift
@@ -20,10 +20,11 @@ enum KnowChainId {
     static let moonbeam = "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d"
     static let moonriver = "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b"
     static let alephZero = "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e"
-    static let ternoa = "6859c81ca95ef624c9dfe4dc6e3381c33e5d6509e35e147092bfbc780f777c4e"
+    static let ternoa = "6859c81ca95ef624c9dfe4dc6e3381c33e5d6ce4ef5d70c1d18e8256330d0ea2"
     static let polkadex = "3920bcb4960a1eef5580cd5367ff3f430eef052774f78468852f7b9cb39f8a3c"
     static let calamari = "4ac80c99289841dd946ef92765bf659a307d39189b3ce374a92b5f0415ee17a1"
     static let zeitgeist = "1bf2a2ecb4a868de66ea8610f2ce7c8c43706561b6476031315f6640fe38e060"
+    static let mantaAtlantic = "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1c4b2599b87487420976a"
     static let ethereum = "eip155:1"
     static let rococo = "a84b46a3e602245284bb9a72c4abd58ee979aa7a5d7f8c4dfdddfaaf0665a4ae"
     static let westend = "e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e"
@@ -33,7 +34,7 @@ enum KnowChainId {
     static let avail = "b91746b45e0346cc2f815a520b9c6cb4d5c0902af848db0a80f85932d2e8276a"
 
     static let availTuringTestnet = "d3d2f3a3495dc597434a99d7d449ebad6616db45e4e4f178f31cc6fa14378b70"
-    static let vara = "fe1b4c55fd4d668101126434206571a7838a8b6b93a6d1b95d607e78e6c53763"
+    static let vara = "fe1b4c55fd4d668101126434206571a7838a8b6b93a6d1b95d607e4eda8b2812"
     static let mythos = "f6ee56e9c5277df5b4ce6ae9983ee88f3cbed27d31beeb98f9f84f997a1ab0b9"
 
     static var kiltOnEnviroment: String {

--- a/novawallet/Common/Model/KnownChainIds.swift
+++ b/novawallet/Common/Model/KnownChainIds.swift
@@ -20,11 +20,11 @@ enum KnowChainId {
     static let moonbeam = "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d"
     static let moonriver = "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b"
     static let alephZero = "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e"
-    static let ternoa = "6859c81ca95ef624c9dfe4dc6e3381c33e5d6ce4ef5d70c1d18e8256330d0ea2"
+    static let ternoa = "6859c81ca95ef624c9dfe4dc6e3381c33e5d6509e35e147092bfbc780f777c4e"
     static let polkadex = "3920bcb4960a1eef5580cd5367ff3f430eef052774f78468852f7b9cb39f8a3c"
     static let calamari = "4ac80c99289841dd946ef92765bf659a307d39189b3ce374a92b5f0415ee17a1"
     static let zeitgeist = "1bf2a2ecb4a868de66ea8610f2ce7c8c43706561b6476031315f6640fe38e060"
-    static let mantaAtlantic = "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1c4b2599b87487420976a"
+    static let mantaAtlantic = "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb"
     static let ethereum = "eip155:1"
     static let rococo = "a84b46a3e602245284bb9a72c4abd58ee979aa7a5d7f8c4dfdddfaaf0665a4ae"
     static let westend = "e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e"
@@ -34,7 +34,7 @@ enum KnowChainId {
     static let avail = "b91746b45e0346cc2f815a520b9c6cb4d5c0902af848db0a80f85932d2e8276a"
 
     static let availTuringTestnet = "d3d2f3a3495dc597434a99d7d449ebad6616db45e4e4f178f31cc6fa14378b70"
-    static let vara = "fe1b4c55fd4d668101126434206571a7838a8b6b93a6d1b95d607e4eda8b2812"
+    static let vara = "fe1b4c55fd4d668101126434206571a7838a8b6b93a6d1b95d607e78e6c53763"
     static let mythos = "f6ee56e9c5277df5b4ce6ae9983ee88f3cbed27d31beeb98f9f84f997a1ab0b9"
 
     static var kiltOnEnviroment: String {

--- a/novawallet/Common/Services/ChainRegistry/ChainRegistry.swift
+++ b/novawallet/Common/Services/ChainRegistry/ChainRegistry.swift
@@ -54,6 +54,7 @@ final class ChainRegistry {
     let chainSyncService: ChainSyncServiceProtocol
     let runtimeSyncService: RuntimeSyncServiceProtocol
     let commonTypesSyncService: CommonTypesSyncServiceProtocol
+    let stakingNoticesProvider: StakingNoticesProviding
     let chainProvider: StreamableProvider<ChainModel>
     let specVersionSubscriptionFactory: SpecVersionSubscriptionFactoryProtocol
     let logger: LoggerProtocol?
@@ -71,6 +72,7 @@ final class ChainRegistry {
         chainSyncService: ChainSyncServiceProtocol,
         runtimeSyncService: RuntimeSyncServiceProtocol,
         commonTypesSyncService: CommonTypesSyncServiceProtocol,
+        stakingNoticesProvider: StakingNoticesProviding,
         chainProvider: StreamableProvider<ChainModel>,
         specVersionSubscriptionFactory: SpecVersionSubscriptionFactoryProtocol,
         logger: LoggerProtocol? = nil
@@ -80,6 +82,7 @@ final class ChainRegistry {
         self.chainSyncService = chainSyncService
         self.runtimeSyncService = runtimeSyncService
         self.commonTypesSyncService = commonTypesSyncService
+        self.stakingNoticesProvider = stakingNoticesProvider
         self.chainProvider = chainProvider
         self.specVersionSubscriptionFactory = specVersionSubscriptionFactory
         self.logger = logger
@@ -220,6 +223,7 @@ final class ChainRegistry {
     private func syncUpServices() {
         chainSyncService.syncUp()
         commonTypesSyncService.syncUp()
+        stakingNoticesProvider.refresh()
     }
 
     private func internalSwitchSync(mode: ChainSyncMode, chainId: ChainModel.Id) throws {

--- a/novawallet/Common/Services/ChainRegistry/ChainRegistryFactory.swift
+++ b/novawallet/Common/Services/ChainRegistry/ChainRegistryFactory.swift
@@ -113,6 +113,7 @@ final class ChainRegistryFactory {
             chainSyncService: chainSyncService,
             runtimeSyncService: runtimeSyncService,
             commonTypesSyncService: commonTypesSyncService,
+            stakingNoticesProvider: StakingNoticesFacade.sharedProvider,
             chainProvider: chainProvider,
             specVersionSubscriptionFactory: specVersionSubscriptionFactory,
             logger: Logger.shared

--- a/novawallet/Common/Services/StakingNotices/StakingNotice.swift
+++ b/novawallet/Common/Services/StakingNotices/StakingNotice.swift
@@ -13,11 +13,20 @@ struct StakingNotice: Equatable {
     let endDate: Date?
 }
 
+extension CodingUserInfoKey {
+    /// Identifier of the locale to prefer when resolving `shortText` / `longText`
+    /// locale-map entries. e.g. "en_US", "pt_PT", "zh_Hans_CN".
+    /// If absent, the decoder falls back directly to `"en"`.
+    static let stakingNoticePreferredLocale = CodingUserInfoKey(rawValue: "stakingNoticePreferredLocale")!
+}
+
 /// Decodes a single notice from the JSON document `nova-utils/notices/staking_notices.json`.
 ///
 /// v1 schema accepts `shortText` / `longText` as plain strings.
-/// v2 will accept locale-map objects (`{"en": "...", "ru": "..."}`); the decoder below is written
-/// to tolerate either shape so v2 publishes do not break v1 clients. v1 falls back to `en`.
+/// v2 accepts locale-map objects (`{"en": "...", "ru": "..."}`). The decoder reads the
+/// preferred locale from `decoder.userInfo[.stakingNoticePreferredLocale]` if set, and tries
+/// progressively shorter forms (e.g. `pt-PT` → `pt`), falling back to `en` if nothing matches.
+/// `en` is required in every locale map — a map missing it is rejected.
 extension StakingNotice: Decodable {
     private enum CodingKeys: String, CodingKey {
         case chainId
@@ -32,8 +41,8 @@ extension StakingNotice: Decodable {
 
         chainId = try container.decode(ChainModel.Id.self, forKey: .chainId)
         severity = try container.decode(Severity.self, forKey: .severity)
-        shortText = try Self.decodeLocalized(container: container, key: .shortText)
-        longText = try Self.decodeLocalized(container: container, key: .longText)
+        shortText = try Self.decodeLocalized(decoder: decoder, container: container, key: .shortText)
+        longText = try Self.decodeLocalized(decoder: decoder, container: container, key: .longText)
 
         if let endDateString = try container.decodeIfPresent(String.self, forKey: .endDate) {
             let formatter = ISO8601DateFormatter()
@@ -52,6 +61,7 @@ extension StakingNotice: Decodable {
     }
 
     private static func decodeLocalized(
+        decoder: Decoder,
         container: KeyedDecodingContainer<CodingKeys>,
         key: CodingKeys
     ) throws -> String {
@@ -59,6 +69,13 @@ extension StakingNotice: Decodable {
             return plain
         }
         let localeMap = try container.decode([String: String].self, forKey: key)
+
+        let preferred = decoder.userInfo[.stakingNoticePreferredLocale] as? String
+        for candidate in localeCandidates(from: preferred) {
+            if let value = localeMap[candidate] {
+                return value
+            }
+        }
         if let englishValue = localeMap["en"] {
             return englishValue
         }
@@ -67,5 +84,22 @@ extension StakingNotice: Decodable {
             in: container,
             debugDescription: "Locale map for \(key.rawValue) lacks a fallback 'en' entry"
         )
+    }
+
+    /// Normalises a locale identifier (e.g. `pt_PT`, `zh_Hans_CN`) into ordered lookup
+    /// candidates with progressively shorter region/script components stripped:
+    /// `pt_PT` → `["pt-PT", "pt"]`
+    /// `zh_Hans_CN` → `["zh-Hans-CN", "zh-Hans", "zh"]`
+    /// `en` → `["en"]`
+    private static func localeCandidates(from identifier: String?) -> [String] {
+        guard let identifier, !identifier.isEmpty else { return [] }
+        let normalized = identifier.replacingOccurrences(of: "_", with: "-")
+        var candidates: [String] = [normalized]
+        var parts = normalized.split(separator: "-").map(String.init)
+        while parts.count > 1 {
+            parts.removeLast()
+            candidates.append(parts.joined(separator: "-"))
+        }
+        return candidates
     }
 }

--- a/novawallet/Common/Services/StakingNotices/StakingNotice.swift
+++ b/novawallet/Common/Services/StakingNotices/StakingNotice.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+struct StakingNotice: Equatable {
+    enum Severity: String, Decodable, Equatable {
+        case info
+        case critical
+    }
+
+    let chainId: ChainModel.Id
+    let severity: Severity
+    let shortText: String
+    let longText: String
+    let endDate: Date?
+}
+
+/// Decodes a single notice from the JSON document `nova-utils/notices/staking_notices.json`.
+///
+/// v1 schema accepts `shortText` / `longText` as plain strings.
+/// v2 will accept locale-map objects (`{"en": "...", "ru": "..."}`); the decoder below is written
+/// to tolerate either shape so v2 publishes do not break v1 clients. v1 falls back to `en`.
+extension StakingNotice: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case chainId
+        case severity
+        case shortText
+        case longText
+        case endDate
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        chainId = try container.decode(ChainModel.Id.self, forKey: .chainId)
+        severity = try container.decode(Severity.self, forKey: .severity)
+        shortText = try Self.decodeLocalized(container: container, key: .shortText)
+        longText = try Self.decodeLocalized(container: container, key: .longText)
+
+        if let endDateString = try container.decodeIfPresent(String.self, forKey: .endDate) {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withFullDate]
+            guard let date = formatter.date(from: endDateString) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .endDate,
+                    in: container,
+                    debugDescription: "Expected ISO-8601 date (YYYY-MM-DD), got \(endDateString)"
+                )
+            }
+            endDate = date
+        } else {
+            endDate = nil
+        }
+    }
+
+    private static func decodeLocalized(
+        container: KeyedDecodingContainer<CodingKeys>,
+        key: CodingKeys
+    ) throws -> String {
+        if let plain = try? container.decode(String.self, forKey: key) {
+            return plain
+        }
+        let localeMap = try container.decode([String: String].self, forKey: key)
+        if let englishValue = localeMap["en"] {
+            return englishValue
+        }
+        throw DecodingError.dataCorruptedError(
+            forKey: key,
+            in: container,
+            debugDescription: "Locale map for \(key.rawValue) lacks a fallback 'en' entry"
+        )
+    }
+}

--- a/novawallet/Common/Services/StakingNotices/StakingNoticesFacade.swift
+++ b/novawallet/Common/Services/StakingNotices/StakingNoticesFacade.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum StakingNoticesFacade {
+    static let sharedProvider: StakingNoticesProviding = StakingNoticesProvider(
+        url: ApplicationConfig.shared.stakingNoticesURL
+    )
+}

--- a/novawallet/Common/Services/StakingNotices/StakingNoticesProvider.swift
+++ b/novawallet/Common/Services/StakingNotices/StakingNoticesProvider.swift
@@ -130,6 +130,7 @@ final class StakingNoticesProvider: BaseSyncService, StakingNoticesProviding {
 
         var newNotices: [ChainModel.Id: StakingNotice] = [:]
         let decoder = JSONDecoder()
+        decoder.userInfo[.stakingNoticePreferredLocale] = Locale.current.identifier
         for entry in array {
             guard let entryData = try? JSONSerialization.data(withJSONObject: entry),
                   let notice = try? decoder.decode(StakingNotice.self, from: entryData) else {

--- a/novawallet/Common/Services/StakingNotices/StakingNoticesProvider.swift
+++ b/novawallet/Common/Services/StakingNotices/StakingNoticesProvider.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+final class StakingNoticesProvider: StakingNoticesProviding {
+    private struct Observer {
+        weak var target: AnyObject?
+        let callback: () -> Void
+    }
+
+    private let url: URL
+    private let session: URLSession
+    private let cacheURL: URL
+    private let queue = DispatchQueue(label: "com.nova.staking-notices", qos: .userInitiated)
+
+    private var notices: [ChainModel.Id: StakingNotice] = [:]
+    private var observers: [Observer] = []
+    private var inFlight: URLSessionTask?
+
+    init(
+        url: URL,
+        session: URLSession = .shared,
+        cacheURL: URL = StakingNoticesProvider.defaultCacheURL()
+    ) {
+        self.url = url
+        self.session = session
+        self.cacheURL = cacheURL
+        loadFromDisk()
+    }
+
+    static func defaultCacheURL() -> URL {
+        let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        return dir.appendingPathComponent("staking_notices.json")
+    }
+
+    func notice(for chainId: ChainModel.Id) -> StakingNotice? {
+        queue.sync { notices[chainId] }
+    }
+
+    var allNotices: [ChainModel.Id: StakingNotice] {
+        queue.sync { notices }
+    }
+
+    func refresh() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            if self.inFlight != nil { return }
+            var request = URLRequest(url: self.url)
+            request.cachePolicy = .reloadIgnoringLocalCacheData
+            self.inFlight = self.session.dataTask(with: request) { [weak self] data, _, _ in
+                guard let self else { return }
+                self.queue.async {
+                    self.inFlight = nil
+                    guard let data else { return }
+                    self.applyData(data, persistToDisk: true)
+                }
+            }
+            self.inFlight?.resume()
+        }
+    }
+
+    func subscribe(_ observer: AnyObject, callback: @escaping () -> Void) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.observers.removeAll { $0.target === observer }
+            self.observers.append(Observer(target: observer, callback: callback))
+        }
+    }
+
+    func unsubscribe(_ observer: AnyObject) {
+        queue.async { [weak self] in
+            self?.observers.removeAll { $0.target === observer || $0.target == nil }
+        }
+    }
+
+    private func loadFromDisk() {
+        guard let data = try? Data(contentsOf: cacheURL) else { return }
+        applyData(data, persistToDisk: false)
+    }
+
+    /// Parse + commit + notify. Errors on a single entry skip that entry; the rest still apply.
+    private func applyData(_ data: Data, persistToDisk: Bool) {
+        guard let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return
+        }
+
+        var newNotices: [ChainModel.Id: StakingNotice] = [:]
+        let decoder = JSONDecoder()
+        for entry in array {
+            guard let entryData = try? JSONSerialization.data(withJSONObject: entry),
+                  let notice = try? decoder.decode(StakingNotice.self, from: entryData) else {
+                continue
+            }
+            newNotices[notice.chainId] = notice
+        }
+
+        guard newNotices != notices else { return }
+        notices = newNotices
+
+        if persistToDisk {
+            try? data.write(to: cacheURL, options: .atomic)
+        }
+
+        let snapshot = observers
+        DispatchQueue.main.async {
+            snapshot.forEach { $0.callback() }
+        }
+    }
+}

--- a/novawallet/Common/Services/StakingNotices/StakingNoticesProvider.swift
+++ b/novawallet/Common/Services/StakingNotices/StakingNoticesProvider.swift
@@ -1,9 +1,11 @@
 import Foundation
+import Foundation_iOS
 
 final class StakingNoticesProvider: BaseSyncService, StakingNoticesProviding {
     private let url: URL
     private let session: URLSession
     private let cacheURL: URL
+    private let localizationManager: LocalizationManagerProtocol
 
     private let noticesState = Observable<[ChainModel.Id: StakingNotice]>(state: [:])
     // inFlight is always accessed while mutex is held (performSyncUp and stopSyncUp
@@ -14,13 +16,21 @@ final class StakingNoticesProvider: BaseSyncService, StakingNoticesProviding {
         url: URL,
         session: URLSession = .shared,
         cacheURL: URL = StakingNoticesProvider.defaultCacheURL(),
+        localizationManager: LocalizationManagerProtocol = LocalizationManager.shared,
         logger: LoggerProtocol = Logger.shared
     ) {
         self.url = url
         self.session = session
         self.cacheURL = cacheURL
+        self.localizationManager = localizationManager
         super.init(logger: logger)
         loadFromDisk()
+
+        // Re-decode the cached JSON whenever the user switches app language so that
+        // notice text updates without waiting for the next network fetch.
+        localizationManager.addObserver(with: self, queue: .main) { [weak self] _, _ in
+            self?.loadFromDisk()
+        }
     }
 
     static func defaultCacheURL() -> URL {
@@ -118,11 +128,11 @@ final class StakingNoticesProvider: BaseSyncService, StakingNoticesProviding {
     }
 
     /// Parse + commit + optionally persist. Errors on individual entries skip that entry.
+    /// Notices whose `endDate` has passed are filtered out so users never see stale warnings.
     ///
-    /// `applyAndPersist` acquires `mutex` internally (it is NOT called while mutex is held,
-    /// except via `loadFromDisk` during `init`, at which point no other thread can reach `self`).
-    /// When `noticesState.state` is assigned, `Observable<T>` calls `dispatchInQueueWhenPossible`
-    /// which async-dispatches to `.main` — so the observer closures run after mutex is released.
+    /// Always acquires `mutex`. Callers must NOT hold `mutex` before invoking this — call
+    /// paths: network callback (URLSession bg thread), locale observer (main queue), and
+    /// `loadFromDisk` during `init` (no other threads yet).
     private func applyAndPersist(_ data: Data, persistToDisk: Bool = true) {
         guard let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
             return
@@ -130,10 +140,18 @@ final class StakingNoticesProvider: BaseSyncService, StakingNoticesProviding {
 
         var newNotices: [ChainModel.Id: StakingNotice] = [:]
         let decoder = JSONDecoder()
-        decoder.userInfo[.stakingNoticePreferredLocale] = Locale.current.identifier
+        // Use Nova's own localization manager — it stores the user's in-app language
+        // choice in SharedSettings and is the sole authority for the selected locale.
+        // iOS-level APIs (Locale.preferredLanguages, Bundle.main.preferredLocalizations)
+        // are NOT updated by Nova's language picker and must not be used here.
+        decoder.userInfo[.stakingNoticePreferredLocale] = localizationManager.selectedLocalization
+        let now = Date()
         for entry in array {
             guard let entryData = try? JSONSerialization.data(withJSONObject: entry),
                   let notice = try? decoder.decode(StakingNotice.self, from: entryData) else {
+                continue
+            }
+            if let endDate = notice.endDate, endDate <= now {
                 continue
             }
             newNotices[notice.chainId] = notice
@@ -142,7 +160,7 @@ final class StakingNoticesProvider: BaseSyncService, StakingNoticesProviding {
         mutex.lock()
         let stateChanged = (newNotices != noticesState.state)
         if stateChanged {
-            // Safe to assign under mutex: notificiation closures are async-dispatched to .main
+            // Safe to assign under mutex: notification closures are async-dispatched to .main
             // by dispatchInQueueWhenPossible, so they don't run until after unlock.
             noticesState.state = newNotices
         }
@@ -158,18 +176,3 @@ enum StakingNoticesProviderError: Error {
     case httpStatus(Int)
     case emptyResponse
 }
-
-#if F_DEV
-    extension StakingNoticesProvider {
-        /// Inject hardcoded notices for visual testing without a real network fetch.
-        /// Caller responsibility: call from the main thread.
-        func injectStubForTesting(_ stub: [ChainModel.Id: StakingNotice]) {
-            mutex.lock()
-            let changed = (stub != noticesState.state)
-            if changed {
-                noticesState.state = stub
-            }
-            mutex.unlock()
-        }
-    }
-#endif

--- a/novawallet/Common/Services/StakingNotices/StakingNoticesProvider.swift
+++ b/novawallet/Common/Services/StakingNotices/StakingNoticesProvider.swift
@@ -1,28 +1,25 @@
 import Foundation
 
-final class StakingNoticesProvider: StakingNoticesProviding {
-    private struct Observer {
-        weak var target: AnyObject?
-        let callback: () -> Void
-    }
-
+final class StakingNoticesProvider: BaseSyncService, StakingNoticesProviding {
     private let url: URL
     private let session: URLSession
     private let cacheURL: URL
-    private let queue = DispatchQueue(label: "com.nova.staking-notices", qos: .userInitiated)
 
-    private var notices: [ChainModel.Id: StakingNotice] = [:]
-    private var observers: [Observer] = []
+    private let noticesState = Observable<[ChainModel.Id: StakingNotice]>(state: [:])
+    // inFlight is always accessed while mutex is held (performSyncUp and stopSyncUp
+    // are both invoked by BaseSyncService while holding mutex).
     private var inFlight: URLSessionTask?
 
     init(
         url: URL,
         session: URLSession = .shared,
-        cacheURL: URL = StakingNoticesProvider.defaultCacheURL()
+        cacheURL: URL = StakingNoticesProvider.defaultCacheURL(),
+        logger: LoggerProtocol = Logger.shared
     ) {
         self.url = url
         self.session = session
         self.cacheURL = cacheURL
+        super.init(logger: logger)
         loadFromDisk()
     }
 
@@ -31,53 +28,102 @@ final class StakingNoticesProvider: StakingNoticesProviding {
         return dir.appendingPathComponent("staking_notices.json")
     }
 
+    // MARK: - StakingNoticesProviding
+
     func notice(for chainId: ChainModel.Id) -> StakingNotice? {
-        queue.sync { notices[chainId] }
+        mutex.lock()
+        defer { mutex.unlock() }
+        return noticesState.state[chainId]
     }
 
     var allNotices: [ChainModel.Id: StakingNotice] {
-        queue.sync { notices }
+        mutex.lock()
+        defer { mutex.unlock() }
+        return noticesState.state
     }
 
     func refresh() {
-        queue.async { [weak self] in
-            guard let self else { return }
-            if self.inFlight != nil { return }
-            var request = URLRequest(url: self.url)
-            request.cachePolicy = .reloadIgnoringLocalCacheData
-            self.inFlight = self.session.dataTask(with: request) { [weak self] data, _, _ in
-                guard let self else { return }
-                self.queue.async {
-                    self.inFlight = nil
-                    guard let data else { return }
-                    self.applyData(data, persistToDisk: true)
-                }
-            }
-            self.inFlight?.resume()
-        }
+        if !getIsActive() { setup() }
+        syncUp()
     }
 
     func subscribe(_ observer: AnyObject, callback: @escaping () -> Void) {
-        queue.async { [weak self] in
-            guard let self else { return }
-            self.observers.removeAll { $0.target === observer }
-            self.observers.append(Observer(target: observer, callback: callback))
+        mutex.lock()
+        defer { mutex.unlock() }
+        // addObserver with queue: .main → notifications dispatched async to main queue.
+        noticesState.addObserver(with: observer, queue: .main) { _, _ in
+            callback()
         }
     }
 
     func unsubscribe(_ observer: AnyObject) {
-        queue.async { [weak self] in
-            self?.observers.removeAll { $0.target === observer || $0.target == nil }
+        mutex.lock()
+        defer { mutex.unlock() }
+        noticesState.removeObserver(by: observer)
+    }
+
+    // MARK: - BaseSyncService
+
+    // Called by BaseSyncService while mutex is already held — do NOT re-lock mutex here.
+    override func performSyncUp() {
+        var request = URLRequest(url: url)
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+
+        let task = session.dataTask(with: request) { [weak self] data, response, error in
+            guard let self else { return }
+            if let error {
+                self.clearAndComplete(error)
+                return
+            }
+            if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
+                self.clearAndComplete(StakingNoticesProviderError.httpStatus(http.statusCode))
+                return
+            }
+            guard let data else {
+                self.clearAndComplete(StakingNoticesProviderError.emptyResponse)
+                return
+            }
+            self.applyAndPersist(data)
+            self.clearAndComplete(nil)
         }
+
+        // mutex is already held by caller; store directly.
+        inFlight = task
+        task.resume()
+    }
+
+    // Called by BaseSyncService while mutex is already held — do NOT re-lock mutex here.
+    override func stopSyncUp() {
+        let task = inFlight
+        inFlight = nil
+        task?.cancel()
+    }
+
+    deinit {
+        inFlight?.cancel()
+    }
+
+    // MARK: - Private
+
+    private func clearAndComplete(_ error: Error?) {
+        mutex.lock()
+        inFlight = nil
+        mutex.unlock()
+        complete(error)
     }
 
     private func loadFromDisk() {
         guard let data = try? Data(contentsOf: cacheURL) else { return }
-        applyData(data, persistToDisk: false)
+        applyAndPersist(data, persistToDisk: false)
     }
 
-    /// Parse + commit + notify. Errors on a single entry skip that entry; the rest still apply.
-    private func applyData(_ data: Data, persistToDisk: Bool) {
+    /// Parse + commit + optionally persist. Errors on individual entries skip that entry.
+    ///
+    /// `applyAndPersist` acquires `mutex` internally (it is NOT called while mutex is held,
+    /// except via `loadFromDisk` during `init`, at which point no other thread can reach `self`).
+    /// When `noticesState.state` is assigned, `Observable<T>` calls `dispatchInQueueWhenPossible`
+    /// which async-dispatches to `.main` — so the observer closures run after mutex is released.
+    private func applyAndPersist(_ data: Data, persistToDisk: Bool = true) {
         guard let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
             return
         }
@@ -92,16 +138,22 @@ final class StakingNoticesProvider: StakingNoticesProviding {
             newNotices[notice.chainId] = notice
         }
 
-        guard newNotices != notices else { return }
-        notices = newNotices
+        mutex.lock()
+        let stateChanged = (newNotices != noticesState.state)
+        if stateChanged {
+            // Safe to assign under mutex: notificiation closures are async-dispatched to .main
+            // by dispatchInQueueWhenPossible, so they don't run until after unlock.
+            noticesState.state = newNotices
+        }
+        mutex.unlock()
 
-        if persistToDisk {
+        if stateChanged, persistToDisk {
             try? data.write(to: cacheURL, options: .atomic)
         }
-
-        let snapshot = observers
-        DispatchQueue.main.async {
-            snapshot.forEach { $0.callback() }
-        }
     }
+}
+
+enum StakingNoticesProviderError: Error {
+    case httpStatus(Int)
+    case emptyResponse
 }

--- a/novawallet/Common/Services/StakingNotices/StakingNoticesProvider.swift
+++ b/novawallet/Common/Services/StakingNotices/StakingNoticesProvider.swift
@@ -157,3 +157,18 @@ enum StakingNoticesProviderError: Error {
     case httpStatus(Int)
     case emptyResponse
 }
+
+#if F_DEV
+    extension StakingNoticesProvider {
+        /// Inject hardcoded notices for visual testing without a real network fetch.
+        /// Caller responsibility: call from the main thread.
+        func injectStubForTesting(_ stub: [ChainModel.Id: StakingNotice]) {
+            mutex.lock()
+            let changed = (stub != noticesState.state)
+            if changed {
+                noticesState.state = stub
+            }
+            mutex.unlock()
+        }
+    }
+#endif

--- a/novawallet/Common/Services/StakingNotices/StakingNoticesProviderProtocol.swift
+++ b/novawallet/Common/Services/StakingNotices/StakingNoticesProviderProtocol.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+protocol StakingNoticesProviding: AnyObject {
+    /// Returns the current notice for the given chain, if any. Reads from in-memory cache.
+    func notice(for chainId: ChainModel.Id) -> StakingNotice?
+
+    /// All currently-known notices keyed by chainId. Reads from in-memory cache.
+    var allNotices: [ChainModel.Id: StakingNotice] { get }
+
+    /// Trigger a refresh from the remote URL. Safe to call multiple times.
+    func refresh()
+
+    /// Register an observer that fires on the main queue whenever `allNotices` changes.
+    /// The provider holds the observer weakly. Re-subscribing with the same target is a no-op.
+    func subscribe(_ observer: AnyObject, callback: @escaping () -> Void)
+    func unsubscribe(_ observer: AnyObject)
+}

--- a/novawallet/Modules/Staking/Dashboard/Model/StakingDashboardBuilder.swift
+++ b/novawallet/Modules/Staking/Dashboard/Model/StakingDashboardBuilder.swift
@@ -146,6 +146,7 @@ final class StakingDashboardBuilder {
          * We allow staking to be in inactive set if:
          * - there is no active staking for the asset
          * - the asset is not in the testnet
+         * - the chain is not demoted (see StakingDashboardTierConfig)
          *
          * Otherwise staking goes to the More Options
          */
@@ -160,7 +161,7 @@ final class StakingDashboardBuilder {
 
             if activeStakingAssets.contains(stakingOption.chainAssetId) {
                 moreOptionsConcrete.append(dashboardItem)
-            } else if chain.isTestnet {
+            } else if chain.isTestnet || StakingDashboardTierConfig.demotedChainIds.contains(chain.chainId) {
                 updateCombined(store: &moreOptionsCombined, item: dashboardItem)
             } else {
                 updateCombined(store: &inactiveStakings, item: dashboardItem)

--- a/novawallet/Modules/Staking/Dashboard/Model/StakingDashboardTierConfig.swift
+++ b/novawallet/Modules/Staking/Dashboard/Model/StakingDashboardTierConfig.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Static config for chains demoted from the dashboard's main `inactive` (offer) list
+/// into the `More Options` screen.
+///
+/// Behaviour:
+/// - Chains in this set are routed into `more` instead of `inactive` by `StakingDashboardBuilder`.
+/// - Existing user stakes are unaffected — `active` classification happens earlier in the builder.
+/// - This is intentionally a code-side constant, not a remote-config value. Demoting/promoting
+///   a chain is a slow-changing structural decision.
+enum StakingDashboardTierConfig {
+    static let demotedChainIds: Set<ChainModel.Id> = [
+        KnowChainId.vara,
+        KnowChainId.zeitgeist,
+        KnowChainId.moonriver,
+        KnowChainId.alephZero,
+        KnowChainId.polkadex,
+        KnowChainId.ternoa,
+        KnowChainId.mantaAtlantic
+    ]
+}

--- a/novawallet/Modules/Staking/Dashboard/StakingDashboardInteractor.swift
+++ b/novawallet/Modules/Staking/Dashboard/StakingDashboardInteractor.swift
@@ -15,6 +15,7 @@ final class StakingDashboardInteractor {
     let applicationHandler: ApplicationHandlerProtocol
     let stateObserver: Observable<StakingDashboardModel>
     let walletNotificationService: WalletNotificationServiceProtocol
+    let noticesProvider: StakingNoticesProviding
 
     private var syncService: MultistakingSyncServiceProtocol?
     private var modelBuilder: StakingDashboardBuilderProtocol?
@@ -38,7 +39,8 @@ final class StakingDashboardInteractor {
         stateObserver: Observable<StakingDashboardModel>,
         applicationHandler: ApplicationHandlerProtocol,
         walletNotificationService: WalletNotificationServiceProtocol,
-        currencyManager: CurrencyManagerProtocol
+        currencyManager: CurrencyManagerProtocol,
+        noticesProvider: StakingNoticesProviding
     ) {
         self.syncServiceFactory = syncServiceFactory
         self.walletSettings = walletSettings
@@ -50,6 +52,7 @@ final class StakingDashboardInteractor {
         self.applicationHandler = applicationHandler
         self.stateObserver = stateObserver
         self.walletNotificationService = walletNotificationService
+        self.noticesProvider = noticesProvider
         self.currencyManager = currencyManager
     }
 
@@ -68,6 +71,17 @@ final class StakingDashboardInteractor {
         syncService?.subscribeSyncState(self, queue: .main) { [weak self] _, state in
             self?.modelBuilder?.applySync(state: state)
         }
+    }
+
+    private func setupNoticesSubscription() {
+        noticesProvider.subscribe(self) { [weak self] in
+            self?.handleNoticesChanged()
+        }
+        noticesProvider.refresh()
+    }
+
+    private func handleNoticesChanged() {
+        presenter?.didReceiveNoticesUpdate()
     }
 
     private func resetBalanceSubscription() {
@@ -167,6 +181,7 @@ extension StakingDashboardInteractor: StakingDashboardInteractorInputProtocol {
         setupChainsStore()
         setupDashboardItemsSubscription()
         setupSyncStateSubscription()
+        setupNoticesSubscription()
 
         eventCenter.add(observer: self, dispatchIn: .main)
         applicationHandler.delegate = self

--- a/novawallet/Modules/Staking/Dashboard/StakingDashboardPresenter.swift
+++ b/novawallet/Modules/Staking/Dashboard/StakingDashboardPresenter.swift
@@ -173,6 +173,11 @@ extension StakingDashboardPresenter: StakingDashboardInteractorOutputProtocol {
         hasWalletsListUpdates = hasUpdates
         updateWalletView()
     }
+
+    func didReceiveNoticesUpdate() {
+        guard let result = lastResult else { return }
+        reloadStakingView(using: result.model)
+    }
 }
 
 // MARK: - Localizable

--- a/novawallet/Modules/Staking/Dashboard/StakingDashboardProtocols.swift
+++ b/novawallet/Modules/Staking/Dashboard/StakingDashboardProtocols.swift
@@ -30,6 +30,7 @@ protocol StakingDashboardInteractorOutputProtocol: AnyObject {
     func didReceive(result: StakingDashboardBuilderResult)
     func didReceive(error: StakingDashboardInteractorError)
     func didReceiveWalletsState(hasUpdates: Bool)
+    func didReceiveNoticesUpdate()
 }
 
 protocol StakingDashboardWireframeProtocol: ErrorPresentable, AlertPresentable, CommonRetryable,

--- a/novawallet/Modules/Staking/Dashboard/StakingDashboardViewController.swift
+++ b/novawallet/Modules/Staking/Dashboard/StakingDashboardViewController.swift
@@ -208,7 +208,14 @@ extension StakingDashboardViewController: UICollectionViewDelegateFlowLayout {
         layout _: UICollectionViewLayout,
         sizeForItemAt indexPath: IndexPath
     ) -> CGSize {
-        let height = StakingDashboardSection(rawValue: indexPath.section)?.rowHeight ?? 0
+        var height = StakingDashboardSection(rawValue: indexPath.section)?.rowHeight ?? 0
+
+        if
+            StakingDashboardSection(rawValue: indexPath.section) == .activeStakings,
+            activeItems.indices.contains(indexPath.row),
+            activeItems[indexPath.row].notice != nil {
+            height += NoticeStripView.stripHeight
+        }
 
         return CGSize(width: collectionView.frame.width, height: height)
     }

--- a/novawallet/Modules/Staking/Dashboard/StakingDashboardViewFactory.swift
+++ b/novawallet/Modules/Staking/Dashboard/StakingDashboardViewFactory.swift
@@ -8,10 +8,13 @@ struct StakingDashboardViewFactory {
     ) -> StakingDashboardViewProtocol? {
         let stateObserver = Observable(state: StakingDashboardModel())
 
+        let noticesProvider = StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
+
         guard
             let interactor = createInteractor(
                 for: stateObserver,
-                walletNotificationService: walletNotificationService
+                walletNotificationService: walletNotificationService,
+                noticesProvider: noticesProvider
             ),
             let currencyManager = CurrencyManager.shared else {
             return nil
@@ -28,7 +31,8 @@ struct StakingDashboardViewFactory {
             assetFormatterFactory: AssetBalanceFormatterFactory(),
             priceAssetInfoFactory: priceAssetInfoFactory,
             chainAssetViewModelFactory: ChainAssetViewModelFactory(),
-            estimatedEarningsFormatter: NumberFormatter.percentBase.localizableResource()
+            estimatedEarningsFormatter: NumberFormatter.percentBase.localizableResource(),
+            noticesProvider: noticesProvider
         )
 
         let presenter = StakingDashboardPresenter(
@@ -54,7 +58,8 @@ struct StakingDashboardViewFactory {
 
     private static func createInteractor(
         for stateObserver: Observable<StakingDashboardModel>,
-        walletNotificationService: WalletNotificationServiceProtocol
+        walletNotificationService: WalletNotificationServiceProtocol,
+        noticesProvider: StakingNoticesProviding
     ) -> StakingDashboardInteractor? {
         let walletSettings = SelectedWalletSettings.shared
 
@@ -88,7 +93,8 @@ struct StakingDashboardViewFactory {
             stateObserver: stateObserver,
             applicationHandler: ApplicationHandler(),
             walletNotificationService: walletNotificationService,
-            currencyManager: currencyManager
+            currencyManager: currencyManager,
+            noticesProvider: noticesProvider
         )
     }
 }

--- a/novawallet/Modules/Staking/Dashboard/StakingDashboardViewFactory.swift
+++ b/novawallet/Modules/Staking/Dashboard/StakingDashboardViewFactory.swift
@@ -8,7 +8,7 @@ struct StakingDashboardViewFactory {
     ) -> StakingDashboardViewProtocol? {
         let stateObserver = Observable(state: StakingDashboardModel())
 
-        let noticesProvider = StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
+        let noticesProvider = StakingNoticesFacade.sharedProvider
 
         guard
             let interactor = createInteractor(

--- a/novawallet/Modules/Staking/Dashboard/View/NoticeStripView.swift
+++ b/novawallet/Modules/Staking/Dashboard/View/NoticeStripView.swift
@@ -20,12 +20,12 @@ final class NoticeStripView: UIView {
             return
         }
         isHidden = false
-        let (bg, fg) = banner.severity == .critical
+        let (background, foreground) = banner.severity == .critical
             ? (R.color.colorErrorBlockBackground()!, R.color.colorTextNegative()!)
             : (R.color.colorWarningBlockBackground()!, R.color.colorTextWarning()!)
-        backgroundColor = bg
-        dot.backgroundColor = fg
-        label.textColor = fg
+        backgroundColor = background
+        dot.backgroundColor = foreground
+        label.textColor = foreground
         label.text = banner.text
     }
 

--- a/novawallet/Modules/Staking/Dashboard/View/NoticeStripView.swift
+++ b/novawallet/Modules/Staking/Dashboard/View/NoticeStripView.swift
@@ -1,7 +1,8 @@
 import UIKit
 
 final class NoticeStripView: UIView {
-    private let dot = UIView()
+    static let stripHeight: CGFloat = 28
+
     private let label = UILabel()
 
     override init(frame: CGRect) {
@@ -14,6 +15,14 @@ final class NoticeStripView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override var isHidden: Bool {
+        didSet { invalidateIntrinsicContentSize() }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.noIntrinsicMetric, height: isHidden ? 0 : Self.stripHeight)
+    }
+
     func bind(to banner: StakingNoticeBanner?) {
         guard let banner else {
             isHidden = true
@@ -24,28 +33,20 @@ final class NoticeStripView: UIView {
             ? (R.color.colorErrorBlockBackground()!, R.color.colorTextNegative()!)
             : (R.color.colorWarningBlockBackground()!, R.color.colorTextWarning()!)
         backgroundColor = background
-        dot.backgroundColor = foreground
         label.textColor = foreground
         label.text = banner.text
     }
 
     private func configure() {
-        addSubview(dot)
         addSubview(label)
-        dot.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
-        dot.layer.cornerRadius = 3
-        label.font = .systemFont(ofSize: 12, weight: .regular)
+        label.font = .systemFont(ofSize: 14, weight: .semibold)
         label.numberOfLines = 1
+        label.textAlignment = .center
         NSLayoutConstraint.activate([
-            dot.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
-            dot.centerYAnchor.constraint(equalTo: centerYAnchor),
-            dot.widthAnchor.constraint(equalToConstant: 6),
-            dot.heightAnchor.constraint(equalToConstant: 6),
-            label.leadingAnchor.constraint(equalTo: dot.trailingAnchor, constant: 8),
-            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
             label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
-            heightAnchor.constraint(equalToConstant: 28)
+            label.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
 }

--- a/novawallet/Modules/Staking/Dashboard/View/NoticeStripView.swift
+++ b/novawallet/Modules/Staking/Dashboard/View/NoticeStripView.swift
@@ -1,0 +1,51 @@
+import UIKit
+
+final class NoticeStripView: UIView {
+    private let dot = UIView()
+    private let label = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func bind(to banner: StakingNoticeBanner?) {
+        guard let banner else {
+            isHidden = true
+            return
+        }
+        isHidden = false
+        let (bg, fg) = banner.severity == .critical
+            ? (R.color.colorErrorBlockBackground()!, R.color.colorTextNegative()!)
+            : (R.color.colorWarningBlockBackground()!, R.color.colorTextWarning()!)
+        backgroundColor = bg
+        dot.backgroundColor = fg
+        label.textColor = fg
+        label.text = banner.text
+    }
+
+    private func configure() {
+        addSubview(dot)
+        addSubview(label)
+        dot.translatesAutoresizingMaskIntoConstraints = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+        dot.layer.cornerRadius = 3
+        label.font = .systemFont(ofSize: 12, weight: .regular)
+        label.numberOfLines = 1
+        NSLayoutConstraint.activate([
+            dot.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
+            dot.centerYAnchor.constraint(equalTo: centerYAnchor),
+            dot.widthAnchor.constraint(equalToConstant: 6),
+            dot.heightAnchor.constraint(equalToConstant: 6),
+            label.leadingAnchor.constraint(equalTo: dot.trailingAnchor, constant: 8),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
+            heightAnchor.constraint(equalToConstant: 28)
+        ])
+    }
+}

--- a/novawallet/Modules/Staking/Dashboard/View/StakingDashboardActiveCell.swift
+++ b/novawallet/Modules/Staking/Dashboard/View/StakingDashboardActiveCell.swift
@@ -58,6 +58,8 @@ final class StakingDashboardActiveCellView: UIView {
         view.spacing = 6
     }
 
+    let noticeStrip = NoticeStripView()
+
     var skeletonView: SkrullableView?
 
     private var loadingState: LoadingState = .none
@@ -82,6 +84,8 @@ final class StakingDashboardActiveCellView: UIView {
     }
 
     func bind(viewModel: StakingDashboardEnabledViewModel, locale: Locale) {
+        noticeStrip.bind(to: viewModel.notice)
+
         assetView.bind(
             viewModel: viewModel.chainAssetViewModel.assetViewModel.imageViewModel,
             size: Constants.assetIconSize
@@ -169,6 +173,12 @@ final class StakingDashboardActiveCellView: UIView {
         }
 
         assetView.setContentCompressionResistancePriority(.low, for: .horizontal)
+
+        addSubview(noticeStrip)
+        noticeStrip.isHidden = true
+        noticeStrip.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+        }
     }
 }
 

--- a/novawallet/Modules/Staking/Dashboard/View/StakingDashboardActiveCell.swift
+++ b/novawallet/Modules/Staking/Dashboard/View/StakingDashboardActiveCell.swift
@@ -150,10 +150,17 @@ final class StakingDashboardActiveCellView: UIView {
     }
 
     private func setupLayout() {
+        addSubview(noticeStrip)
+        noticeStrip.isHidden = true
+        noticeStrip.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+        }
+
         addSubview(detailsView)
 
         detailsView.snp.makeConstraints { make in
-            make.top.bottom.trailing.equalToSuperview().inset(4)
+            make.top.equalTo(noticeStrip.snp.bottom).offset(4)
+            make.bottom.trailing.equalToSuperview().inset(4)
             make.width.equalTo(130)
         }
 
@@ -161,7 +168,7 @@ final class StakingDashboardActiveCellView: UIView {
 
         assetContainerView.snp.makeConstraints { make in
             make.leading.equalToSuperview().inset(Constants.assetIconLeadingOffset)
-            make.top.equalToSuperview().inset(Constants.assetIconTopOffset)
+            make.top.equalTo(noticeStrip.snp.bottom).offset(Constants.assetIconTopOffset)
             make.trailing.lessThanOrEqualTo(detailsView.snp.leading).offset(-8)
         }
 
@@ -173,12 +180,6 @@ final class StakingDashboardActiveCellView: UIView {
         }
 
         assetView.setContentCompressionResistancePriority(.low, for: .horizontal)
-
-        addSubview(noticeStrip)
-        noticeStrip.isHidden = true
-        noticeStrip.snp.makeConstraints { make in
-            make.top.leading.trailing.equalToSuperview()
-        }
     }
 }
 

--- a/novawallet/Modules/Staking/Dashboard/View/StakingDashboardInactiveCell.swift
+++ b/novawallet/Modules/Staking/Dashboard/View/StakingDashboardInactiveCell.swift
@@ -1,6 +1,22 @@
 import UIKit
 import UIKit_iOS
 
+private final class PaddedLabel: UILabel {
+    var textInsets = UIEdgeInsets(top: 4, left: 7, bottom: 4, right: 7)
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: textInsets))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return CGSize(
+            width: size.width + textInsets.left + textInsets.right,
+            height: size.height + textInsets.top + textInsets.bottom
+        )
+    }
+}
+
 final class StakingDashboardInactiveCell: BlurredCollectionViewCell<StakingDashboardInactiveCellView> {
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -19,6 +35,18 @@ final class StakingDashboardInactiveCellView: GenericTitleValueView<
     >,
     IconDetailsGenericView<GenericPairValueView<ShimmerLabel, UILabel>>
 > {
+    private let noticeChip: PaddedLabel = {
+        let label = PaddedLabel()
+        label.text = "Notice"
+        label.font = .systemFont(ofSize: 10, weight: .semibold)
+        label.textAlignment = .center
+        label.layer.cornerRadius = 5
+        label.layer.masksToBounds = true
+        label.isHidden = true
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        return label
+    }()
+
     private enum Constants {
         static let iconSize = CGSize(width: 44, height: 44)
     }
@@ -64,6 +92,17 @@ final class StakingDashboardInactiveCellView: GenericTitleValueView<
             stakingTypeView.bind(viewModel: stakingTypeViewModel)
         } else {
             stakingTypeView.isHidden = true
+        }
+
+        if let notice = viewModel.notice {
+            noticeChip.isHidden = false
+            let (background, foreground): (UIColor, UIColor) = notice.severity == .critical
+                ? (R.color.colorErrorBlockBackground()!, R.color.colorTextNegative()!)
+                : (R.color.colorWarningBlockBackground()!, R.color.colorTextWarning()!)
+            noticeChip.backgroundColor = background
+            noticeChip.textColor = foreground
+        } else {
+            noticeChip.isHidden = true
         }
 
         estimatedEarningsLabel.bind(viewModel: viewModel.estimatedEarnings.map(with: { $0 ?? "" }))
@@ -165,6 +204,10 @@ final class StakingDashboardInactiveCellView: GenericTitleValueView<
 
         titleView.sView.fView.makeHorizontal()
         titleView.sView.fView.spacing = 4
+
+        titleView.sView.fView.stackView.addArrangedSubview(noticeChip)
+        titleView.sView.fView.stackView.setCustomSpacing(6, after: titleView.sView.fView.sView)
+        titleView.sView.fView.stackView.alignment = .center
 
         titleView.sView.sView.makeHorizontal()
         titleView.sView.sView.spacing = 6

--- a/novawallet/Modules/Staking/Dashboard/View/StakingDashboardInactiveCell.swift
+++ b/novawallet/Modules/Staking/Dashboard/View/StakingDashboardInactiveCell.swift
@@ -2,7 +2,7 @@ import UIKit
 import UIKit_iOS
 
 private final class PaddedLabel: UILabel {
-    var textInsets = UIEdgeInsets(top: 4, left: 7, bottom: 4, right: 7)
+    var textInsets = UIEdgeInsets(top: 2, left: 7, bottom: 2, right: 7)
 
     override func drawText(in rect: CGRect) {
         super.drawText(in: rect.inset(by: textInsets))
@@ -206,6 +206,7 @@ final class StakingDashboardInactiveCellView: GenericTitleValueView<
         titleView.sView.fView.spacing = 4
 
         titleView.sView.fView.stackView.addArrangedSubview(noticeChip)
+        titleView.sView.fView.stackView.setCustomSpacing(6, after: titleView.sView.fView.fView)
         titleView.sView.fView.stackView.setCustomSpacing(6, after: titleView.sView.fView.sView)
         titleView.sView.fView.stackView.alignment = .center
 

--- a/novawallet/Modules/Staking/Dashboard/View/StakingDashboardInactiveCell.swift
+++ b/novawallet/Modules/Staking/Dashboard/View/StakingDashboardInactiveCell.swift
@@ -37,7 +37,6 @@ final class StakingDashboardInactiveCellView: GenericTitleValueView<
 > {
     private let noticeChip: PaddedLabel = {
         let label = PaddedLabel()
-        label.text = "Notice"
         label.font = .systemFont(ofSize: 10, weight: .semibold)
         label.textAlignment = .center
         label.layer.cornerRadius = 5
@@ -96,6 +95,9 @@ final class StakingDashboardInactiveCellView: GenericTitleValueView<
 
         if let notice = viewModel.notice {
             noticeChip.isHidden = false
+            noticeChip.text = R.string.localizable.stakingNoticeChip(
+                preferredLanguages: locale.rLanguages
+            )
             let (background, foreground): (UIColor, UIColor) = notice.severity == .critical
                 ? (R.color.colorErrorBlockBackground()!, R.color.colorTextNegative()!)
                 : (R.color.colorWarningBlockBackground()!, R.color.colorTextWarning()!)

--- a/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModel.swift
+++ b/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModel.swift
@@ -44,6 +44,7 @@ struct StakingDashboardDisabledViewModel {
     let estimatedEarnings: LoadableViewModelState<String?>
     let balance: SecuredViewModel<BalanceViewModelProtocol?>
     let stakingType: TitleIconViewModel?
+    let notice: StakingNoticeBanner?
 }
 
 struct StakingDashboardViewModel {

--- a/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModel.swift
+++ b/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModel.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+struct StakingNoticeBanner: Equatable {
+    enum Severity: Equatable { case info; case critical }
+    let severity: Severity
+    /// Short text shown on the banner strip.
+    let text: String
+}
+
 struct StakingDashboardEnabledViewModel {
     enum Status {
         case active
@@ -29,6 +36,7 @@ struct StakingDashboardEnabledViewModel {
     let yourStake: SecuredViewModel<LoadableViewModelState<BalanceViewModelProtocol>>
     let estimatedEarnings: LoadableViewModelState<String?>
     let stakingType: TitleIconViewModel?
+    let notice: StakingNoticeBanner?
 }
 
 struct StakingDashboardDisabledViewModel {

--- a/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModelFactory.swift
+++ b/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModelFactory.swift
@@ -246,11 +246,21 @@ extension StakingDashboardViewModelFactory: StakingDashboardViewModelFactoryProt
 
         let stakingType = createStakingType(for: model, locale: locale)
 
+        let notice: StakingNoticeBanner? = noticesProvider.notice(
+            for: chainAsset.chain.chainId
+        ).map { stakingNotice in
+            StakingNoticeBanner(
+                severity: stakingNotice.severity == .critical ? .critical : .info,
+                text: stakingNotice.shortText
+            )
+        }
+
         return .init(
             chainAssetViewModel: loadableChainAsset,
             estimatedEarnings: estimatedEarnings,
             balance: .wrapped(balance, with: privacyModeEnabled),
-            stakingType: stakingType
+            stakingType: stakingType,
+            notice: notice
         )
     }
 

--- a/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModelFactory.swift
+++ b/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModelFactory.swift
@@ -35,17 +35,20 @@ final class StakingDashboardViewModelFactory {
     let assetFormatterFactory: AssetBalanceFormatterFactoryProtocol
     let chainAssetViewModelFactory: ChainAssetViewModelFactoryProtocol
     let estimatedEarningsFormatter: LocalizableResource<NumberFormatter>
+    let noticesProvider: StakingNoticesProviding
 
     init(
         assetFormatterFactory: AssetBalanceFormatterFactoryProtocol,
         priceAssetInfoFactory: PriceAssetInfoFactoryProtocol,
         chainAssetViewModelFactory: ChainAssetViewModelFactoryProtocol,
-        estimatedEarningsFormatter: LocalizableResource<NumberFormatter>
+        estimatedEarningsFormatter: LocalizableResource<NumberFormatter>,
+        noticesProvider: StakingNoticesProviding
     ) {
         self.assetFormatterFactory = assetFormatterFactory
         self.priceAssetInfoFactory = priceAssetInfoFactory
         self.chainAssetViewModelFactory = chainAssetViewModelFactory
         self.estimatedEarningsFormatter = estimatedEarningsFormatter
+        self.noticesProvider = noticesProvider
     }
 
     private func createEstimatedEarnings(
@@ -193,13 +196,23 @@ extension StakingDashboardViewModelFactory: StakingDashboardViewModelFactoryProt
             locale: locale
         )
 
+        let notice: StakingNoticeBanner? = noticesProvider.notice(
+            for: chainAsset.chain.chainId
+        ).map { stakingNotice in
+            StakingNoticeBanner(
+                severity: stakingNotice.severity == .critical ? .critical : .info,
+                text: stakingNotice.shortText
+            )
+        }
+
         return .init(
             chainAssetViewModel: chainAssetViewModel,
             totalRewards: .wrapped(totalRewards, with: privacyModeEnabled),
             status: status,
             yourStake: .wrapped(yourStake, with: privacyModeEnabled),
             estimatedEarnings: estimatedEarnings,
-            stakingType: stakingType
+            stakingType: stakingType,
+            notice: notice
         )
     }
 

--- a/novawallet/Modules/Staking/StakingMain/Common/Views/StakingNoticeBlockView.swift
+++ b/novawallet/Modules/Staking/StakingMain/Common/Views/StakingNoticeBlockView.swift
@@ -1,0 +1,91 @@
+import UIKit
+
+/// Expanded notice block shown at the top of the stake-details screen.
+/// Shows severity-coloured background, a dot + bold title row, and the full longText body.
+final class StakingNoticeBlockView: UIView {
+    struct Model: Equatable {
+        enum Severity: Equatable { case info; case critical }
+        let severity: Severity
+        let title: String
+        let body: String
+    }
+
+    private let containerView = UIView()
+    private let headDot = UIView()
+    private let headLabel = UILabel()
+    private let bodyLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func bind(_ model: Model?) {
+        guard let model else {
+            isHidden = true
+            return
+        }
+        isHidden = false
+
+        let (background, border, foreground): (UIColor, UIColor, UIColor) = model.severity == .critical
+            ? (
+                R.color.colorErrorBlockBackground()!,
+                R.color.colorTextNegative()!.withAlphaComponent(0.30),
+                R.color.colorTextNegative()!
+            )
+            : (
+                R.color.colorWarningBlockBackground()!,
+                R.color.colorTextWarning()!.withAlphaComponent(0.25),
+                R.color.colorTextWarning()!
+            )
+
+        containerView.backgroundColor = background
+        containerView.layer.borderColor = border.cgColor
+        headDot.backgroundColor = foreground
+        headLabel.textColor = foreground
+        headLabel.text = model.title
+        bodyLabel.text = model.body
+    }
+
+    private func configure() {
+        addSubview(containerView)
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.layer.cornerRadius = 12
+        containerView.layer.borderWidth = 1
+
+        [headDot, headLabel, bodyLabel].forEach {
+            containerView.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        headDot.layer.cornerRadius = 3
+        headLabel.font = .systemFont(ofSize: 13, weight: .semibold)
+        bodyLabel.font = .systemFont(ofSize: 13, weight: .regular)
+        bodyLabel.numberOfLines = 0
+        bodyLabel.textColor = R.color.colorTextSecondary()!
+
+        NSLayoutConstraint.activate([
+            containerView.topAnchor.constraint(equalTo: topAnchor),
+            containerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            containerView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            headDot.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 14),
+            headDot.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 16),
+            headDot.widthAnchor.constraint(equalToConstant: 6),
+            headDot.heightAnchor.constraint(equalToConstant: 6),
+
+            headLabel.leadingAnchor.constraint(equalTo: headDot.trailingAnchor, constant: 8),
+            headLabel.centerYAnchor.constraint(equalTo: headDot.centerYAnchor),
+            headLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -14),
+
+            bodyLabel.topAnchor.constraint(equalTo: headLabel.bottomAnchor, constant: 6),
+            bodyLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 14),
+            bodyLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -14),
+            bodyLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -14)
+        ])
+    }
+}

--- a/novawallet/Modules/Staking/StakingMain/Common/Views/StakingNoticeBlockView.swift
+++ b/novawallet/Modules/Staking/StakingMain/Common/Views/StakingNoticeBlockView.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// Expanded notice block shown at the top of the stake-details screen.
-/// Shows severity-coloured background, a dot + bold title row, and the full longText body.
+/// Severity-coloured background with a centred bold title and a high-contrast body.
 final class StakingNoticeBlockView: UIView {
     struct Model: Equatable {
         enum Severity: Equatable { case info; case critical }
@@ -11,7 +11,6 @@ final class StakingNoticeBlockView: UIView {
     }
 
     private let containerView = UIView()
-    private let headDot = UIView()
     private let headLabel = UILabel()
     private let bodyLabel = UILabel()
 
@@ -44,7 +43,6 @@ final class StakingNoticeBlockView: UIView {
 
         containerView.backgroundColor = background
         containerView.layer.borderColor = border.cgColor
-        headDot.backgroundColor = foreground
         headLabel.textColor = foreground
         headLabel.text = model.title
         bodyLabel.text = model.body
@@ -56,16 +54,19 @@ final class StakingNoticeBlockView: UIView {
         containerView.layer.cornerRadius = 12
         containerView.layer.borderWidth = 1
 
-        [headDot, headLabel, bodyLabel].forEach {
+        [headLabel, bodyLabel].forEach {
             containerView.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
 
-        headDot.layer.cornerRadius = 3
-        headLabel.font = .systemFont(ofSize: 13, weight: .semibold)
-        bodyLabel.font = .systemFont(ofSize: 13, weight: .regular)
+        headLabel.font = .systemFont(ofSize: 17, weight: .bold)
+        headLabel.textAlignment = .center
+        headLabel.numberOfLines = 0
+
+        bodyLabel.font = .systemFont(ofSize: 14, weight: .regular)
         bodyLabel.numberOfLines = 0
-        bodyLabel.textColor = R.color.colorTextSecondary()!
+        bodyLabel.textAlignment = .center
+        bodyLabel.textColor = R.color.colorTextPrimary()!
 
         NSLayoutConstraint.activate([
             containerView.topAnchor.constraint(equalTo: topAnchor),
@@ -73,16 +74,11 @@ final class StakingNoticeBlockView: UIView {
             containerView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
             containerView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
-            headDot.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 14),
-            headDot.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 16),
-            headDot.widthAnchor.constraint(equalToConstant: 6),
-            headDot.heightAnchor.constraint(equalToConstant: 6),
-
-            headLabel.leadingAnchor.constraint(equalTo: headDot.trailingAnchor, constant: 8),
-            headLabel.centerYAnchor.constraint(equalTo: headDot.centerYAnchor),
+            headLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 16),
+            headLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 14),
             headLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -14),
 
-            bodyLabel.topAnchor.constraint(equalTo: headLabel.bottomAnchor, constant: 6),
+            bodyLabel.topAnchor.constraint(equalTo: headLabel.bottomAnchor, constant: 8),
             bodyLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 14),
             bodyLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -14),
             bodyLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -14)

--- a/novawallet/Modules/Staking/StakingMain/StakingMainInteractor.swift
+++ b/novawallet/Modules/Staking/StakingMain/StakingMainInteractor.swift
@@ -11,6 +11,7 @@ final class StakingMainInteractor: AnyProviderAutoCleaning {
     let settingsManager: SettingsManagerProtocol
     let selectedWalletSettings: SelectedWalletSettings
     let stakingOption: Multistaking.ChainAssetOption
+    let noticesProvider: StakingNoticesProviding
     let stakingRewardsFilterRepository: AnyDataProviderRepository<StakingRewardsFilter>
     let operationQueue: OperationQueue
     let eventCenter: EventCenterProtocol
@@ -24,6 +25,7 @@ final class StakingMainInteractor: AnyProviderAutoCleaning {
         ahmInfoFactory: AHMFullInfoFactoryProtocol,
         settingsManager: SettingsManagerProtocol,
         stakingOption: Multistaking.ChainAssetOption,
+        noticesProvider: StakingNoticesProviding,
         selectedWalletSettings: SelectedWalletSettings,
         eventCenter: EventCenterProtocol,
         stakingRewardsFilterRepository: AnyDataProviderRepository<StakingRewardsFilter>,
@@ -33,6 +35,7 @@ final class StakingMainInteractor: AnyProviderAutoCleaning {
         self.ahmInfoFactory = ahmInfoFactory
         self.settingsManager = settingsManager
         self.stakingOption = stakingOption
+        self.noticesProvider = noticesProvider
         self.eventCenter = eventCenter
         self.selectedWalletSettings = selectedWalletSettings
         self.stakingRewardsFilterRepository = stakingRewardsFilterRepository
@@ -77,6 +80,16 @@ final class StakingMainInteractor: AnyProviderAutoCleaning {
         return info.destinationChain.chainId == chainAsset.chain.chainId
     }
 
+    func setupNoticesSubscription() {
+        noticesProvider.subscribe(self) { [weak self] in
+            self?.handleNoticesChanged()
+        }
+    }
+
+    private func handleNoticesChanged() {
+        presenter?.didReceiveNoticesUpdate()
+    }
+
     func provideAHMInfo() {
         guard let parentChainId = chainAsset.chain.parentId else {
             return
@@ -111,6 +124,7 @@ extension StakingMainInteractor: StakingMainInteractorInputProtocol {
 
         provideAHMInfo()
         provideStakingRewardsFilter()
+        setupNoticesSubscription()
 
         eventCenter.add(observer: self, dispatchIn: .main)
     }

--- a/novawallet/Modules/Staking/StakingMain/StakingMainInteractor.swift
+++ b/novawallet/Modules/Staking/StakingMain/StakingMainInteractor.swift
@@ -84,6 +84,7 @@ final class StakingMainInteractor: AnyProviderAutoCleaning {
         noticesProvider.subscribe(self) { [weak self] in
             self?.handleNoticesChanged()
         }
+        noticesProvider.refresh()
     }
 
     private func handleNoticesChanged() {

--- a/novawallet/Modules/Staking/StakingMain/StakingMainPresenter.swift
+++ b/novawallet/Modules/Staking/StakingMain/StakingMainPresenter.swift
@@ -10,6 +10,7 @@ final class StakingMainPresenter {
     let childPresenterFactory: StakingMainPresenterFactoryProtocol
     let viewModelFactory: StakingMainViewModelFactoryProtocol
     let ahmViewModelFactory: AHMInfoViewModelFactoryProtocol
+    let noticesProvider: StakingNoticesProviding
     let stakingOption: Multistaking.ChainAssetOption
     let localizationManager: LocalizationManagerProtocol
     let logger: LoggerProtocol?
@@ -22,6 +23,7 @@ final class StakingMainPresenter {
         interactor: StakingMainInteractorInputProtocol,
         wireframe: StakingMainWireframeProtocol,
         stakingOption: Multistaking.ChainAssetOption,
+        noticesProvider: StakingNoticesProviding,
         childPresenterFactory: StakingMainPresenterFactoryProtocol,
         viewModelFactory: StakingMainViewModelFactoryProtocol,
         ahmViewModelFactory: AHMInfoViewModelFactoryProtocol,
@@ -31,6 +33,7 @@ final class StakingMainPresenter {
         self.interactor = interactor
         self.wireframe = wireframe
         self.stakingOption = stakingOption
+        self.noticesProvider = noticesProvider
         self.childPresenterFactory = childPresenterFactory
         self.viewModelFactory = viewModelFactory
         self.ahmViewModelFactory = ahmViewModelFactory
@@ -46,6 +49,18 @@ private extension StakingMainPresenter {
         let viewModel = viewModelFactory.createMainViewModel(chainAsset: stakingOption.chainAsset)
 
         view?.didReceive(viewModel: viewModel)
+    }
+
+    func provideNoticeModel() {
+        let chainId = stakingOption.chainAsset.chain.chainId
+        let noticeModel: StakingNoticeBlockView.Model? = noticesProvider.notice(for: chainId).map {
+            StakingNoticeBlockView.Model(
+                severity: $0.severity == .critical ? .critical : .info,
+                title: $0.shortText,
+                body: $0.longText
+            )
+        }
+        view?.didReceiveNotice(noticeModel)
     }
 
     func provideAHMAlertModel() {
@@ -70,6 +85,7 @@ extension StakingMainPresenter: StakingMainPresenterProtocol {
         view?.didReceiveStakingState(viewModel: .undefined)
 
         provideMainViewModel()
+        provideNoticeModel()
 
         if childPresenter == nil, let view = view {
             childPresenter = childPresenterFactory.createPresenter(
@@ -150,6 +166,10 @@ extension StakingMainPresenter: StakingMainInteractorOutputProtocol {
         self.ahmInfo = ahmInfo
 
         provideAHMAlertModel()
+    }
+
+    func didReceiveNoticesUpdate() {
+        provideNoticeModel()
     }
 }
 

--- a/novawallet/Modules/Staking/StakingMain/StakingMainProtocols.swift
+++ b/novawallet/Modules/Staking/StakingMain/StakingMainProtocols.swift
@@ -11,6 +11,7 @@ protocol StakingMainViewProtocol: ControllerBackedProtocol {
     func didReceiveStatics(viewModel: StakingMainStaticViewModelProtocol)
     func didReceiveSelectedEntity(_ entity: StakingSelectedEntityViewModel)
     func didReceiveAHMAlert(viewModel: InlinableAlertView.Model?)
+    func didReceiveNotice(_ model: StakingNoticeBlockView.Model?)
     func didEditRewardFilters()
 }
 
@@ -38,6 +39,7 @@ protocol StakingMainInteractorOutputProtocol: AnyObject {
     func didReceiveExpansion(_ isExpanded: Bool)
     func didReceiveRewardFilter(_ filter: StakingRewardFiltersPeriod)
     func didReceiveAHMInfo(_ ahmInfo: AHMFullInfo?)
+    func didReceiveNoticesUpdate()
 }
 
 protocol StakingMainWireframeProtocol: AlertPresentable, NoAccountSupportPresentable, WebPresentable {

--- a/novawallet/Modules/Staking/StakingMain/StakingMainViewController.swift
+++ b/novawallet/Modules/Staking/StakingMain/StakingMainViewController.swift
@@ -257,6 +257,10 @@ extension StakingMainViewController: StakingMainViewProtocol {
     func didReceiveAHMAlert(viewModel: InlinableAlertView.Model?) {
         rootView.setAHMAlert(with: viewModel)
     }
+
+    func didReceiveNotice(_ model: StakingNoticeBlockView.Model?) {
+        rootView.bindNotice(model)
+    }
 }
 
 // MARK: - NetworkInfoViewDelegate

--- a/novawallet/Modules/Staking/StakingMain/StakingMainViewFactory.swift
+++ b/novawallet/Modules/Staking/StakingMain/StakingMainViewFactory.swift
@@ -11,9 +11,12 @@ enum StakingMainViewFactory {
     ) -> StakingMainViewProtocol? {
         let settings = SettingsManager.shared
 
+        let noticesProvider = StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
+
         let interactor = createInteractor(
             with: settings,
-            stakingOption: stakingOption
+            stakingOption: stakingOption,
+            noticesProvider: noticesProvider
         )
         let wireframe = StakingMainWireframe()
 
@@ -42,6 +45,7 @@ enum StakingMainViewFactory {
             interactor: interactor,
             wireframe: wireframe,
             stakingOption: stakingOption,
+            noticesProvider: noticesProvider,
             childPresenterFactory: childPresenterFactory,
             viewModelFactory: StakingMainViewModelFactory(),
             ahmViewModelFactory: AHMInfoViewModelFactory(),
@@ -62,7 +66,8 @@ enum StakingMainViewFactory {
 
     private static func createInteractor(
         with settings: SettingsManagerProtocol,
-        stakingOption: Multistaking.ChainAssetOption
+        stakingOption: Multistaking.ChainAssetOption,
+        noticesProvider: StakingNoticesProviding
     ) -> StakingMainInteractor {
         let mapper = AnyCoreDataMapper(StakingRewardsFilterMapper())
         let facade = UserDataStorageFacade.shared
@@ -74,6 +79,7 @@ enum StakingMainViewFactory {
             ahmInfoFactory: ahmInfoFactory,
             settingsManager: settings,
             stakingOption: stakingOption,
+            noticesProvider: noticesProvider,
             selectedWalletSettings: SelectedWalletSettings.shared,
             eventCenter: EventCenter.shared,
             stakingRewardsFilterRepository: stakingRewardsFilterRepository,

--- a/novawallet/Modules/Staking/StakingMain/StakingMainViewFactory.swift
+++ b/novawallet/Modules/Staking/StakingMain/StakingMainViewFactory.swift
@@ -11,7 +11,7 @@ enum StakingMainViewFactory {
     ) -> StakingMainViewProtocol? {
         let settings = SettingsManager.shared
 
-        let noticesProvider = StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
+        let noticesProvider = StakingNoticesFacade.sharedProvider
 
         let interactor = createInteractor(
             with: settings,

--- a/novawallet/Modules/Staking/StakingMain/StakingMainViewLayout.swift
+++ b/novawallet/Modules/Staking/StakingMain/StakingMainViewLayout.swift
@@ -30,6 +30,12 @@ final class StakingMainViewLayout: UIView {
     var scrollView: UIScrollView { containerView.scrollView }
     var stackView: UIStackView { containerView.stackView }
 
+    let noticeBlockView: StakingNoticeBlockView = {
+        let view = StakingNoticeBlockView()
+        view.isHidden = true
+        return view
+    }()
+
     var networkInfoContainerView: UIView = .create { view in
         view.translatesAutoresizingMaskIntoConstraints = false
     }
@@ -108,6 +114,7 @@ private extension StakingMainViewLayout {
         }
 
         setupScrollView()
+        setupNoticeBlockView()
         setupNetworkInfoView()
         setupAlertsView()
     }
@@ -160,6 +167,14 @@ private extension StakingMainViewLayout {
 
     func setupScrollView() {
         scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
+    }
+
+    func setupNoticeBlockView() {
+        stackView.addArrangedSubview(noticeBlockView)
+        noticeBlockView.snp.makeConstraints { make in
+            make.width.equalToSuperview()
+        }
+        stackView.setCustomSpacing(8, after: noticeBlockView)
     }
 
     func setupNetworkInfoView() {
@@ -231,6 +246,10 @@ private extension StakingMainViewLayout {
 // MARK: - Internal
 
 extension StakingMainViewLayout {
+    func bindNotice(_ model: StakingNoticeBlockView.Model?) {
+        noticeBlockView.bind(model)
+    }
+
     func setupEntityView(for viewModel: StakingSelectedEntityViewModel) {
         let entityView: StackTableView
 

--- a/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsInteractor.swift
+++ b/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsInteractor.swift
@@ -6,15 +6,18 @@ final class StakingMoreOptionsInteractor {
 
     let dAppProvider: AnySingleValueProvider<DAppList>
     let stakingStateObserver: Observable<StakingDashboardModel>
+    let noticesProvider: StakingNoticesProviding
     private let operationQueue: OperationQueue
 
     init(
         dAppProvider: AnySingleValueProvider<DAppList>,
         stakingStateObserver: Observable<StakingDashboardModel>,
+        noticesProvider: StakingNoticesProviding,
         operationQueue: OperationQueue
     ) {
         self.dAppProvider = dAppProvider
         self.stakingStateObserver = stakingStateObserver
+        self.noticesProvider = noticesProvider
         self.operationQueue = operationQueue
     }
 
@@ -61,12 +64,24 @@ final class StakingMoreOptionsInteractor {
             }
         }
     }
+
+    private func setupNoticesSubscription() {
+        noticesProvider.subscribe(self) { [weak self] in
+            self?.handleNoticesChanged()
+        }
+        noticesProvider.refresh()
+    }
+
+    private func handleNoticesChanged() {
+        presenter?.didReceiveNoticesUpdate()
+    }
 }
 
 extension StakingMoreOptionsInteractor: StakingMoreOptionsInteractorInputProtocol {
     func setup() {
         subscribeStakingState()
         subscribeDApps()
+        setupNoticesSubscription()
     }
 
     func remakeDAppsSubscription() {

--- a/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsPresenter.swift
+++ b/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsPresenter.swift
@@ -98,6 +98,10 @@ extension StakingMoreOptionsPresenter: StakingMoreOptionsInteractorOutputProtoco
         self.moreOptions = moreOptions
         provideMoreOptionsViewModel(moreOptions: moreOptions)
     }
+
+    func didReceiveNoticesUpdate() {
+        provideMoreOptionsViewModel(moreOptions: moreOptions)
+    }
 }
 
 extension StakingMoreOptionsPresenter: Localizable {

--- a/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsProtocols.swift
+++ b/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsProtocols.swift
@@ -17,6 +17,7 @@ protocol StakingMoreOptionsInteractorInputProtocol: AnyObject {
 protocol StakingMoreOptionsInteractorOutputProtocol: AnyObject {
     func didReceive(dAppsResult: Result<DAppList, Error>?)
     func didReceive(moreOptions: [StakingDashboardItemModel])
+    func didReceiveNoticesUpdate()
 }
 
 protocol StakingMoreOptionsWireframeProtocol: ErrorPresentable,

--- a/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsViewFactory.swift
+++ b/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsViewFactory.swift
@@ -24,7 +24,8 @@ struct StakingMoreOptionsViewFactory {
             assetFormatterFactory: AssetBalanceFormatterFactory(),
             priceAssetInfoFactory: priceAssetInfoFactory,
             chainAssetViewModelFactory: ChainAssetViewModelFactory(),
-            estimatedEarningsFormatter: NumberFormatter.percentBase.localizableResource()
+            estimatedEarningsFormatter: NumberFormatter.percentBase.localizableResource(),
+            noticesProvider: StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
         )
 
         let wallet: MetaAccountModel = SelectedWalletSettings.shared.value

--- a/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsViewFactory.swift
+++ b/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsViewFactory.swift
@@ -12,9 +12,11 @@ struct StakingMoreOptionsViewFactory {
         let dAppProvider: AnySingleValueProvider<DAppList> = JsonDataProviderFactory.shared.getJson(
             for: dAppsUrl
         )
+        let noticesProvider = StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
         let interactor = StakingMoreOptionsInteractor(
             dAppProvider: dAppProvider,
             stakingStateObserver: stateObserver,
+            noticesProvider: noticesProvider,
             operationQueue: OperationQueue()
         )
         let wireframe = StakingMoreOptionsWireframe()
@@ -25,7 +27,7 @@ struct StakingMoreOptionsViewFactory {
             priceAssetInfoFactory: priceAssetInfoFactory,
             chainAssetViewModelFactory: ChainAssetViewModelFactory(),
             estimatedEarningsFormatter: NumberFormatter.percentBase.localizableResource(),
-            noticesProvider: StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
+            noticesProvider: noticesProvider
         )
 
         let wallet: MetaAccountModel = SelectedWalletSettings.shared.value

--- a/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsViewFactory.swift
+++ b/novawallet/Modules/Staking/StakingMoreOptions/StakingMoreOptionsViewFactory.swift
@@ -12,7 +12,7 @@ struct StakingMoreOptionsViewFactory {
         let dAppProvider: AnySingleValueProvider<DAppList> = JsonDataProviderFactory.shared.getJson(
             for: dAppsUrl
         )
-        let noticesProvider = StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
+        let noticesProvider = StakingNoticesFacade.sharedProvider
         let interactor = StakingMoreOptionsInteractor(
             dAppProvider: dAppProvider,
             stakingStateObserver: stateObserver,

--- a/novawallet/Modules/Staking/StartStakingInfo/MythosStaking/StartStakingInfoMythosInteractor.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/MythosStaking/StartStakingInfoMythosInteractor.swift
@@ -44,6 +44,7 @@ final class StartStakingInfoMythosInteractor: StartStakingInfoBaseInteractor {
         walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol,
         priceLocalSubscriptionFactory: PriceProviderFactoryProtocol,
         stakingDashboardProviderFactory: StakingDashboardProviderFactoryProtocol,
+        noticesProvider: StakingNoticesProviding,
         durationOperationFactory: MythosStkDurationOperationFactoryProtocol,
         currencyManager: CurrencyManagerProtocol,
         sharedOperation: SharedOperationProtocol,
@@ -64,6 +65,7 @@ final class StartStakingInfoMythosInteractor: StartStakingInfoBaseInteractor {
             walletLocalSubscriptionFactory: walletLocalSubscriptionFactory,
             priceLocalSubscriptionFactory: priceLocalSubscriptionFactory,
             stakingDashboardProviderFactory: stakingDashboardProviderFactory,
+            noticesProvider: noticesProvider,
             currencyManager: currencyManager,
             operationQueue: operationQueue
         )

--- a/novawallet/Modules/Staking/StartStakingInfo/MythosStaking/StartStakingInfoMythosPresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/MythosStaking/StartStakingInfoMythosPresenter.swift
@@ -23,6 +23,7 @@ final class StartStakingInfoMythosPresenter: StartStakingInfoBasePresenter {
         balanceDerivationFactory: StakingTypeBalanceFactoryProtocol,
         localizationManager: LocalizationManagerProtocol,
         applicationConfig: ApplicationConfigProtocol,
+        noticesProvider: StakingNoticesProviding,
         logger: LoggerProtocol
     ) {
         state = .init(chainAsset: chainAsset, minStake: nil)
@@ -35,6 +36,7 @@ final class StartStakingInfoMythosPresenter: StartStakingInfoBasePresenter {
             balanceDerivationFactory: balanceDerivationFactory,
             localizationManager: localizationManager,
             applicationConfig: applicationConfig,
+            noticesProvider: noticesProvider,
             logger: logger
         )
     }

--- a/novawallet/Modules/Staking/StartStakingInfo/ParachainStaking/StartStakingInfoParachainPresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/ParachainStaking/StartStakingInfoParachainPresenter.swift
@@ -21,6 +21,7 @@ final class StartStakingInfoParachainPresenter: StartStakingInfoBasePresenter {
         balanceDerivationFactory: StakingTypeBalanceFactoryProtocol,
         localizationManager: LocalizationManagerProtocol,
         applicationConfig: ApplicationConfigProtocol,
+        noticesProvider: StakingNoticesProviding,
         logger: LoggerProtocol
     ) {
         state = .init(chainAsset: chainAsset)
@@ -34,6 +35,7 @@ final class StartStakingInfoParachainPresenter: StartStakingInfoBasePresenter {
             balanceDerivationFactory: balanceDerivationFactory,
             localizationManager: localizationManager,
             applicationConfig: applicationConfig,
+            noticesProvider: noticesProvider,
             logger: logger
         )
     }

--- a/novawallet/Modules/Staking/StartStakingInfo/ParachainStaking/StartStakingParachainInteractor.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/ParachainStaking/StartStakingParachainInteractor.swift
@@ -37,6 +37,7 @@ final class StartStakingParachainInteractor: StartStakingInfoBaseInteractor, Any
         walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol,
         priceLocalSubscriptionFactory: PriceProviderFactoryProtocol,
         stakingDashboardProviderFactory: StakingDashboardProviderFactoryProtocol,
+        noticesProvider: StakingNoticesProviding,
         currencyManager: CurrencyManagerProtocol,
         networkInfoFactory: ParaStkNetworkInfoOperationFactoryProtocol,
         durationOperationFactory: ParaStkDurationOperationFactoryProtocol,
@@ -57,6 +58,7 @@ final class StartStakingParachainInteractor: StartStakingInfoBaseInteractor, Any
             walletLocalSubscriptionFactory: walletLocalSubscriptionFactory,
             priceLocalSubscriptionFactory: priceLocalSubscriptionFactory,
             stakingDashboardProviderFactory: stakingDashboardProviderFactory,
+            noticesProvider: noticesProvider,
             currencyManager: currencyManager,
             operationQueue: operationQueue
         )

--- a/novawallet/Modules/Staking/StartStakingInfo/RelaychainStaking/StartStakingInfoRelaychainPresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/RelaychainStaking/StartStakingInfoRelaychainPresenter.swift
@@ -20,6 +20,7 @@ final class StartStakingInfoRelaychainPresenter: StartStakingInfoBasePresenter {
         balanceDerivationFactory: StakingTypeBalanceFactoryProtocol,
         localizationManager: LocalizationManagerProtocol,
         applicationConfig: ApplicationConfigProtocol,
+        noticesProvider: StakingNoticesProviding,
         logger: LoggerProtocol
     ) {
         state = .init(stakingType: selectedStakingType, chainAsset: chainAsset)
@@ -33,6 +34,7 @@ final class StartStakingInfoRelaychainPresenter: StartStakingInfoBasePresenter {
             balanceDerivationFactory: balanceDerivationFactory,
             localizationManager: localizationManager,
             applicationConfig: applicationConfig,
+            noticesProvider: noticesProvider,
             logger: logger
         )
     }

--- a/novawallet/Modules/Staking/StartStakingInfo/RelaychainStaking/StartStakingRelaychainInteractor.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/RelaychainStaking/StartStakingRelaychainInteractor.swift
@@ -39,6 +39,7 @@ final class StartStakingRelaychainInteractor: StartStakingInfoBaseInteractor, An
         walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol,
         priceLocalSubscriptionFactory: PriceProviderFactoryProtocol,
         stakingDashboardProviderFactory: StakingDashboardProviderFactoryProtocol,
+        noticesProvider: StakingNoticesProviding,
         currencyManager: CurrencyManagerProtocol,
         networkInfoOperationFactory: NetworkStakingInfoOperationFactoryProtocol,
         eraCoundownOperationFactory: EraCountdownOperationFactoryProtocol,
@@ -60,6 +61,7 @@ final class StartStakingRelaychainInteractor: StartStakingInfoBaseInteractor, An
             walletLocalSubscriptionFactory: walletLocalSubscriptionFactory,
             priceLocalSubscriptionFactory: priceLocalSubscriptionFactory,
             stakingDashboardProviderFactory: stakingDashboardProviderFactory,
+            noticesProvider: noticesProvider,
             currencyManager: currencyManager,
             operationQueue: operationQueue
         )

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBaseInteractor.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBaseInteractor.swift
@@ -11,6 +11,7 @@ class StartStakingInfoBaseInteractor: StartStakingInfoInteractorInputProtocol, A
     let selectedWalletSettings: SelectedWalletSettings
     let selectedStakingType: StakingType?
     let sharedOperation: SharedOperationStatusProtocol
+    let noticesProvider: StakingNoticesProviding
 
     private(set) var priceProvider: StreamableProvider<PriceData>?
     private(set) var balanceProvider: StreamableProvider<AssetBalance>?
@@ -26,6 +27,7 @@ class StartStakingInfoBaseInteractor: StartStakingInfoInteractorInputProtocol, A
         walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol,
         priceLocalSubscriptionFactory: PriceProviderFactoryProtocol,
         stakingDashboardProviderFactory: StakingDashboardProviderFactoryProtocol,
+        noticesProvider: StakingNoticesProviding,
         currencyManager: CurrencyManagerProtocol,
         operationQueue: OperationQueue
     ) {
@@ -36,6 +38,7 @@ class StartStakingInfoBaseInteractor: StartStakingInfoInteractorInputProtocol, A
         self.walletLocalSubscriptionFactory = walletLocalSubscriptionFactory
         self.priceLocalSubscriptionFactory = priceLocalSubscriptionFactory
         self.stakingDashboardProviderFactory = stakingDashboardProviderFactory
+        self.noticesProvider = noticesProvider
         self.operationQueue = operationQueue
         self.currencyManager = currencyManager
     }
@@ -92,12 +95,24 @@ class StartStakingInfoBaseInteractor: StartStakingInfoInteractorInputProtocol, A
         )
     }
 
+    private func setupNoticesSubscription() {
+        noticesProvider.subscribe(self) { [weak self] in
+            self?.handleNoticesChanged()
+        }
+        noticesProvider.refresh()
+    }
+
+    private func handleNoticesChanged() {
+        basePresenter?.didReceiveNoticesUpdate()
+    }
+
     func setup() {
         setupSelectedAccount()
 
         performAssetBalanceSubscription()
         performPriceSubscription()
         performStakingStateSubscription()
+        setupNoticesSubscription()
     }
 
     func remakeSubscriptions() {

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
@@ -215,6 +215,22 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
         provideNoticeModel()
     }
 
+    func checkForCriticalNotice() {
+        guard let notice = noticesProvider.notice(for: chainAsset.chain.chainId),
+              notice.severity == .critical else {
+            return
+        }
+        wireframe.presentCriticalNoticeSheet(
+            from: view,
+            title: notice.shortText,
+            body: notice.longText,
+            onCancel: { [weak self] in
+                self?.wireframe.complete(from: self?.view)
+            },
+            onContinue: { /* sheet auto-dismisses; no further action */ }
+        )
+    }
+
     func showNoAccountAlert() {
         guard let view = view,
               let wallet = wallet else {

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
@@ -12,6 +12,7 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
     let chainAsset: ChainAsset
     let logger: LoggerProtocol
     let accountManagementFilter: AccountManagementFilterProtocol
+    let noticesProvider: StakingNoticesProviding
 
     private(set) var price: PriceData?
     private(set) var accountExistense: AccountExistense?
@@ -26,6 +27,7 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
         balanceDerivationFactory: StakingTypeBalanceFactoryProtocol,
         localizationManager: LocalizationManagerProtocol,
         applicationConfig: ApplicationConfigProtocol,
+        noticesProvider: StakingNoticesProviding,
         accountManagementFilter: AccountManagementFilterProtocol = AccountManagementFilter(),
         logger: LoggerProtocol
     ) {
@@ -35,9 +37,22 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
         self.startStakingViewModelFactory = startStakingViewModelFactory
         self.balanceDerivationFactory = balanceDerivationFactory
         self.applicationConfig = applicationConfig
+        self.noticesProvider = noticesProvider
         self.accountManagementFilter = accountManagementFilter
         self.logger = logger
         self.localizationManager = localizationManager
+    }
+
+    func provideNoticeModel() {
+        let notice = noticesProvider.notice(for: chainAsset.chain.chainId)
+        let model: StakingNoticeBlockView.Model? = notice.map { stakingNotice in
+            StakingNoticeBlockView.Model(
+                severity: stakingNotice.severity == .critical ? .critical : .info,
+                title: stakingNotice.shortText,
+                body: stakingNotice.longText
+            )
+        }
+        view?.didReceiveNotice(model)
     }
 
     func provideBalanceModel() {
@@ -193,6 +208,11 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
 
     func setup() {
         baseInteractor.setup()
+        provideNoticeModel()
+    }
+
+    func didReceiveNoticesUpdate() {
+        provideNoticeModel()
     }
 
     func showNoAccountAlert() {

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoBasePresenter.swift
@@ -215,22 +215,6 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
         provideNoticeModel()
     }
 
-    func checkForCriticalNotice() {
-        guard let notice = noticesProvider.notice(for: chainAsset.chain.chainId),
-              notice.severity == .critical else {
-            return
-        }
-        wireframe.presentCriticalNoticeSheet(
-            from: view,
-            title: notice.shortText,
-            body: notice.longText,
-            onCancel: { [weak self] in
-                self?.wireframe.complete(from: self?.view)
-            },
-            onContinue: { /* sheet auto-dismisses; no further action */ }
-        )
-    }
-
     func showNoAccountAlert() {
         guard let view = view,
               let wallet = wallet else {
@@ -261,6 +245,23 @@ class StartStakingInfoBasePresenter: StartStakingInfoInteractorOutputProtocol, S
     }
 
     func startStaking() {
+        if let notice = noticesProvider.notice(for: chainAsset.chain.chainId),
+           notice.severity == .critical {
+            wireframe.presentCriticalNoticeSheet(
+                from: view,
+                title: notice.shortText,
+                body: notice.longText,
+                onCancel: {},
+                onContinue: { [weak self] in
+                    self?.proceedToStakingSetup()
+                }
+            )
+        } else {
+            proceedToStakingSetup()
+        }
+    }
+
+    private func proceedToStakingSetup() {
         guard let view = view,
               let accountExistense = accountExistense else {
             return

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoProtocols.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoProtocols.swift
@@ -9,7 +9,6 @@ protocol StartStakingInfoViewProtocol: AnyObject, ControllerBackedProtocol {
 protocol StartStakingInfoPresenterProtocol: AnyObject {
     func setup()
     func startStaking()
-    func checkForCriticalNotice()
 }
 
 protocol StartStakingInfoInteractorInputProtocol: AnyObject {

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoProtocols.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoProtocols.swift
@@ -3,6 +3,7 @@ import BigInt
 protocol StartStakingInfoViewProtocol: AnyObject, ControllerBackedProtocol {
     func didReceive(viewModel: LoadableViewModelState<StartStakingViewModel>)
     func didReceive(balance: String)
+    func didReceiveNotice(_ model: StakingNoticeBlockView.Model?)
 }
 
 protocol StartStakingInfoPresenterProtocol: AnyObject {
@@ -21,6 +22,7 @@ protocol StartStakingInfoInteractorOutputProtocol: AnyObject {
     func didReceive(baseError: BaseStartStakingInfoError)
     func didReceive(wallet: MetaAccountModel, chainAccountId: AccountId?)
     func didReceiveStakingEnabled()
+    func didReceiveNoticesUpdate()
 }
 
 protocol StartStakingInfoRelaychainInteractorInputProtocol: StartStakingInfoInteractorInputProtocol {

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoProtocols.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoProtocols.swift
@@ -9,6 +9,7 @@ protocol StartStakingInfoViewProtocol: AnyObject, ControllerBackedProtocol {
 protocol StartStakingInfoPresenterProtocol: AnyObject {
     func setup()
     func startStaking()
+    func checkForCriticalNotice()
 }
 
 protocol StartStakingInfoInteractorInputProtocol: AnyObject {
@@ -63,6 +64,13 @@ protocol StartStakingInfoWireframeProtocol: CommonRetryable, AlertPresentable, N
     func showWalletDetails(from view: ControllerBackedProtocol?, wallet: MetaAccountModel)
     func showSetupAmount(from view: ControllerBackedProtocol?)
     func complete(from view: ControllerBackedProtocol?)
+    func presentCriticalNoticeSheet(
+        from view: StartStakingInfoViewProtocol?,
+        title: String,
+        body: String,
+        onCancel: @escaping () -> Void,
+        onContinue: @escaping () -> Void
+    )
 }
 
 enum BaseStartStakingInfoError: Error {

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewController.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewController.swift
@@ -76,6 +76,8 @@ final class StartStakingInfoViewController: UIViewController, ViewHolder {
             rootView.updateLoadingState()
             rootView.skeletonView?.restartSkrulling()
         }
+
+        presenter.checkForCriticalNotice()
     }
 
     @objc private func startStakingAction() {

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewController.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewController.swift
@@ -76,8 +76,6 @@ final class StartStakingInfoViewController: UIViewController, ViewHolder {
             rootView.updateLoadingState()
             rootView.skeletonView?.restartSkrulling()
         }
-
-        presenter.checkForCriticalNotice()
     }
 
     @objc private func startStakingAction() {

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewController.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewController.swift
@@ -107,6 +107,10 @@ extension StartStakingInfoViewController: StartStakingInfoViewProtocol {
         self.balance = balance
         rootView.updateBalanceButton(text: balance, locale: selectedLocale)
     }
+
+    func didReceiveNotice(_ model: StakingNoticeBlockView.Model?) {
+        rootView.bindNotice(model)
+    }
 }
 
 extension StartStakingInfoViewController: Localizable {

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory+Mythos.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory+Mythos.swift
@@ -24,7 +24,13 @@ extension StartStakingInfoViewFactory {
             return nil
         }
 
-        let interactor = createMythosInteractor(state: state, currencyManager: currencyManager)
+        let noticesProvider = StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
+
+        let interactor = createMythosInteractor(
+            state: state,
+            noticesProvider: noticesProvider,
+            currencyManager: currencyManager
+        )
 
         let wireframe = StartStakingInfoMythosWireframe(state: state)
 
@@ -46,6 +52,7 @@ extension StartStakingInfoViewFactory {
             balanceDerivationFactory: StakingTypeBalanceFactory(stakingType: stakingOption.type),
             localizationManager: LocalizationManager.shared,
             applicationConfig: ApplicationConfig.shared,
+            noticesProvider: noticesProvider,
             logger: Logger.shared
         )
 
@@ -63,6 +70,7 @@ extension StartStakingInfoViewFactory {
 
     private static func createMythosInteractor(
         state: MythosStakingSharedStateProtocol,
+        noticesProvider: StakingNoticesProviding,
         currencyManager: CurrencyManagerProtocol
     ) -> StartStakingInfoMythosInteractor {
         let selectedWalletSettings = SelectedWalletSettings.shared
@@ -87,6 +95,7 @@ extension StartStakingInfoViewFactory {
             walletLocalSubscriptionFactory: walletLocalSubscriptionFactory,
             priceLocalSubscriptionFactory: priceLocalSubscriptionFactory,
             stakingDashboardProviderFactory: stakingDashboardProviderFactory,
+            noticesProvider: noticesProvider,
             durationOperationFactory: durationOperationFactory,
             currencyManager: currencyManager,
             sharedOperation: state.startSharedOperation(),

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory+Mythos.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory+Mythos.swift
@@ -24,7 +24,7 @@ extension StartStakingInfoViewFactory {
             return nil
         }
 
-        let noticesProvider = StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
+        let noticesProvider = StakingNoticesFacade.sharedProvider
 
         let interactor = createMythosInteractor(
             state: state,

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
@@ -79,8 +79,11 @@ struct StartStakingInfoViewFactory {
             return nil
         }
 
+        let noticesProvider = StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
+
         let interactor = createRelaychainInteractor(
             state: state,
+            noticesProvider: noticesProvider,
             currencyManager: currencyManager,
             operationQueue: operationQueue
         )
@@ -104,6 +107,7 @@ struct StartStakingInfoViewFactory {
             balanceDerivationFactory: StakingTypeBalanceFactory(stakingType: state.stakingType),
             localizationManager: LocalizationManager.shared,
             applicationConfig: ApplicationConfig.shared,
+            noticesProvider: noticesProvider,
             logger: Logger.shared
         )
 
@@ -121,6 +125,7 @@ struct StartStakingInfoViewFactory {
 
     private static func createRelaychainInteractor(
         state: RelaychainStartStakingStateProtocol,
+        noticesProvider: StakingNoticesProviding,
         currencyManager: CurrencyManagerProtocol,
         operationQueue: OperationQueue
     ) -> StartStakingRelaychainInteractor {
@@ -145,6 +150,7 @@ struct StartStakingInfoViewFactory {
             walletLocalSubscriptionFactory: walletLocalSubscriptionFactory,
             priceLocalSubscriptionFactory: priceLocalSubscriptionFactory,
             stakingDashboardProviderFactory: stakingDashboardProviderFactory,
+            noticesProvider: noticesProvider,
             currencyManager: currencyManager,
             networkInfoOperationFactory: networkOperationFactory,
             eraCoundownOperationFactory: eraCountdownFactory,
@@ -176,7 +182,13 @@ struct StartStakingInfoViewFactory {
             return nil
         }
 
-        let interactor = createParachainInteractor(state: state, currencyManager: currencyManager)
+        let noticesProvider = StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
+
+        let interactor = createParachainInteractor(
+            state: state,
+            noticesProvider: noticesProvider,
+            currencyManager: currencyManager
+        )
 
         let wireframe = StartStakingInfoParachainWireframe(state: state)
         let balanceViewModelFactory = BalanceViewModelFactory(
@@ -196,6 +208,7 @@ struct StartStakingInfoViewFactory {
             balanceDerivationFactory: StakingTypeBalanceFactory(stakingType: stakingOption.type),
             localizationManager: LocalizationManager.shared,
             applicationConfig: ApplicationConfig.shared,
+            noticesProvider: noticesProvider,
             logger: Logger.shared
         )
 
@@ -213,6 +226,7 @@ struct StartStakingInfoViewFactory {
 
     private static func createParachainInteractor(
         state: ParachainStakingSharedStateProtocol,
+        noticesProvider: StakingNoticesProviding,
         currencyManager: CurrencyManagerProtocol
     ) -> StartStakingParachainInteractor {
         let selectedWalletSettings = SelectedWalletSettings.shared
@@ -244,6 +258,7 @@ struct StartStakingInfoViewFactory {
             walletLocalSubscriptionFactory: walletLocalSubscriptionFactory,
             priceLocalSubscriptionFactory: priceLocalSubscriptionFactory,
             stakingDashboardProviderFactory: stakingDashboardProviderFactory,
+            noticesProvider: noticesProvider,
             currencyManager: currencyManager,
             networkInfoFactory: ParaStkNetworkInfoOperationFactory(),
             durationOperationFactory: stakingDurationFactory,

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
@@ -79,7 +79,7 @@ struct StartStakingInfoViewFactory {
             return nil
         }
 
-        let noticesProvider = StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
+        let noticesProvider = StakingNoticesFacade.sharedProvider
 
         let interactor = createRelaychainInteractor(
             state: state,
@@ -182,7 +182,7 @@ struct StartStakingInfoViewFactory {
             return nil
         }
 
-        let noticesProvider = StakingNoticesProvider(url: ApplicationConfig.shared.stakingNoticesURL)
+        let noticesProvider = StakingNoticesFacade.sharedProvider
 
         let interactor = createParachainInteractor(
             state: state,

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoWireframe.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoWireframe.swift
@@ -1,4 +1,6 @@
 import Foundation
+import UIKit
+import UIKit_iOS
 
 class StartStakingInfoWireframe: StartStakingInfoWireframeProtocol {
     func showWalletDetails(from view: ControllerBackedProtocol?, wallet: MetaAccountModel) {
@@ -15,5 +17,30 @@ class StartStakingInfoWireframe: StartStakingInfoWireframeProtocol {
 
     func complete(from view: ControllerBackedProtocol?) {
         MainTransitionHelper.dismissAndPopBack(from: view)
+    }
+
+    func presentCriticalNoticeSheet(
+        from view: StartStakingInfoViewProtocol?,
+        title: String,
+        body: String,
+        onCancel: @escaping () -> Void,
+        onContinue: @escaping () -> Void
+    ) {
+        guard let sheetView = StartStakingCriticalNoticeSheetViewFactory.createView(
+            title: title,
+            body: body,
+            onCancel: onCancel,
+            onContinue: onContinue
+        ) else {
+            return
+        }
+
+        let factory = ModalSheetPresentationFactory(
+            configuration: ModalSheetPresentationConfiguration.nova
+        )
+        sheetView.controller.modalTransitioningFactory = factory
+        sheetView.controller.modalPresentationStyle = .custom
+
+        view?.controller.present(sheetView.controller, animated: true, completion: nil)
     }
 }

--- a/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetPresenter.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetPresenter.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Foundation_iOS
+
+final class StartStakingCriticalNoticeSheetPresenter {
+    weak var view: StartStakingCriticalNoticeSheetViewProtocol?
+
+    let onCancel: () -> Void
+    let onContinue: () -> Void
+
+    private var timer: Timer?
+    private var remainingSeconds: Int
+    private let countdownDuration: Int
+
+    private static let criticalNoticeCountdownDuration: Int = 10
+
+    init(
+        onCancel: @escaping () -> Void,
+        onContinue: @escaping () -> Void,
+        countdownDuration: Int = StartStakingCriticalNoticeSheetPresenter.criticalNoticeCountdownDuration
+    ) {
+        self.onCancel = onCancel
+        self.onContinue = onContinue
+        self.countdownDuration = countdownDuration
+        remainingSeconds = countdownDuration
+    }
+
+    deinit {
+        timer?.invalidate()
+        timer = nil
+    }
+}
+
+// MARK: - Private
+
+private extension StartStakingCriticalNoticeSheetPresenter {
+    func startTimer() {
+        remainingSeconds = countdownDuration
+        view?.didStartTimer(totalSeconds: countdownDuration)
+
+        timer = Timer.scheduledTimer(
+            withTimeInterval: 1.0,
+            repeats: true
+        ) { [weak self] _ in
+            self?.timerTick()
+        }
+    }
+
+    func timerTick() {
+        remainingSeconds -= 1
+
+        if remainingSeconds <= 0 {
+            invalidateTimer()
+            let locale = LocalizationManager.shared.selectedLocale
+            let languages = locale.rLanguages
+            let confirmTitle = R.string(preferredLanguages: languages).localizable.commonContinue()
+            view?.didFinishTimer(confirmTitle: confirmTitle)
+        } else {
+            view?.didUpdateTimer(remainingSeconds: remainingSeconds)
+        }
+    }
+
+    func invalidateTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+}
+
+// MARK: - StartStakingCriticalNoticeSheetPresenterProtocol
+
+extension StartStakingCriticalNoticeSheetPresenter: StartStakingCriticalNoticeSheetPresenterProtocol {
+    func setup() {
+        startTimer()
+    }
+
+    func cancel() {
+        invalidateTimer()
+        view?.controller.dismiss(animated: true) { [weak self] in
+            self?.onCancel()
+        }
+    }
+
+    func confirm() {
+        view?.controller.dismiss(animated: true) { [weak self] in
+            self?.onContinue()
+        }
+    }
+}

--- a/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetProtocols.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetProtocols.swift
@@ -1,0 +1,11 @@
+protocol StartStakingCriticalNoticeSheetViewProtocol: ControllerBackedProtocol {
+    func didStartTimer(totalSeconds: Int)
+    func didUpdateTimer(remainingSeconds: Int)
+    func didFinishTimer(confirmTitle: String)
+}
+
+protocol StartStakingCriticalNoticeSheetPresenterProtocol: AnyObject {
+    func setup()
+    func cancel()
+    func confirm()
+}

--- a/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetViewController.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetViewController.swift
@@ -9,7 +9,6 @@ final class StartStakingCriticalNoticeSheetViewController: UIViewController, Vie
 
     private let noticeTitle: String
     private let body: String
-    private var confirmTitle: String = ""
 
     init(
         presenter: StartStakingCriticalNoticeSheetPresenterProtocol,
@@ -43,7 +42,6 @@ final class StartStakingCriticalNoticeSheetViewController: UIViewController, Vie
         let languages = locale.rLanguages
         let localizedStrings = R.string(preferredLanguages: languages).localizable
         rootView.cancelButton.imageWithTitleView?.title = localizedStrings.commonCancel()
-        confirmTitle = localizedStrings.commonContinue()
 
         setupHandlers()
         presenter.setup()

--- a/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetViewController.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetViewController.swift
@@ -20,7 +20,7 @@ final class StartStakingCriticalNoticeSheetViewController: UIViewController, Vie
         self.body = body
         super.init(nibName: nil, bundle: nil)
 
-        preferredContentSize = CGSize(width: 0.0, height: 400.0)
+        preferredContentSize = CGSize(width: 0.0, height: 340.0)
     }
 
     @available(*, unavailable)

--- a/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetViewController.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetViewController.swift
@@ -1,0 +1,99 @@
+import UIKit
+import Foundation_iOS
+import UIKit_iOS
+
+final class StartStakingCriticalNoticeSheetViewController: UIViewController, ViewHolder {
+    typealias RootViewType = StartStakingCriticalNoticeSheetViewLayout
+
+    let presenter: StartStakingCriticalNoticeSheetPresenterProtocol
+
+    private let noticeTitle: String
+    private let body: String
+    private var confirmTitle: String = ""
+
+    init(
+        presenter: StartStakingCriticalNoticeSheetPresenterProtocol,
+        title: String,
+        body: String
+    ) {
+        self.presenter = presenter
+        noticeTitle = title
+        self.body = body
+        super.init(nibName: nil, bundle: nil)
+
+        preferredContentSize = CGSize(width: 0.0, height: 400.0)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = StartStakingCriticalNoticeSheetViewLayout()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        rootView.titleLabel.text = noticeTitle
+        rootView.bodyLabel.text = body
+
+        let locale = LocalizationManager.shared.selectedLocale
+        let languages = locale.rLanguages
+        let localizedStrings = R.string(preferredLanguages: languages).localizable
+        rootView.cancelButton.imageWithTitleView?.title = localizedStrings.commonCancel()
+        confirmTitle = localizedStrings.commonContinue()
+
+        setupHandlers()
+        presenter.setup()
+    }
+}
+
+// MARK: - Private
+
+private extension StartStakingCriticalNoticeSheetViewController {
+    func setupHandlers() {
+        rootView.cancelButton.addTarget(
+            self,
+            action: #selector(actionCancel),
+            for: .touchUpInside
+        )
+        rootView.timerButton.addTarget(
+            self,
+            action: #selector(actionConfirm),
+            for: .touchUpInside
+        )
+    }
+
+    @objc func actionCancel() {
+        presenter.cancel()
+    }
+
+    @objc func actionConfirm() {
+        presenter.confirm()
+    }
+}
+
+// MARK: - StartStakingCriticalNoticeSheetViewProtocol
+
+extension StartStakingCriticalNoticeSheetViewController: StartStakingCriticalNoticeSheetViewProtocol {
+    func didStartTimer(totalSeconds: Int) {
+        rootView.timerButton.startTimer(totalSeconds: totalSeconds)
+    }
+
+    func didUpdateTimer(remainingSeconds: Int) {
+        rootView.timerButton.updateTimerLabel(remainingSeconds: remainingSeconds)
+    }
+
+    func didFinishTimer(confirmTitle: String) {
+        rootView.timerButton.finishTimer(title: confirmTitle)
+    }
+}
+
+// MARK: - ModalPresenterDelegate
+
+extension StartStakingCriticalNoticeSheetViewController: ModalPresenterDelegate {
+    func presenterShouldHide(_: ModalPresenterProtocol) -> Bool { false }
+    func presenterDidHide(_: ModalPresenterProtocol) {}
+}

--- a/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetViewFactory.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetViewFactory.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct StartStakingCriticalNoticeSheetViewFactory {
+    static func createView(
+        title: String,
+        body: String,
+        onCancel: @escaping () -> Void,
+        onContinue: @escaping () -> Void
+    ) -> StartStakingCriticalNoticeSheetViewProtocol? {
+        let presenter = StartStakingCriticalNoticeSheetPresenter(
+            onCancel: onCancel,
+            onContinue: onContinue
+        )
+
+        let view = StartStakingCriticalNoticeSheetViewController(
+            presenter: presenter,
+            title: title,
+            body: body
+        )
+
+        presenter.view = view
+
+        return view
+    }
+}

--- a/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetViewLayout.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetViewLayout.swift
@@ -31,7 +31,9 @@ final class StartStakingCriticalNoticeSheetViewLayout: UIView {
         view.applySecondaryDefaultStyle()
     }
 
-    let timerButton: TimerButton = .create { _ in }
+    let timerButton: TimerButton = .create { view in
+        view.activeColor = R.color.colorButtonBackgroundReject()!
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetViewLayout.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingCriticalNoticeSheetViewLayout.swift
@@ -1,0 +1,92 @@
+import UIKit
+
+final class StartStakingCriticalNoticeSheetViewLayout: UIView {
+    let iconView: GenericBorderedView<UIImageView> = .create { view in
+        view.contentView.image = R.image.iconWarningApp()!
+        view.contentView.contentMode = .scaleAspectFit
+
+        view.contentInsets = .init(inset: (Constants.iconContainerSize - Constants.iconSize) / 2)
+        view.backgroundView.apply(style: .selectableContainer(radius: 20))
+    }
+
+    let titleLabel: UILabel = .create { view in
+        view.apply(style: .title3Primary)
+        view.numberOfLines = 0
+        view.textAlignment = .center
+    }
+
+    let bodyLabel: UILabel = .create { view in
+        view.apply(style: .footnoteSecondary)
+        view.numberOfLines = 0
+        view.textAlignment = .center
+    }
+
+    private let buttonsStackView: UIStackView = .create { view in
+        view.axis = .horizontal
+        view.spacing = 12
+        view.distribution = .fillEqually
+    }
+
+    let cancelButton: TriangularedButton = .create { view in
+        view.applySecondaryDefaultStyle()
+    }
+
+    let timerButton: TimerButton = .create { _ in }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = R.color.colorBottomSheetBackground()
+        setupLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Private
+
+private extension StartStakingCriticalNoticeSheetViewLayout {
+    func setupLayout() {
+        addSubview(iconView)
+        iconView.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(16)
+            make.size.equalTo(Constants.iconContainerSize)
+            make.centerX.equalToSuperview()
+        }
+
+        addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(iconView.snp.bottom).offset(24)
+            make.leading.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
+        }
+
+        addSubview(bodyLabel)
+        bodyLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(8)
+            make.leading.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
+        }
+
+        buttonsStackView.addArrangedSubview(cancelButton)
+        buttonsStackView.addArrangedSubview(timerButton)
+
+        addSubview(buttonsStackView)
+        buttonsStackView.snp.makeConstraints { make in
+            make.top.equalTo(bodyLabel.snp.bottom).offset(24)
+            make.leading.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
+            make.height.equalTo(UIConstants.actionHeight)
+            make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).offset(-UIConstants.actionBottomInset)
+        }
+    }
+}
+
+// MARK: - Constants
+
+private extension StartStakingCriticalNoticeSheetViewLayout {
+    enum Constants {
+        static let iconSize: CGFloat = 66
+        static let iconContainerSize: CGFloat = 88
+    }
+}

--- a/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingInfoViewLayout.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/View/StartStakingInfoViewLayout.swift
@@ -6,6 +6,8 @@ final class StartStakingInfoViewLayout: ScrollableContainerLayoutView {
     let paragraphStyle: MultiColorTextStyle
     var skeletonView: SkrullableView?
 
+    let noticeBlock = StakingNoticeBlockView()
+
     var header: StackTableHeaderCell = .create {
         $0.titleLabel.textAlignment = .center
     }
@@ -96,6 +98,10 @@ final class StartStakingInfoViewLayout: ScrollableContainerLayoutView {
         }
     }
 
+    func bindNotice(_ model: StakingNoticeBlockView.Model?) {
+        noticeBlock.bind(model)
+    }
+
     func updateContent(
         title: AccentTextModel,
         paragraphs: [ParagraphView.Model],
@@ -111,6 +117,7 @@ final class StartStakingInfoViewLayout: ScrollableContainerLayoutView {
 
         stackView.spacing = Constants.containerSpacing
 
+        setNotice()
         set(title: title)
         set(paragraphs: paragraphs)
         setWiki(urlModel: wikiUrl)
@@ -122,6 +129,11 @@ final class StartStakingInfoViewLayout: ScrollableContainerLayoutView {
         actionView.actionButton.imageWithTitleView?.title = R.string(
             preferredLanguages: locale.rLanguages
         ).localizable.stakingStartTitle()
+    }
+
+    private func setNotice() {
+        stackView.addArrangedSubview(noticeBlock)
+        stackView.setCustomSpacing(Constants.noticeSpacing, after: noticeBlock)
     }
 
     private func set(title: AccentTextModel) {
@@ -293,6 +305,7 @@ extension StartStakingInfoViewLayout {
             right: 16
         )
         static let containerSpacing: CGFloat = 32
+        static let noticeSpacing: CGFloat = 16
         static let wikiAndTermsSpacing: CGFloat = 16
         static let actionViewHeight: CGFloat = UIConstants.actionHeight
         static let footerBorderWidth: CGFloat = 1

--- a/novawallet/en.lproj/Localizable.strings
+++ b/novawallet/en.lproj/Localizable.strings
@@ -2042,3 +2042,4 @@ Do you want to continue?";
 "inlinable.alert.wo.message" = "Beware of scammers. No one can unlock a watch-only wallet or its funds";
 "create.watch.only.missing.any.address" = "Enter at least one address...";
 "asset.list.watch.only.balance" = "Watch-only balance";
+"staking.notice.chip" = "Notice";

--- a/novawallet/es.lproj/Localizable.strings
+++ b/novawallet/es.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "Introduce al menos una dirección...";
 "asset.list.watch.only.balance" = "Saldo solo de visualización";
 "create.watch.only.subtitle" = "Sigue la actividad de la cartera sin una clave privada.\nNo podrás realizar ninguna transacción.";
+"staking.notice.chip" = "Aviso";

--- a/novawallet/fr.lproj/Localizable.strings
+++ b/novawallet/fr.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "Entrez au moins une adresse...";
 "asset.list.watch.only.balance" = "Solde en consultation seulement";
 "create.watch.only.subtitle" = "Suivez l'activité du portefeuille sans clé privée.\nVous ne pourrez effectuer aucune transaction.";
+"staking.notice.chip" = "Avis";

--- a/novawallet/hu.lproj/Localizable.strings
+++ b/novawallet/hu.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "Adjon meg legalább egy címet...";
 "asset.list.watch.only.balance" = "Csak-figyelési egyenleg";
 "create.watch.only.subtitle" = "Pénztárca aktivitás nyomon követése privát kulcs nélkül.\nNem lesz képes tranzakciók végrehajtására.";
+"staking.notice.chip" = "Értesítés";

--- a/novawallet/id.lproj/Localizable.strings
+++ b/novawallet/id.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "Masukkan setidaknya satu alamat...";
 "asset.list.watch.only.balance" = "Saldo untuk dilihat saja";
 "create.watch.only.subtitle" = "Lacak aktivitas dompet tanpa kunci privat.\nAnda tidak akan dapat melakukan transaksi apapun.";
+"staking.notice.chip" = "Pemberitahuan";

--- a/novawallet/it.lproj/Localizable.strings
+++ b/novawallet/it.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "Inserisci almeno un indirizzo...";
 "asset.list.watch.only.balance" = "Saldo solo visualizzazione";
 "create.watch.only.subtitle" = "Tieni traccia dell’attività del portafoglio senza una chiave privata.\nNon potrai eseguire alcuna transazione.";
+"staking.notice.chip" = "Avviso";

--- a/novawallet/ja.lproj/Localizable.strings
+++ b/novawallet/ja.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "少なくとも1つのアドレスを入力してください...";
 "asset.list.watch.only.balance" = "ウォッチオンリーバランス";
 "create.watch.only.subtitle" = "秘密鍵を使わずにウォレットのアクティビティを追跡することができます。\nトランザクションを実行することはできません。";
+"staking.notice.chip" = "通知";

--- a/novawallet/ko.lproj/Localizable.strings
+++ b/novawallet/ko.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "최소 하나의 주소를 입력하세요...";
 "asset.list.watch.only.balance" = "보기 전용 잔액";
 "create.watch.only.subtitle" = "비공개 키 없이 지갑 활동을 추적합니다.\n어떠한 거래도 수행할 수 없습니다.";
+"staking.notice.chip" = "안내";

--- a/novawallet/pl.lproj/Localizable.strings
+++ b/novawallet/pl.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "Wprowadź co najmniej jeden adres...";
 "asset.list.watch.only.balance" = "Saldo tylko do obserwacji";
 "create.watch.only.subtitle" = "Śledź aktywność portfela bez klucza prywatnego.\nNie będziesz w stanie przeprowadzać żadnych transakcji.";
+"staking.notice.chip" = "Uwaga";

--- a/novawallet/pt-PT.lproj/Localizable.strings
+++ b/novawallet/pt-PT.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "Insira pelo menos um endereço...";
 "asset.list.watch.only.balance" = "Saldo somente de visualização";
 "create.watch.only.subtitle" = "Acompanhe a atividade da carteira sem uma chave privada.\nVocê não poderá realizar transações.";
+"staking.notice.chip" = "Aviso";

--- a/novawallet/ru.lproj/Localizable.strings
+++ b/novawallet/ru.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "Введите хотя бы один адрес...";
 "asset.list.watch.only.balance" = "Только просмотр баланса";
 "create.watch.only.subtitle" = "Отслеживание активности кошелька без приватного ключа.\nВы не сможете выполнить никакие транзакции.";
+"staking.notice.chip" = "Уведомление";

--- a/novawallet/tr.lproj/Localizable.strings
+++ b/novawallet/tr.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "En az bir adres girin...";
 "asset.list.watch.only.balance" = "Sadece-izleme bakiyesi";
 "create.watch.only.subtitle" = "Cüzdan aktivitesini özel anahtar olmadan izleyin.\nHerhangi bir işlem gerçekleştiremezsiniz.";
+"staking.notice.chip" = "Bildirim";

--- a/novawallet/vi.lproj/Localizable.strings
+++ b/novawallet/vi.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "Nhập ít nhất một địa chỉ...";
 "asset.list.watch.only.balance" = "Số dư chỉ theo dõi";
 "create.watch.only.subtitle" = "Theo dõi hoạt động ví mà không cần khóa riêng.\nBạn sẽ không thể thực hiện bất kỳ giao dịch nào.";
+"staking.notice.chip" = "Thông báo";

--- a/novawallet/zh-Hans.lproj/Localizable.strings
+++ b/novawallet/zh-Hans.lproj/Localizable.strings
@@ -2035,3 +2035,4 @@
 "create.watch.only.missing.any.address" = "请输入至少一个地址...";
 "asset.list.watch.only.balance" = "仅观察余额";
 "create.watch.only.subtitle" = "在没有私钥的情况下跟踪钱包活动。\n您将无法执行任何交易。";
+"staking.notice.chip" = "通知";

--- a/novawalletTests/Common/Services/ChainRegistry/ChainRegistryTests.swift
+++ b/novawalletTests/Common/Services/ChainRegistry/ChainRegistryTests.swift
@@ -3,6 +3,15 @@ import XCTest
 import Operation_iOS
 import Cuckoo
 
+// No-op stub for tests that don't care about staking-notices behavior.
+private final class NoOpStakingNoticesProvider: StakingNoticesProviding {
+    var allNotices: [ChainModel.Id: StakingNotice] { [:] }
+    func notice(for _: ChainModel.Id) -> StakingNotice? { nil }
+    func refresh() {}
+    func subscribe(_: AnyObject, callback _: @escaping () -> Void) {}
+    func unsubscribe(_: AnyObject) {}
+}
+
 class ChainRegistryTests: XCTestCase {
     func testSetupCompletionWhenAllChainsFullySynced() throws {
         // given
@@ -139,6 +148,7 @@ class ChainRegistryTests: XCTestCase {
             chainSyncService: chainSyncService,
             runtimeSyncService: runtimeSyncService,
             commonTypesSyncService: commonTypesSyncService,
+            stakingNoticesProvider: NoOpStakingNoticesProvider(),
             chainProvider: chainProvider,
             specVersionSubscriptionFactory: specVersionSubscriptionFactory,
             logger: Logger.shared

--- a/novawalletTests/Common/Services/StakingNotices/StakingNoticeDecodingTests.swift
+++ b/novawalletTests/Common/Services/StakingNotices/StakingNoticeDecodingTests.swift
@@ -39,6 +39,66 @@ final class StakingNoticeDecodingTests: XCTestCase {
         XCTAssertEqual(notice.longText, "Rewards may pause briefly.")
     }
 
+    func testDecodesV2LocaleMapPicksPreferredLocale() throws {
+        let json = """
+        {
+          "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+          "severity": "info",
+          "shortText": {"en": "Validator program update", "ru": "Обновление программы валидаторов"},
+          "longText": {"en": "Rewards may pause briefly.", "ru": "Награды могут приостановиться."}
+        }
+        """.data(using: .utf8)!
+
+        let localized = JSONDecoder()
+        localized.userInfo[.stakingNoticePreferredLocale] = "ru_RU"
+
+        let notice = try localized.decode(StakingNotice.self, from: json)
+
+        XCTAssertEqual(notice.shortText, "Обновление программы валидаторов")
+        XCTAssertEqual(notice.longText, "Награды могут приостановиться.")
+    }
+
+    func testDecodesV2LocaleMapFallsBackToLanguageWhenRegionMissing() throws {
+        let json = """
+        {
+          "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+          "severity": "info",
+          "shortText": {"en": "Update", "pt": "Atualização"},
+          "longText": {"en": "Body.", "pt": "Corpo."}
+        }
+        """.data(using: .utf8)!
+
+        let localized = JSONDecoder()
+        // Preferred is pt_PT (Portugal) but the map only has the generic `pt` key —
+        // parser should strip the region and find `pt`.
+        localized.userInfo[.stakingNoticePreferredLocale] = "pt_PT"
+
+        let notice = try localized.decode(StakingNotice.self, from: json)
+
+        XCTAssertEqual(notice.shortText, "Atualização")
+        XCTAssertEqual(notice.longText, "Corpo.")
+    }
+
+    func testDecodesV2LocaleMapFallsBackToEnglishWhenPreferredAbsent() throws {
+        let json = """
+        {
+          "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+          "severity": "info",
+          "shortText": {"en": "Update", "ru": "Обновление"},
+          "longText": {"en": "Body.", "ru": "Тело."}
+        }
+        """.data(using: .utf8)!
+
+        let localized = JSONDecoder()
+        // Preferred is Japanese but the map only has en/ru — should fall back to en.
+        localized.userInfo[.stakingNoticePreferredLocale] = "ja_JP"
+
+        let notice = try localized.decode(StakingNotice.self, from: json)
+
+        XCTAssertEqual(notice.shortText, "Update")
+        XCTAssertEqual(notice.longText, "Body.")
+    }
+
     func testEndDateIsOptional() throws {
         let json = """
         {

--- a/novawalletTests/Common/Services/StakingNotices/StakingNoticeDecodingTests.swift
+++ b/novawalletTests/Common/Services/StakingNotices/StakingNoticeDecodingTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import novawallet
+
+final class StakingNoticeDecodingTests: XCTestCase {
+    private let decoder = JSONDecoder()
+
+    func testDecodesV1PlainStringSchema() throws {
+        let json = """
+        {
+          "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1c4b2599b87487420976a",
+          "severity": "critical",
+          "shortText": "Migrate by Aug 1, 2026",
+          "longText": "The Manta Atlantic parachain slot expires August 1, 2026.",
+          "endDate": "2026-08-01"
+        }
+        """.data(using: .utf8)!
+
+        let notice = try decoder.decode(StakingNotice.self, from: json)
+
+        XCTAssertEqual(notice.severity, .critical)
+        XCTAssertEqual(notice.shortText, "Migrate by Aug 1, 2026")
+        XCTAssertEqual(notice.longText, "The Manta Atlantic parachain slot expires August 1, 2026.")
+        XCTAssertNotNil(notice.endDate)
+    }
+
+    func testDecodesV2LocaleMapSchemaFallsBackToEnglish() throws {
+        let json = """
+        {
+          "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+          "severity": "info",
+          "shortText": {"en": "Validator program update", "ru": "Обновление программы валидаторов"},
+          "longText": {"en": "Rewards may pause briefly.", "ru": "Награды могут приостановиться."}
+        }
+        """.data(using: .utf8)!
+
+        let notice = try decoder.decode(StakingNotice.self, from: json)
+
+        XCTAssertEqual(notice.shortText, "Validator program update")
+        XCTAssertEqual(notice.longText, "Rewards may pause briefly.")
+    }
+
+    func testEndDateIsOptional() throws {
+        let json = """
+        {
+          "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+          "severity": "info",
+          "shortText": "x",
+          "longText": "y"
+        }
+        """.data(using: .utf8)!
+
+        let notice = try decoder.decode(StakingNotice.self, from: json)
+        XCTAssertNil(notice.endDate)
+    }
+
+    func testRejectsLocaleMapWithoutEnglishFallback() {
+        let json = """
+        {
+          "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+          "severity": "info",
+          "shortText": {"ru": "Привет"},
+          "longText": "y"
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertThrowsError(try decoder.decode(StakingNotice.self, from: json))
+    }
+
+    func testRejectsInvalidEndDate() {
+        let json = """
+        {
+          "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+          "severity": "info",
+          "shortText": "x",
+          "longText": "y",
+          "endDate": "next Friday"
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertThrowsError(try decoder.decode(StakingNotice.self, from: json))
+    }
+
+    func testRejectsUnknownSeverity() {
+        let json = """
+        {
+          "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+          "severity": "urgent",
+          "shortText": "x",
+          "longText": "y"
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertThrowsError(try decoder.decode(StakingNotice.self, from: json))
+    }
+}

--- a/novawalletTests/Common/Services/StakingNotices/StakingNoticesProviderTests.swift
+++ b/novawalletTests/Common/Services/StakingNotices/StakingNoticesProviderTests.swift
@@ -1,5 +1,41 @@
 import XCTest
+import Foundation_iOS
 @testable import novawallet
+
+// Minimal stub — only what StakingNoticesProvider needs.
+private final class StubLocalizationManager: LocalizationManagerProtocol {
+    var selectedLocalization: String
+    var availableLocalizations: [String]
+    private var observers: [(owner: Weak<AnyObject>, queue: DispatchQueue?, closure: LocalizationChangeClosure)] = []
+
+    init(localization: String = "en") {
+        selectedLocalization = localization
+        availableLocalizations = [localization]
+    }
+
+    func addObserver(with owner: AnyObject, queue: DispatchQueue?, closure: @escaping LocalizationChangeClosure) {
+        observers.append((Weak(owner), queue, closure))
+    }
+
+    func removeObserver(by owner: AnyObject) {
+        observers.removeAll { $0.owner.value === owner }
+    }
+
+    func simulateChange(from old: String, to new: String) {
+        selectedLocalization = new
+        observers = observers.filter { $0.owner.value != nil }
+        for obs in observers {
+            let fire = { obs.closure(old, new) }
+            if let q = obs.queue { q.async(execute: fire) } else { fire() }
+        }
+    }
+}
+
+// Tiny weak-box so the stub can hold observers weakly (matching LocalizationManager behaviour).
+private struct Weak<T: AnyObject> {
+    weak var value: T?
+    init(_ v: T) { value = v }
+}
 
 final class StakingNoticesProviderTests: XCTestCase {
     private var tempCacheURL: URL!
@@ -62,5 +98,72 @@ final class StakingNoticesProviderTests: XCTestCase {
 
         // loadFromDisk() is synchronous in init — no drain needed.
         XCTAssertEqual(provider.allNotices.count, 1)
+    }
+
+    // MARK: - Locale tests
+
+    /// Provider must use LocalizationManager.selectedLocalization, NOT Locale.preferredLanguages.
+    /// Regression test for the bug where Spanish UI showed English notice text because
+    /// Locale.preferredLanguages returned "en-US" even after Nova's in-app language switch.
+    func testUsesLocalizationManagerLocaleNotSystemLocale() throws {
+        let json = """
+        [{
+          "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+          "severity": "info",
+          "shortText": {"en": "English text", "es": "Texto en español"},
+          "longText": {"en": "English body", "es": "Cuerpo en español"}
+        }]
+        """.data(using: .utf8)!
+        try json.write(to: tempCacheURL)
+
+        let locManager = StubLocalizationManager(localization: "es")
+        let provider = StakingNoticesProvider(
+            url: URL(string: "https://example.com/x.json")!,
+            cacheURL: tempCacheURL,
+            localizationManager: locManager
+        )
+
+        let notice = provider.allNotices["70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e"]
+        XCTAssertEqual(
+            notice?.shortText,
+            "Texto en español",
+            "Provider must pick locale from LocalizationManager, not Locale.preferredLanguages"
+        )
+        XCTAssertEqual(notice?.longText, "Cuerpo en español")
+    }
+
+    /// When the user switches app language, the provider re-decodes cached JSON and emits
+    /// updated notices — no network fetch required.
+    func testReDecodesOnLocalizationChange() throws {
+        let json = """
+        [{
+          "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+          "severity": "info",
+          "shortText": {"en": "English text", "ru": "Текст на русском"},
+          "longText": {"en": "English body", "ru": "Тело на русском"}
+        }]
+        """.data(using: .utf8)!
+        try json.write(to: tempCacheURL)
+
+        let locManager = StubLocalizationManager(localization: "en")
+        let provider = StakingNoticesProvider(
+            url: URL(string: "https://example.com/x.json")!,
+            cacheURL: tempCacheURL,
+            localizationManager: locManager
+        )
+
+        let chainId = "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e"
+        XCTAssertEqual(provider.allNotices[chainId]?.shortText, "English text")
+
+        // Simulate in-app language switch: observer fires on .main
+        let expectation = self.expectation(description: "notice updated to Russian")
+        provider.subscribe(self) {
+            if provider.allNotices[chainId]?.shortText == "Текст на русском" {
+                expectation.fulfill()
+            }
+        }
+        locManager.simulateChange(from: "en", to: "ru")
+
+        waitForExpectations(timeout: 1.0)
     }
 }

--- a/novawalletTests/Common/Services/StakingNotices/StakingNoticesProviderTests.swift
+++ b/novawalletTests/Common/Services/StakingNotices/StakingNoticesProviderTests.swift
@@ -37,11 +37,7 @@ final class StakingNoticesProviderTests: XCTestCase {
             cacheURL: tempCacheURL
         )
 
-        // Drain the queue so init's loadFromDisk completes.
-        let exp = expectation(description: "load")
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) { exp.fulfill() }
-        wait(for: [exp], timeout: 1)
-
+        // loadFromDisk() is synchronous in init — no drain needed.
         XCTAssertEqual(provider.allNotices.count, 1)
     }
 
@@ -63,10 +59,8 @@ final class StakingNoticesProviderTests: XCTestCase {
             url: URL(string: "https://example.com/x.json")!,
             cacheURL: tempCacheURL
         )
-        let exp = expectation(description: "load")
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) { exp.fulfill() }
-        wait(for: [exp], timeout: 1)
 
+        // loadFromDisk() is synchronous in init — no drain needed.
         XCTAssertEqual(provider.allNotices.count, 1)
     }
 }

--- a/novawalletTests/Common/Services/StakingNotices/StakingNoticesProviderTests.swift
+++ b/novawalletTests/Common/Services/StakingNotices/StakingNoticesProviderTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import novawallet
+
+final class StakingNoticesProviderTests: XCTestCase {
+    private var tempCacheURL: URL!
+
+    override func setUpWithError() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        tempCacheURL = tempDir.appendingPathComponent("staking_notices_test_\(UUID().uuidString).json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempCacheURL)
+    }
+
+    func testEmptyOnFirstLaunch() {
+        let provider = StakingNoticesProvider(
+            url: URL(string: "https://example.com/x.json")!,
+            cacheURL: tempCacheURL
+        )
+        XCTAssertTrue(provider.allNotices.isEmpty)
+    }
+
+    func testLoadsCachedFileOnInit() throws {
+        let json = """
+        [{
+          "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+          "severity": "info",
+          "shortText": "Test",
+          "longText": "Test long"
+        }]
+        """.data(using: .utf8)!
+        try json.write(to: tempCacheURL)
+
+        let provider = StakingNoticesProvider(
+            url: URL(string: "https://example.com/x.json")!,
+            cacheURL: tempCacheURL
+        )
+
+        // Drain the queue so init's loadFromDisk completes.
+        let exp = expectation(description: "load")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) { exp.fulfill() }
+        wait(for: [exp], timeout: 1)
+
+        XCTAssertEqual(provider.allNotices.count, 1)
+    }
+
+    func testMalformedEntryDoesNotBreakBatch() {
+        let json = """
+        [
+          {"chainId": "bad-entry-missing-fields"},
+          {
+            "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+            "severity": "info",
+            "shortText": "Test",
+            "longText": "Test long"
+          }
+        ]
+        """.data(using: .utf8)!
+        try? json.write(to: tempCacheURL)
+
+        let provider = StakingNoticesProvider(
+            url: URL(string: "https://example.com/x.json")!,
+            cacheURL: tempCacheURL
+        )
+        let exp = expectation(description: "load")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) { exp.fulfill() }
+        wait(for: [exp], timeout: 1)
+
+        XCTAssertEqual(provider.allNotices.count, 1)
+    }
+}

--- a/novawalletTests/Modules/Staking/Dashboard/StakingDashboardBuilderDemotionTests.swift
+++ b/novawalletTests/Modules/Staking/Dashboard/StakingDashboardBuilderDemotionTests.swift
@@ -1,9 +1,8 @@
 import XCTest
+import BigInt
 @testable import novawallet
 
 final class StakingDashboardBuilderDemotionTests: XCTestCase {
-    var resultModel: StakingDashboardModel?
-
     func testDemotedChainRoutesToMoreOptions() {
         // given
         let alephZeroChain = ChainModelGenerator.generateChain(
@@ -16,33 +15,38 @@ final class StakingDashboardBuilderDemotionTests: XCTestCase {
         let asset = alephZeroChain.assets.first!
         let chainAsset = ChainAsset(chain: alephZeroChain, asset: asset)
 
+        let expectation = XCTestExpectation(description: "result closure called")
+        var resultModel: StakingDashboardModel?
+
+        let callbackQueue = DispatchQueue(label: "test.callback")
         let builder = StakingDashboardBuilder(
-            callbackQueue: .main,
-            resultClosure: { [weak self] result in
-                self?.resultModel = result.model
+            callbackQueue: callbackQueue,
+            resultClosure: { result in
+                resultModel = result.model
+                expectation.fulfill()
             }
         )
 
         builder.applyAssets(models: [chainAsset])
 
         // when
+        wait(for: [expectation], timeout: 5)
         let model = resultModel
 
         // then
         XCTAssertNotNil(model, "Model should be generated")
 
-        let moreChainIds = Set(model?.more.compactMap { item in
-            item.chainAsset.chain.chainId
-        } ?? [])
+        let moreChainIds = Set(model?.more.map(\.chainAsset.chain.chainId) ?? [])
+        let inactiveChainIds = Set(model?.inactive.map(\.chainAsset.chain.chainId) ?? [])
 
-        let inactiveChainIds = Set(model?.inactive.compactMap { item in
-            item.chainAsset.chain.chainId
-        } ?? [])
-
-        XCTAssertTrue(moreChainIds.contains(KnowChainId.alephZero),
-                      "Aleph Zero should be in more options")
-        XCTAssertFalse(inactiveChainIds.contains(KnowChainId.alephZero),
-                       "Aleph Zero should NOT be in inactive section")
+        XCTAssertTrue(
+            moreChainIds.contains(KnowChainId.alephZero),
+            "Aleph Zero should be in more options"
+        )
+        XCTAssertFalse(
+            inactiveChainIds.contains(KnowChainId.alephZero),
+            "Aleph Zero should NOT be in inactive section"
+        )
     }
 
     func testNonDemotedChainRoutesToInactiveSection() {
@@ -57,33 +61,38 @@ final class StakingDashboardBuilderDemotionTests: XCTestCase {
         let asset = polkadotChain.assets.first!
         let chainAsset = ChainAsset(chain: polkadotChain, asset: asset)
 
+        let expectation = XCTestExpectation(description: "result closure called")
+        var resultModel: StakingDashboardModel?
+
+        let callbackQueue = DispatchQueue(label: "test.callback")
         let builder = StakingDashboardBuilder(
-            callbackQueue: .main,
-            resultClosure: { [weak self] result in
-                self?.resultModel = result.model
+            callbackQueue: callbackQueue,
+            resultClosure: { result in
+                resultModel = result.model
+                expectation.fulfill()
             }
         )
 
         builder.applyAssets(models: [chainAsset])
 
         // when
+        wait(for: [expectation], timeout: 5)
         let model = resultModel
 
         // then
         XCTAssertNotNil(model, "Model should be generated")
 
-        let moreChainIds = Set(model?.more.compactMap { item in
-            item.chainAsset.chain.chainId
-        } ?? [])
+        let moreChainIds = Set(model?.more.map(\.chainAsset.chain.chainId) ?? [])
+        let inactiveChainIds = Set(model?.inactive.map(\.chainAsset.chain.chainId) ?? [])
 
-        let inactiveChainIds = Set(model?.inactive.compactMap { item in
-            item.chainAsset.chain.chainId
-        } ?? [])
-
-        XCTAssertTrue(inactiveChainIds.contains(KnowChainId.polkadot),
-                      "Polkadot should be in inactive section")
-        XCTAssertFalse(moreChainIds.contains(KnowChainId.polkadot),
-                       "Polkadot should NOT be in more options")
+        XCTAssertTrue(
+            inactiveChainIds.contains(KnowChainId.polkadot),
+            "Polkadot should be in inactive section"
+        )
+        XCTAssertFalse(
+            moreChainIds.contains(KnowChainId.polkadot),
+            "Polkadot should NOT be in more options"
+        )
     }
 
     func testDemotedChainWithActiveStakeStillAppearsInActive() {
@@ -98,39 +107,7 @@ final class StakingDashboardBuilderDemotionTests: XCTestCase {
         let asset = alephZeroChain.assets.first!
         let chainAsset = ChainAsset(chain: alephZeroChain, asset: asset)
 
-        // Create a mock wallet
-        let account = AccountModel(
-            address: "test_address",
-            cryptoType: .sr25519,
-            publicKey: Data(repeating: 0, count: 32),
-            username: "Test User"
-        )
-
-        let chainAccountRequest = ChainAccountRequest(
-            networkType: alephZeroChain.chainNetworkType,
-            cryptoType: .sr25519
-        )
-
-        let walletModel = MetaAccountModel(
-            metaId: "test_meta_id",
-            name: "Test Wallet",
-            substratePublicKey: Data(repeating: 0, count: 32),
-            substrateAccountId: account.accountId,
-            ethereumAddress: nil,
-            ethereumPublicKey: nil,
-            chainAccounts: [
-                ChainAccount(
-                    chainId: alephZeroChain.chainId,
-                    accountId: account.accountId,
-                    publicKey: account.publicKey,
-                    cryptoType: account.cryptoType,
-                    username: account.username
-                )
-            ],
-            type: .substrate,
-            googleBackupName: nil,
-            isBackedUp: false
-        )
+        let walletModel = AccountGenerator.generateMetaAccount()
 
         let dashboardItem = Multistaking.DashboardItem(
             stakingOption: .init(
@@ -140,27 +117,47 @@ final class StakingDashboardBuilderDemotionTests: XCTestCase {
                     type: .relaychain
                 )
             ),
-            onchainState: .bonded,
+            onchainState: .active,
             hasAssignedStake: true,
-            stake: BigUInt(1000000000000),
+            stake: BigUInt(1_000_000_000_000),
             totalRewards: nil,
             maxApy: nil
         )
 
+        let expectationWallet = XCTestExpectation(description: "wallet result closure called")
+        let expectationAssets = XCTestExpectation(description: "assets result closure called")
+        let expectationDashboard = XCTestExpectation(description: "dashboard result closure called")
+
+        var callCount = 0
+        var resultModel: StakingDashboardModel?
+
+        let callbackQueue = DispatchQueue(label: "test.callback")
         let builder = StakingDashboardBuilder(
-            callbackQueue: .main,
-            resultClosure: { [weak self] result in
-                self?.resultModel = result.model
+            callbackQueue: callbackQueue,
+            resultClosure: { result in
+                callCount += 1
+                resultModel = result.model
+                switch callCount {
+                case 1:
+                    expectationWallet.fulfill()
+                case 2:
+                    expectationAssets.fulfill()
+                case 3:
+                    expectationDashboard.fulfill()
+                default:
+                    break
+                }
             }
         )
 
         builder.applyWallet(model: walletModel)
+        wait(for: [expectationWallet], timeout: 5)
+
         builder.applyAssets(models: [chainAsset])
-        builder.applyDashboardItem(
-            changes: [
-                .insert(dashboardItem)
-            ]
-        )
+        wait(for: [expectationAssets], timeout: 5)
+
+        builder.applyDashboardItem(changes: [.insert(newItem: dashboardItem)])
+        wait(for: [expectationDashboard], timeout: 5)
 
         // when
         let model = resultModel
@@ -168,17 +165,16 @@ final class StakingDashboardBuilderDemotionTests: XCTestCase {
         // then
         XCTAssertNotNil(model, "Model should be generated")
 
-        let activeChainIds = Set(model?.active.compactMap { item in
-            item.chainAsset.chain.chainId
-        } ?? [])
+        let activeChainIds = Set(model?.active.map(\.stakingOption.chainAsset.chain.chainId) ?? [])
+        let moreChainIds = Set(model?.more.map(\.chainAsset.chain.chainId) ?? [])
 
-        let moreChainIds = Set(model?.more.compactMap { item in
-            item.chainAsset.chain.chainId
-        } ?? [])
-
-        XCTAssertTrue(activeChainIds.contains(KnowChainId.alephZero),
-                      "Aleph Zero with active stake should be in active section")
-        XCTAssertFalse(moreChainIds.contains(KnowChainId.alephZero),
-                       "Aleph Zero with active stake should NOT be in more options")
+        XCTAssertTrue(
+            activeChainIds.contains(KnowChainId.alephZero),
+            "Aleph Zero with active stake should be in active section"
+        )
+        XCTAssertFalse(
+            moreChainIds.contains(KnowChainId.alephZero),
+            "Aleph Zero with active stake should NOT be in more options"
+        )
     }
 }

--- a/novawalletTests/Modules/Staking/Dashboard/StakingDashboardBuilderDemotionTests.swift
+++ b/novawalletTests/Modules/Staking/Dashboard/StakingDashboardBuilderDemotionTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import novawallet
+
+final class StakingDashboardBuilderDemotionTests: XCTestCase {
+    var resultModel: StakingDashboardModel?
+
+    func testDemotedChainRoutesToMoreOptions() {
+        // given
+        let alephZeroChain = ChainModelGenerator.generateChain(
+            defaultChainId: KnowChainId.alephZero,
+            generatingAssets: 1,
+            addressPrefix: 42,
+            hasStaking: true
+        )
+
+        let asset = alephZeroChain.assets.first!
+        let chainAsset = ChainAsset(chain: alephZeroChain, asset: asset)
+
+        let builder = StakingDashboardBuilder(
+            callbackQueue: .main,
+            resultClosure: { [weak self] result in
+                self?.resultModel = result.model
+            }
+        )
+
+        builder.applyAssets(models: [chainAsset])
+
+        // when
+        let model = resultModel
+
+        // then
+        XCTAssertNotNil(model, "Model should be generated")
+
+        let moreChainIds = Set(model?.more.compactMap { item in
+            item.chainAsset.chain.chainId
+        } ?? [])
+
+        let inactiveChainIds = Set(model?.inactive.compactMap { item in
+            item.chainAsset.chain.chainId
+        } ?? [])
+
+        XCTAssertTrue(moreChainIds.contains(KnowChainId.alephZero),
+                      "Aleph Zero should be in more options")
+        XCTAssertFalse(inactiveChainIds.contains(KnowChainId.alephZero),
+                       "Aleph Zero should NOT be in inactive section")
+    }
+
+    func testNonDemotedChainRoutesToInactiveSection() {
+        // given
+        let polkadotChain = ChainModelGenerator.generateChain(
+            defaultChainId: KnowChainId.polkadot,
+            generatingAssets: 1,
+            addressPrefix: 0,
+            hasStaking: true
+        )
+
+        let asset = polkadotChain.assets.first!
+        let chainAsset = ChainAsset(chain: polkadotChain, asset: asset)
+
+        let builder = StakingDashboardBuilder(
+            callbackQueue: .main,
+            resultClosure: { [weak self] result in
+                self?.resultModel = result.model
+            }
+        )
+
+        builder.applyAssets(models: [chainAsset])
+
+        // when
+        let model = resultModel
+
+        // then
+        XCTAssertNotNil(model, "Model should be generated")
+
+        let moreChainIds = Set(model?.more.compactMap { item in
+            item.chainAsset.chain.chainId
+        } ?? [])
+
+        let inactiveChainIds = Set(model?.inactive.compactMap { item in
+            item.chainAsset.chain.chainId
+        } ?? [])
+
+        XCTAssertTrue(inactiveChainIds.contains(KnowChainId.polkadot),
+                      "Polkadot should be in inactive section")
+        XCTAssertFalse(moreChainIds.contains(KnowChainId.polkadot),
+                       "Polkadot should NOT be in more options")
+    }
+
+    func testDemotedChainWithActiveStakeStillAppearsInActive() {
+        // given
+        let alephZeroChain = ChainModelGenerator.generateChain(
+            defaultChainId: KnowChainId.alephZero,
+            generatingAssets: 1,
+            addressPrefix: 42,
+            hasStaking: true
+        )
+
+        let asset = alephZeroChain.assets.first!
+        let chainAsset = ChainAsset(chain: alephZeroChain, asset: asset)
+
+        // Create a mock wallet
+        let account = AccountModel(
+            address: "test_address",
+            cryptoType: .sr25519,
+            publicKey: Data(repeating: 0, count: 32),
+            username: "Test User"
+        )
+
+        let chainAccountRequest = ChainAccountRequest(
+            networkType: alephZeroChain.chainNetworkType,
+            cryptoType: .sr25519
+        )
+
+        let walletModel = MetaAccountModel(
+            metaId: "test_meta_id",
+            name: "Test Wallet",
+            substratePublicKey: Data(repeating: 0, count: 32),
+            substrateAccountId: account.accountId,
+            ethereumAddress: nil,
+            ethereumPublicKey: nil,
+            chainAccounts: [
+                ChainAccount(
+                    chainId: alephZeroChain.chainId,
+                    accountId: account.accountId,
+                    publicKey: account.publicKey,
+                    cryptoType: account.cryptoType,
+                    username: account.username
+                )
+            ],
+            type: .substrate,
+            googleBackupName: nil,
+            isBackedUp: false
+        )
+
+        let dashboardItem = Multistaking.DashboardItem(
+            stakingOption: .init(
+                walletId: walletModel.metaId,
+                option: .init(
+                    chainAssetId: chainAsset.chainAssetId,
+                    type: .relaychain
+                )
+            ),
+            onchainState: .bonded,
+            hasAssignedStake: true,
+            stake: BigUInt(1000000000000),
+            totalRewards: nil,
+            maxApy: nil
+        )
+
+        let builder = StakingDashboardBuilder(
+            callbackQueue: .main,
+            resultClosure: { [weak self] result in
+                self?.resultModel = result.model
+            }
+        )
+
+        builder.applyWallet(model: walletModel)
+        builder.applyAssets(models: [chainAsset])
+        builder.applyDashboardItem(
+            changes: [
+                .insert(dashboardItem)
+            ]
+        )
+
+        // when
+        let model = resultModel
+
+        // then
+        XCTAssertNotNil(model, "Model should be generated")
+
+        let activeChainIds = Set(model?.active.compactMap { item in
+            item.chainAsset.chain.chainId
+        } ?? [])
+
+        let moreChainIds = Set(model?.more.compactMap { item in
+            item.chainAsset.chain.chainId
+        } ?? [])
+
+        XCTAssertTrue(activeChainIds.contains(KnowChainId.alephZero),
+                      "Aleph Zero with active stake should be in active section")
+        XCTAssertFalse(moreChainIds.contains(KnowChainId.alephZero),
+                       "Aleph Zero with active stake should NOT be in more options")
+    }
+}

--- a/novawalletTests/Modules/Staking/StartStakingInfo/StartStakingInfoCriticalNoticeInterceptTests.swift
+++ b/novawalletTests/Modules/Staking/StartStakingInfo/StartStakingInfoCriticalNoticeInterceptTests.swift
@@ -1,0 +1,342 @@
+import XCTest
+import BigInt
+import Foundation_iOS
+@testable import novawallet
+
+// MARK: - Tests
+
+final class StartStakingInfoCriticalNoticeInterceptTests: XCTestCase {
+    // MARK: Helpers
+
+    /// Held strongly so presenter.view (which is weak) stays alive for the test duration.
+    private var retainedView: MockStartStakingInfoView?
+
+    override func tearDown() {
+        retainedView = nil
+        super.tearDown()
+    }
+
+    /// Builds a presenter wired with the given noticesProvider and wireframe.
+    /// The presenter's view is assigned and accountExistense is pre-loaded to
+    /// .assetBalance so `proceedToStakingSetup()` can reach `wireframe.showSetupAmount`.
+    private func makePresenter(
+        noticesProvider: MockStakingNoticesProvider,
+        wireframe: MockStartStakingInfoWireframe
+    ) -> StartStakingInfoRelaychainPresenter {
+        let chain = ChainModelGenerator.generateChain(
+            generatingAssets: 1,
+            addressPrefix: 42,
+            hasStaking: true
+        )
+        let asset = chain.assets.first!
+        let chainAsset = ChainAsset(chain: chain, asset: asset)
+
+        let interactor = MockStartStakingInfoRelaychainInteractor()
+
+        let presenter = StartStakingInfoRelaychainPresenter(
+            selectedStakingType: nil,
+            chainAsset: chainAsset,
+            interactor: interactor,
+            wireframe: wireframe,
+            startStakingViewModelFactory: MockStartStakingViewModelFactory(),
+            balanceDerivationFactory: MockStakingTypeBalanceFactory(),
+            localizationManager: LocalizationManager.shared,
+            applicationConfig: ApplicationConfig.shared,
+            noticesProvider: noticesProvider,
+            logger: Logger.shared
+        )
+
+        let view = MockStartStakingInfoView()
+        // Keep view alive: presenter.view is weak, so without a strong reference it would
+        // be freed before startStaking() is called and proceedToStakingSetup would bail out.
+        retainedView = view
+        presenter.view = view
+
+        // Push accountExistense = .assetBalance so proceedToStakingSetup reaches showSetupAmount.
+        let chainAssetId = ChainAssetId(chainId: chainAsset.chain.chainId, assetId: chainAsset.asset.assetId)
+        let balance = AssetBalance.createZero(for: chainAssetId, accountId: Data(repeating: 0, count: 32))
+        presenter.didReceive(assetBalance: balance)
+
+        return presenter
+    }
+
+    // MARK: - Test: no notice → showSetupAmount is called directly
+
+    func testNoNoticeCallsShowSetupAmount() {
+        // given
+        let noticesProvider = MockStakingNoticesProvider()
+        // no entry → notice(for:) returns nil
+        let wireframe = MockStartStakingInfoWireframe()
+        let presenter = makePresenter(noticesProvider: noticesProvider, wireframe: wireframe)
+
+        // when
+        presenter.startStaking()
+
+        // then
+        XCTAssertEqual(wireframe.showSetupAmountCalls, 1, "showSetupAmount should be called once")
+        XCTAssertEqual(wireframe.presentCriticalNoticeSheetCalls.count, 0, "modal should NOT be presented")
+    }
+
+    // MARK: - Test: info-severity notice → showSetupAmount is called directly
+
+    func testInfoNoticeCallsShowSetupAmount() {
+        // given
+        let noticesProvider = MockStakingNoticesProvider()
+        let wireframe = MockStartStakingInfoWireframe()
+        let presenter = makePresenter(noticesProvider: noticesProvider, wireframe: wireframe)
+
+        // inject an info-severity notice for this chain
+        let chainId = presenter.chainAsset.chain.chainId
+        noticesProvider.notices[chainId] = StakingNotice(
+            chainId: chainId,
+            severity: .info,
+            shortText: "Info title",
+            longText: "Info body",
+            endDate: nil
+        )
+
+        // when
+        presenter.startStaking()
+
+        // then
+        XCTAssertEqual(wireframe.showSetupAmountCalls, 1, "showSetupAmount should be called once for info notice")
+        XCTAssertEqual(wireframe.presentCriticalNoticeSheetCalls.count, 0, "modal should NOT be presented for info notice")
+    }
+
+    // MARK: - Test: critical notice → modal sheet is presented
+
+    func testCriticalNoticePresentsCriticalSheet() {
+        // given
+        let noticesProvider = MockStakingNoticesProvider()
+        let wireframe = MockStartStakingInfoWireframe()
+        let presenter = makePresenter(noticesProvider: noticesProvider, wireframe: wireframe)
+
+        let chainId = presenter.chainAsset.chain.chainId
+        let expectedShortText = "Network compromised"
+        let expectedLongText = "This network has a critical security issue."
+        noticesProvider.notices[chainId] = StakingNotice(
+            chainId: chainId,
+            severity: .critical,
+            shortText: expectedShortText,
+            longText: expectedLongText,
+            endDate: nil
+        )
+
+        // when
+        presenter.startStaking()
+
+        // then
+        XCTAssertEqual(wireframe.presentCriticalNoticeSheetCalls.count, 1, "modal should be presented for critical notice")
+        XCTAssertEqual(wireframe.showSetupAmountCalls, 0, "showSetupAmount should NOT be called directly for critical notice")
+
+        let call = wireframe.presentCriticalNoticeSheetCalls.first
+        XCTAssertEqual(call?.title, expectedShortText)
+        XCTAssertEqual(call?.body, expectedLongText)
+    }
+
+    // MARK: - Bonus: critical notice onContinue → calls showSetupAmount
+
+    func testCriticalNoticeOnContinueCallsShowSetupAmount() {
+        // given
+        let noticesProvider = MockStakingNoticesProvider()
+        let wireframe = MockStartStakingInfoWireframe()
+        let presenter = makePresenter(noticesProvider: noticesProvider, wireframe: wireframe)
+
+        let chainId = presenter.chainAsset.chain.chainId
+        noticesProvider.notices[chainId] = StakingNotice(
+            chainId: chainId,
+            severity: .critical,
+            shortText: "Critical",
+            longText: "Long body",
+            endDate: nil
+        )
+
+        // when: present the modal
+        presenter.startStaking()
+
+        // sanity: modal was shown, setup amount not yet called
+        XCTAssertEqual(wireframe.presentCriticalNoticeSheetCalls.count, 1)
+        XCTAssertEqual(wireframe.showSetupAmountCalls, 0)
+
+        // when: user taps Continue
+        wireframe.presentCriticalNoticeSheetCalls.first?.onContinue()
+
+        // then: setup amount flow is triggered
+        XCTAssertEqual(wireframe.showSetupAmountCalls, 1, "onContinue should route to setup-amount screen")
+    }
+}
+
+// MARK: - Mocks
+
+private final class MockStartStakingInfoView: StartStakingInfoViewProtocol {
+    var isSetup: Bool { false }
+    var controller: UIViewController { UIViewController() }
+
+    func didReceive(viewModel _: LoadableViewModelState<StartStakingViewModel>) {}
+    func didReceive(balance _: String) {}
+    func didReceiveNotice(_: StakingNoticeBlockView.Model?) {}
+}
+
+private final class MockStartStakingInfoWireframe: StartStakingInfoWireframeProtocol {
+    // MARK: Recorded calls
+
+    struct CriticalNoticeSheetCall {
+        let title: String
+        let body: String
+        let onContinue: () -> Void
+    }
+
+    var presentCriticalNoticeSheetCalls: [CriticalNoticeSheetCall] = []
+    var showSetupAmountCalls = 0
+
+    // MARK: StartStakingInfoWireframeProtocol
+
+    func presentCriticalNoticeSheet(
+        from _: StartStakingInfoViewProtocol?,
+        title: String,
+        body: String,
+        onCancel _: @escaping () -> Void,
+        onContinue: @escaping () -> Void
+    ) {
+        presentCriticalNoticeSheetCalls.append(.init(title: title, body: body, onContinue: onContinue))
+    }
+
+    func showSetupAmount(from _: ControllerBackedProtocol?) {
+        showSetupAmountCalls += 1
+    }
+
+    func showWalletDetails(from _: ControllerBackedProtocol?, wallet _: MetaAccountModel) {}
+    func complete(from _: ControllerBackedProtocol?) {}
+
+    // MARK: AlertPresentable
+
+    func present(message _: String?, title _: String?, closeAction _: String?, from _: ControllerBackedProtocol?) {}
+    func present(viewModel _: AlertPresentableViewModel, style _: UIAlertController.Style, from _: ControllerBackedProtocol?) {}
+
+    // MARK: ErrorPresentable
+
+    func present(error _: Error, from _: ControllerBackedProtocol?, locale _: Locale?) -> Bool { false }
+
+    // MARK: CommonRetryable
+
+    func presentRequestStatus(on _: ControllerBackedProtocol?, with _: RequestStatusAlertModel) {}
+    func presentTryAgainOperation(on _: ControllerBackedProtocol?, title _: String, message _: String, actionTitle _: String, retryAction _: @escaping () -> Void) {}
+
+    // MARK: NoAccountSupportPresentable
+
+    func presentNoAccountSupport(from _: ControllerBackedProtocol, walletType _: MetaAccountModelType, chainName _: String, locale _: Locale) {}
+    func presentAddAccount(from _: ControllerBackedProtocol, chainName _: String, message _: String, locale _: Locale, addClosure _: @escaping () -> Void) {}
+
+    // MARK: StakingErrorPresentable (minimum stubs needed)
+
+    func presentAmountTooLow(value _: String, from _: ControllerBackedProtocol, locale _: Locale?) {}
+    func presentMissingController(from _: ControllerBackedProtocol, address _: AccountAddress, locale _: Locale?) {}
+    func presentMissingStash(from _: ControllerBackedProtocol, address _: AccountAddress, locale _: Locale?) {}
+    func presentUnbondingTooHigh(from _: ControllerBackedProtocol, locale _: Locale?) {}
+    func presentRebondingTooHigh(from _: ControllerBackedProtocol, locale _: Locale?) {}
+    func presentRewardIsLessThanFee(from _: ControllerBackedProtocol, action _: @escaping () -> Void, locale _: Locale?) {}
+    func presentControllerBalanceIsZero(from _: ControllerBackedProtocol, action _: @escaping () -> Void, locale _: Locale?) {}
+    func presentUnbondingLimitReached(from _: ControllerBackedProtocol?, locale _: Locale?) {}
+    func presentNoRedeemables(from _: ControllerBackedProtocol?, locale _: Locale?) {}
+    func presentControllerIsAlreadyUsed(from _: ControllerBackedProtocol?, locale _: Locale?) {}
+    func presentDeselectValidatorsWarning(from _: ControllerBackedProtocol, action _: @escaping () -> Void, locale _: Locale?) {}
+    func presentMaxNumberOfNominatorsReached(from _: ControllerBackedProtocol?, stakingType _: String, locale _: Locale?) {}
+    func presentMinRewardableStakeViolated(from _: ControllerBackedProtocol, action _: @escaping () -> Void, minStake _: String, locale _: Locale?) {}
+    func presentLockedTokensInPoolStaking(from _: ControllerBackedProtocol?, lockReason _: String, availableToStake _: String, directRewardableToStake _: String, locale _: Locale?) {}
+    func presentAlreadyHaveStaking(from _: ControllerBackedProtocol?, networkName _: String, onClose _: @escaping () -> Void, locale _: Locale?) {}
+    func presentDirectAndPoolStakingConflict(from _: ControllerBackedProtocol?, locale _: Locale?) {}
+
+    // MARK: BaseErrorPresentable stubs
+
+    func presentAmountTooHigh(from _: ControllerBackedProtocol, locale _: Locale?) {}
+    func presentFeeNotReceived(from _: ControllerBackedProtocol, locale _: Locale?) {}
+    func presentFeeTooHigh(from _: ControllerBackedProtocol, balance _: String, fee _: String, locale _: Locale?) {}
+    func presentExtrinsicFailed(from _: ControllerBackedProtocol, locale _: Locale?) {}
+    func presentInvalidAddress(from _: ControllerBackedProtocol, chainName _: String, locale _: Locale?) {}
+    func presentUpToForFee(from _: ControllerBackedProtocol, available _: String, fee _: String, maxClosure _: (() -> Void)?, locale _: Locale?) {}
+    func presentExistentialDepositWarning(from _: ControllerBackedProtocol, action _: @escaping () -> Void, locale _: Locale?) {}
+    func presentIsSystemAccount(from _: ControllerBackedProtocol?, onContinue _: @escaping () -> Void, locale _: Locale?) {}
+    func presentMinBalanceViolated(from _: ControllerBackedProtocol, minBalanceForOperation _: String, currentBalance _: String, needToAddBalance _: String, locale _: Locale?) {}
+
+    // MARK: StakingBaseErrorPresentable stubs
+
+    func presentCrossedMinStake(from _: ControllerBackedProtocol?, minStake _: String, remaining _: String, action _: @escaping () -> Void, locale _: Locale) {}
+}
+
+private final class MockStakingNoticesProvider: StakingNoticesProviding {
+    var notices: [ChainModel.Id: StakingNotice] = [:]
+    var allNotices: [ChainModel.Id: StakingNotice] { notices }
+    func notice(for chainId: ChainModel.Id) -> StakingNotice? { notices[chainId] }
+    func refresh() {}
+    func subscribe(_: AnyObject, callback _: @escaping () -> Void) {}
+    func unsubscribe(_: AnyObject) {}
+}
+
+private final class MockStartStakingInfoRelaychainInteractor: StartStakingInfoRelaychainInteractorInputProtocol {
+    func setup() {}
+    func remakeSubscriptions() {}
+    func retryDirectStakingMinStake() {}
+    func retryEraCompletionTime() {}
+    func retryNominationPoolsMinStake() {}
+    func remakeCalculator() {}
+}
+
+private final class MockStartStakingViewModelFactory: StartStakingViewModelFactoryProtocol {
+    private static let dummyURL = URL(string: "https://example.com")!
+    private static let dummyParagraph = ParagraphView.Model(image: nil, text: AccentTextModel(text: "", accents: []))
+    private static let dummyUrlModel = StartStakingUrlModel(text: "", url: dummyURL, urlName: "")
+
+    func earnupModel(earnings _: Decimal?, chainAsset _: ChainAsset, locale _: Locale) -> AccentTextModel {
+        AccentTextModel(text: "", accents: [])
+    }
+
+    func stakeModel(minStake _: BigUInt?, rewardStartDelay _: TimeInterval, chainAsset _: ChainAsset, locale _: Locale) -> ParagraphView.Model {
+        Self.dummyParagraph
+    }
+
+    func unstakeModel(unstakePeriod _: TimeInterval, locale _: Locale) -> ParagraphView.Model {
+        Self.dummyParagraph
+    }
+
+    func rewardModel(amount _: BigUInt?, chainAsset _: ChainAsset, rewardTimeInterval _: TimeInterval, destination _: DefaultStakingRewardDestination, locale _: Locale) -> ParagraphView.Model {
+        Self.dummyParagraph
+    }
+
+    func govModel(amount _: BigUInt?, chainAsset _: ChainAsset, locale _: Locale) -> ParagraphView.Model {
+        Self.dummyParagraph
+    }
+
+    func recommendationModel(locale _: Locale) -> ParagraphView.Model {
+        Self.dummyParagraph
+    }
+
+    func testNetworkModel(chain _: ChainModel, locale _: Locale) -> ParagraphView.Model {
+        Self.dummyParagraph
+    }
+
+    func wikiModel(url _: URL, chainAsset _: ChainAsset, locale _: Locale) -> StartStakingUrlModel {
+        Self.dummyUrlModel
+    }
+
+    func termsModel(url _: URL, locale _: Locale) -> StartStakingUrlModel {
+        Self.dummyUrlModel
+    }
+
+    func balance(amount _: BigUInt?, priceData _: PriceData?, chainAsset _: ChainAsset, locale _: Locale) -> String {
+        ""
+    }
+
+    func noAccount(chain _: ChainModel, locale _: Locale) -> String {
+        ""
+    }
+}
+
+private final class MockStakingTypeBalanceFactory: StakingTypeBalanceFactoryProtocol {
+    func getAvailableBalance(from _: AssetBalance?, stakingMethod _: StakingSelectionMethod) -> BigUInt? {
+        nil
+    }
+
+    func getStakeableBalance(from _: AssetBalance?, existentialDeposit _: BigUInt?, stakingMethod _: StakingSelectionMethod) -> BigUInt? {
+        nil
+    }
+}


### PR DESCRIPTION
## Summary

Two coupled changes to the staking experience:

**1. Tier demotion** — 7 staking networks (Vara, Zeitgeist, Moonriver, Aleph Zero, Polkadex, Ternoa, Manta Atlantic) are moved from the dashboard's offer list to the "More Options" screen. Existing user stakes are unaffected and continue to render in the dashboard's `active` section — this is a discovery-tier change only. Demotion source is a hardcoded `Set<ChainModel.Id>` (intentional: tier changes are slow-changing structural decisions).

**2. Notice system** — a new per-chain notice mechanism served from `nova-utils/notices/staking_notices.json`. No app update is needed to publish, edit, or remove a notice. Notices render in four UI contexts:
- Dashboard active stake card → banner strip on top
- Stake details screen → expanded block above the summary
- More Options row → `Notice` chip next to the chain name
- StartStakingInfo screen → expanded block above the "Earn up to X%" headline

Two severity tiers: `info` (yellow) and `critical` (red). Critical-severity notices also present a bottom-sheet modal when the user taps "Start staking" on the StartStakingInfo screen, mirroring the existing watch-only Scam Risk Warning pattern (10-second-gated Continue, Cancel returns to More Options). The inline banner persists behind the modal as a reminder.

## Architecture

- `StakingNoticesProvider` extends `BaseSyncService`. Fetches on the same chains-sync trigger as `chains.json` via `ChainRegistry.syncUpServices()`, disk-caches the response so notices appear immediately on relaunch.
- Locale resolution uses Nova's `LocalizationManager` (not iOS-system locale APIs), so the user's in-app language picker drives notice text. The JSON schema accepts plain strings or locale-map objects (`{"en": "...", "ru": "..."}`) per entry. Notices re-decode live when the user changes language.
- Notices past their `endDate` are hidden automatically.
- Companion JSON shipped in novasamatech/nova-utils#4334.

## Notes

- Demoted-chain set lives in `StakingDashboardTierConfig.swift` — promoting/demoting a chain is a deliberate app-release decision.
- The iOS PR is independent of the nova-utils PR and can merge in either order: if the JSON isn't live yet, the provider yields an empty map and nothing renders.