### PR TITLE
Staking: EnergyWebX (EWT) — parachain-staking-avn lifecycle

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1485,6 +1485,7 @@
 		165FD10F3329A67373DA78C6 /* ReferendumsFiltersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9DFFBEFB45E0A03FAA142C3 /* ReferendumsFiltersViewController.swift */; };
 		166EDC263AC503FF5963005F /* DAppSettingsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3789A955202DA7CCADE13E68 /* DAppSettingsProtocols.swift */; };
 		16EDDDC4B234CAB0D6326B74 /* StakingDashboardPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88BFD7BD1254C2EC1F7E997 /* StakingDashboardPresenter.swift */; };
+		16F56D9F9322686255343774 /* ParachainAvnGrowthInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7304997248684A40BBBF3BB /* ParachainAvnGrowthInfo.swift */; };
 		16FAE3C58B34D700D8A7A217 /* DAppListWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E6E41F045986002E1E26C12 /* DAppListWireframe.swift */; };
 		1705C47629E3A63D18D39B9C /* TransactionHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BAE0A2542AE83345BCCA549 /* TransactionHistoryViewController.swift */; };
 		1710F415F6AC7BBC622F4BD2 /* CollatorStakingSelectInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC320A5EC0D18B6F443BB2E /* CollatorStakingSelectInteractor.swift */; };
@@ -2730,6 +2731,7 @@
 		3FF8EE1158A273D0D50BC7A6 /* StakingUnbondConfirmPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45B7031E0809CED062C83F8 /* StakingUnbondConfirmPresenter.swift */; };
 		40087CC8E6A91976807F7D44 /* DAppBrowserWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F47911F8734C007135137D /* DAppBrowserWireframe.swift */; };
 		4014ED301AA53DA0B07B4221 /* DAppPhishingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147BFCC44EB3938D50EE8D9 /* DAppPhishingPresenter.swift */; };
+		402F5DC317873A8111E586E0 /* ParachainAvnScheduledRequestsUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D015A336334984FDE101AF0 /* ParachainAvnScheduledRequestsUpdater.swift */; };
 		403472F848E2D71B296980DC /* BackupAttentionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE464662C38D81D8F6E55E01 /* BackupAttentionViewLayout.swift */; };
 		4040F1394A73AC2FE598242C /* ControllerAccountConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EF69DFE142600FF2708A13 /* ControllerAccountConfirmationViewController.swift */; };
 		40637D60E1AFB53D8D814B97 /* BannersViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C3B52CE31FA87AD252994D5 /* BannersViewFactory.swift */; };
@@ -2764,6 +2766,7 @@
 		4520C59F8C8CCB7669DDA4DF /* NotificationWalletListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F8388B9F018939BCE7357C /* NotificationWalletListPresenter.swift */; };
 		4541F886953E046C16E42997 /* LedgerWalletConfirmInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96340EDDE0EAA7F9B6D33E96 /* LedgerWalletConfirmInteractor.swift */; };
 		454D41CC5C7CC2FDAB778026 /* CreateWatchOnlyInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D9C85AB0C9D53B522DCF3C5 /* CreateWatchOnlyInteractor.swift */; };
+		45CFC77561787A557C2D442D /* ParachainAvnAccountSubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E12F46CC97392E6C46DF92 /* ParachainAvnAccountSubscriptionService.swift */; };
 		46298240F3528B5C62AEC29E /* GovernanceUnlockSetupWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856BF961EACEB9703B2B37C7 /* GovernanceUnlockSetupWireframe.swift */; };
 		46A946CF3920537D8C116555 /* MythosStakingConfirmProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F90A8B791F2EFE98C6DFA93 /* MythosStakingConfirmProtocols.swift */; };
 		473EDA64B1A18BA80189142D /* GovernanceRemoveVotesConfirmProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BB15F2A86E47DE30AE8107 /* GovernanceRemoveVotesConfirmProtocols.swift */; };
@@ -2793,6 +2796,7 @@
 		4C165167688A2791643AC667 /* LedgerDiscoverProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A9B9D741BABBCE6C70BE45 /* LedgerDiscoverProtocols.swift */; };
 		4C2309A0EF51366D5FE6FF82 /* GovernanceTracksSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D819989DE218D0466D30E1 /* GovernanceTracksSettingsViewController.swift */; };
 		4C4142B4CB2DBCA1F06DC046 /* GovernanceDelegateSetupViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7A6C62EC06FC3B2693FB43 /* GovernanceDelegateSetupViewLayout.swift */; };
+		4C41920A521D3BD7ECC028DB /* ParachainAvnMultistakingUpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DEC95A059351B38C1EB7F3 /* ParachainAvnMultistakingUpdateService.swift */; };
 		4CBA0A25DB544214C4A02F0B /* InAppUpdatesWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC18369BDAF9076681B6E3F /* InAppUpdatesWireframe.swift */; };
 		4CD9B187647A37B4F6343DD7 /* NetworkManageNodeViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B845CBF81C61BB7EBFA845EE /* NetworkManageNodeViewFactory.swift */; };
 		4D31116B94CB85E69432B848 /* TokensManageAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E6ED849A247ACCC3FB1AC3 /* TokensManageAddViewController.swift */; };
@@ -3441,6 +3445,7 @@
 		8324776DA6F43F1408A3ACB5 /* ImportCloudPasswordViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EA837CDC74E8301C0207E5 /* ImportCloudPasswordViewFactory.swift */; };
 		8329367F06C83BA7A0B12A34 /* CommonDelegationTracksPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7235097E09C94005B091B4 /* CommonDelegationTracksPresenter.swift */; };
 		832B616B89972C96D98023DB /* ChangeWatchOnlyViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54289A8A9354D5DDA15F0E1 /* ChangeWatchOnlyViewFactory.swift */; };
+		835106AC700EDACDB44557C8 /* ParachainAvnScheduledRequestsQueryWrapperFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 197A520FF4A0FA796E6F5EF1 /* ParachainAvnScheduledRequestsQueryWrapperFactory.swift */; };
 		835AE15B1F58CB87F775272F /* DelegateVotedReferendaPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5544826542EC3A92FCB2B1D7 /* DelegateVotedReferendaPresenter.swift */; };
 		8364E4802CC617E523EB87A7 /* SwapFeeDetailsViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBBC5F8D082B58B4FDFABD7 /* SwapFeeDetailsViewLayout.swift */; };
 		838D584B803A5A7BCBAD9395 /* StartStakingConfirmProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28FAB72B50D8C736AF67A39 /* StartStakingConfirmProtocols.swift */; };
@@ -5511,6 +5516,7 @@
 		84FFE45B2862076F002432BB /* XcmUnweightedTransferRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FFE45A2862076F002432BB /* XcmUnweightedTransferRequest.swift */; };
 		84FFE45D28620833002432BB /* XcmTransferResolutionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FFE45C28620833002432BB /* XcmTransferResolutionService.swift */; };
 		84FFE505261290830054EA63 /* NetworkInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FFE504261290830054EA63 /* NetworkInfoView.swift */; };
+		8510891A56A9918286DF386E /* ParachainAvnAccountSubscribeHandlingFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3FB88DAD9F614802BC913D /* ParachainAvnAccountSubscribeHandlingFactory.swift */; };
 		852A62972D1940E698A4176F /* DelegatedSignValidationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7713623A2DBA76A1D31A557 /* DelegatedSignValidationPresenter.swift */; };
 		85547F698B551ACD387D84E2 /* SelectValidatorsStartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E62CD2831DCF0A2D5DBB08F /* SelectValidatorsStartViewController.swift */; };
 		85600C63BB1BEC76EDFA04CB /* ReferendumFullDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C535E8504943299B3E4A8EB /* ReferendumFullDetailsViewController.swift */; };
@@ -6262,6 +6268,7 @@
 		D0A73CEDB6B3CF2DD4511963 /* NotificationsManagementViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7A434DA1BF2B133E9685A6 /* NotificationsManagementViewLayout.swift */; };
 		D0AD3C44BBFD6A9F9FDEC933 /* WalletConnectSessionDetailsWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09D09E9ED7911D0BF763184 /* WalletConnectSessionDetailsWireframe.swift */; };
 		D11AEF58F47E3D59BC6D966D /* GovernanceTracksSettingsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81012A15E52FFDDB8608D86 /* GovernanceTracksSettingsProtocols.swift */; };
+		D12948254BFF2EE282654CEF /* ParachainAvnCommissionSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3587D380B49DB69597ED7CEF /* ParachainAvnCommissionSetting.swift */; };
 		D1487642F422F6B96216B0D0 /* GovernanceYourDelegationsViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEA5A50D493EABD48128286 /* GovernanceYourDelegationsViewFactory.swift */; };
 		D153449DFFDC31C7CBB7E7EA /* OnboardingWalletReadyPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5FCE21D2C05E8DDB55A78C /* OnboardingWalletReadyPresenter.swift */; };
 		D1C4208A89633395AF2FDB74 /* ReferendumVoteSetupViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3105383F2825940D0105D5 /* ReferendumVoteSetupViewLayout.swift */; };
@@ -8033,6 +8040,7 @@
 		0CFF82502D9275C900DB17A4 /* AvailableBalanceMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableBalanceMapping.swift; sourceTree = "<group>"; };
 		0CFFB9D22D11A67C00172E8C /* XcmTokensArrivalDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmTokensArrivalDetector.swift; sourceTree = "<group>"; };
 		0CFFB9D82D17592500172E8C /* OperatingSystemApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatingSystemApi.swift; sourceTree = "<group>"; };
+		0D015A336334984FDE101AF0 /* ParachainAvnScheduledRequestsUpdater.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnScheduledRequestsUpdater.swift; sourceTree = "<group>"; };
 		0D32A720511D1D3B0F479AFE /* DAppBrowserTabListProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppBrowserTabListProtocols.swift; sourceTree = "<group>"; };
 		0D37CF4AFB06AF3AC2F78057 /* ImportCloudPasswordPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportCloudPasswordPresenter.swift; sourceTree = "<group>"; };
 		0D3FE2CE7F9F2836755DBA63 /* GovernanceUnlockConfirmProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceUnlockConfirmProtocols.swift; sourceTree = "<group>"; };
@@ -8097,6 +8105,7 @@
 		18EBB92677F15F1E41762DE4 /* CollatorStakingSelectSearchPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollatorStakingSelectSearchPresenter.swift; sourceTree = "<group>"; };
 		194C9BFEE9BA8C9E448D79AA /* AccountExportPasswordInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountExportPasswordInteractor.swift; sourceTree = "<group>"; };
 		196CF53E8DA7174E33118BCB /* MythosStkClaimRewardsPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MythosStkClaimRewardsPresenter.swift; sourceTree = "<group>"; };
+		197A520FF4A0FA796E6F5EF1 /* ParachainAvnScheduledRequestsQueryWrapperFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnScheduledRequestsQueryWrapperFactory.swift; sourceTree = "<group>"; };
 		1988596ED33D0C06FD0CFD73 /* SwipeGovReferendumDetailsPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwipeGovReferendumDetailsPresenter.swift; sourceTree = "<group>"; };
 		19BFAC4CDCC826720CA1010A /* GovernanceDelegateConfirmViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceDelegateConfirmViewLayout.swift; sourceTree = "<group>"; };
 		19D16555800B55CBA7560E68 /* MythosStkUnstakeConfirmInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MythosStkUnstakeConfirmInteractor.swift; sourceTree = "<group>"; };
@@ -8169,6 +8178,7 @@
 		2667181A57442FB4D93B7F36 /* PVWelcomeViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PVWelcomeViewFactory.swift; sourceTree = "<group>"; };
 		267534E8F4BF11B68EAAC691 /* DAppBrowserTabListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppBrowserTabListViewController.swift; sourceTree = "<group>"; };
 		26A0FFF412031C1373EBE2B8 /* ParaStkRebondProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParaStkRebondProtocols.swift; sourceTree = "<group>"; };
+		26DEC95A059351B38C1EB7F3 /* ParachainAvnMultistakingUpdateService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnMultistakingUpdateService.swift; sourceTree = "<group>"; };
 		26F9E9C70B0C14570AB783AF /* LocksPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocksPresenter.swift; sourceTree = "<group>"; };
 		270B309EC85D8897A4ADD98A /* CustomValidatorListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomValidatorListViewController.swift; sourceTree = "<group>"; };
 		271F8692631AE4CCCD51462D /* NotificationsManagementProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationsManagementProtocols.swift; sourceTree = "<group>"; };
@@ -9031,6 +9041,7 @@
 		3543AE2CAA63AC0A20D532B6 /* StakingConfirmProxyViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingConfirmProxyViewLayout.swift; sourceTree = "<group>"; };
 		3558BD7D1B8CA1409BE74879 /* AccountManagementInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountManagementInteractor.swift; sourceTree = "<group>"; };
 		3576FB0B05C782F78C39600C /* GiftClaimViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiftClaimViewFactory.swift; sourceTree = "<group>"; };
+		3587D380B49DB69597ED7CEF /* ParachainAvnCommissionSetting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnCommissionSetting.swift; sourceTree = "<group>"; };
 		358E87C8E90981E6D9515745 /* GovernanceUnlockConfirmViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceUnlockConfirmViewFactory.swift; sourceTree = "<group>"; };
 		3593D7650F5126266ED9FE84 /* GovernanceSelectTracksViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceSelectTracksViewLayout.swift; sourceTree = "<group>"; };
 		35A4A258D911C67F875E386D /* CollatorStakingSelectFiltersViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollatorStakingSelectFiltersViewController.swift; sourceTree = "<group>"; };
@@ -12300,6 +12311,7 @@
 		AC155A29FA8777D90A46913D /* CrowdloanYourContributionsViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CrowdloanYourContributionsViewFactory.swift; sourceTree = "<group>"; };
 		AC1626234F0BF7E20D351CB2 /* ReferendumSearchPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumSearchPresenter.swift; sourceTree = "<group>"; };
 		AC3903A0A93FB8068071F9BD /* GovernanceDelegateSetupViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceDelegateSetupViewController.swift; sourceTree = "<group>"; };
+		AC3FB88DAD9F614802BC913D /* ParachainAvnAccountSubscribeHandlingFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnAccountSubscribeHandlingFactory.swift; sourceTree = "<group>"; };
 		AC404A4071AF571FAC4C1994 /* AccountExportPasswordProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountExportPasswordProtocols.swift; sourceTree = "<group>"; };
 		AC7A05FDBA1F8B71C61001A4 /* GovernanceSelectTracksProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceSelectTracksProtocols.swift; sourceTree = "<group>"; };
 		ACAEDA02F409FE23749A1551 /* AccountCreateWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountCreateWireframe.swift; sourceTree = "<group>"; };
@@ -12620,6 +12632,7 @@
 		D6C6573C52692E4A56E35FF9 /* RecommendedValidatorListProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecommendedValidatorListProtocols.swift; sourceTree = "<group>"; };
 		D6E8ABCF1EB5064F40B697CC /* PVAddConfirmPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PVAddConfirmPresenter.swift; sourceTree = "<group>"; };
 		D6FD6166E6AFB44A7CE8A0EE /* DAppBrowserTabListWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppBrowserTabListWireframe.swift; sourceTree = "<group>"; };
+		D7304997248684A40BBBF3BB /* ParachainAvnGrowthInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnGrowthInfo.swift; sourceTree = "<group>"; };
 		D74FF4FE525ADD8E7805481E /* AddDelegationViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddDelegationViewLayout.swift; sourceTree = "<group>"; };
 		D779CD7E426E469760290DBC /* AddDelegationWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddDelegationWireframe.swift; sourceTree = "<group>"; };
 		D790172C70C98CAE984F7183 /* NPoolsUnstakeConfirmViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NPoolsUnstakeConfirmViewController.swift; sourceTree = "<group>"; };
@@ -12636,6 +12649,7 @@
 		D8A759A20A4A39B3B0E2A735 /* DAppAddFavoriteViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppAddFavoriteViewLayout.swift; sourceTree = "<group>"; };
 		D8C4C48E50DC14085258AB6D /* NftDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NftDetailsViewController.swift; sourceTree = "<group>"; };
 		D8DE2583C0D36ECDB0F012EB /* AssetPriceChartInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetPriceChartInteractor.swift; sourceTree = "<group>"; };
+		D8E12F46CC97392E6C46DF92 /* ParachainAvnAccountSubscriptionService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnAccountSubscriptionService.swift; sourceTree = "<group>"; };
 		D927D2CCA2C24FE116D7CE5C /* StakingSetupProxyViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingSetupProxyViewController.swift; sourceTree = "<group>"; };
 		D99E687F7D5A3862643BF533 /* WalletMigrateAcceptViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletMigrateAcceptViewLayout.swift; sourceTree = "<group>"; };
 		D9DFFBEFB45E0A03FAA142C3 /* ReferendumsFiltersViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumsFiltersViewController.swift; sourceTree = "<group>"; };
@@ -19537,6 +19551,8 @@
 				3754FFC4CD85BD04C4F5411D /* ParachainAvnStakingConstants.swift */,
 				633D485DD456CDFCB098D9C1 /* ParachainAvnCollator.swift */,
 				F42A866274E3DDA80AE0DCF0 /* ParachainAvnStakePosition.swift */,
+				3587D380B49DB69597ED7CEF /* ParachainAvnCommissionSetting.swift */,
+				D7304997248684A40BBBF3BB /* ParachainAvnGrowthInfo.swift */,
 			);
 			name = Model;
 			path = Model;
@@ -22542,6 +22558,7 @@
 				0C1BE1A52A47FC240010933C /* MultistakingSyncServiceFactory.swift */,
 				0C0F6D662D394AF800943A7C /* MythosMultistakingUpdateService.swift */,
 				0C0F6D682D394BE000943A7C /* Multistaking+Mythos.swift */,
+				26DEC95A059351B38C1EB7F3 /* ParachainAvnMultistakingUpdateService.swift */,
 			);
 			path = Multistaking;
 			sourceTree = "<group>";
@@ -26231,6 +26248,9 @@
 				0CA72A982D4B70E300B3FD02 /* StakingRemoteSubscriptionProtocols.swift */,
 				2D02DBB62EFAA904008DBCF9 /* BlockNumberCallbackSubscriptionFactory.swift */,
 				2D02DBC42EFAAFC7008DBCF9 /* BlockNumberRemoteSubscription.swift */,
+				D8E12F46CC97392E6C46DF92 /* ParachainAvnAccountSubscriptionService.swift */,
+				AC3FB88DAD9F614802BC913D /* ParachainAvnAccountSubscribeHandlingFactory.swift */,
+				0D015A336334984FDE101AF0 /* ParachainAvnScheduledRequestsUpdater.swift */,
 			);
 			path = Substrate;
 			sourceTree = "<group>";
@@ -26403,6 +26423,7 @@
 				84C3420628314D9600156569 /* ParaStkScheduledRequestsQueryFactory.swift */,
 				84C11F162840BD46007F7C05 /* ParaStkCollatorsOperationFactory.swift */,
 				2D72133E2F0FC52F00826C7B /* ParaStkScheduledRequestsQueryWrapperFactory.swift */,
+				197A520FF4A0FA796E6F5EF1 /* ParachainAvnScheduledRequestsQueryWrapperFactory.swift */,
 			);
 			path = ParachainStaking;
 			sourceTree = "<group>";
@@ -36962,6 +36983,13 @@
 				12456AEC7EA98AAF8440E8EE /* StakingMainPresenterFactory+ParachainAvn.swift in Sources */,
 				F8C70EE9D7E41D817F8C1FB5 /* ParachainAvnDurationOperationFactory.swift in Sources */,
 				86EF33CE7D2FE628F5C73FB4 /* ParachainAvnNetworkInfoOperationFactory.swift in Sources */,
+				D12948254BFF2EE282654CEF /* ParachainAvnCommissionSetting.swift in Sources */,
+				45CFC77561787A557C2D442D /* ParachainAvnAccountSubscriptionService.swift in Sources */,
+				8510891A56A9918286DF386E /* ParachainAvnAccountSubscribeHandlingFactory.swift in Sources */,
+				402F5DC317873A8111E586E0 /* ParachainAvnScheduledRequestsUpdater.swift in Sources */,
+				835106AC700EDACDB44557C8 /* ParachainAvnScheduledRequestsQueryWrapperFactory.swift in Sources */,
+				4C41920A521D3BD7ECC028DB /* ParachainAvnMultistakingUpdateService.swift in Sources */,
+				16F56D9F9322686255343774 /* ParachainAvnGrowthInfo.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0075488169C69B97C0630EB8 /* AssetReceiveProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47042BBA5082B1EC1D017B56 /* AssetReceiveProtocols.swift */; };
 		0090AF084EEEA26E4018B1B3 /* NominationPoolSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834314A1286CB91F8BB43F06 /* NominationPoolSearchViewController.swift */; };
 		00AE6FF475338CEF6C65F3B0 /* SwipeGovVotingConfirmProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B946DC0085AE7F1360A21A /* SwipeGovVotingConfirmProtocols.swift */; };
+		00C0486D0E219C78A9230119 /* ParachainAvnStakePosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42A866274E3DDA80AE0DCF0 /* ParachainAvnStakePosition.swift */; };
 		0119531FAE0D22EA9464F84D /* ParaStkYourCollatorsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 128EA612020D98F3B0D0FA96 /* ParaStkYourCollatorsProtocols.swift */; };
 		012AE9F8BDA682C691B6F9FD /* PVWelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78CF6E3E64F7608EF6C28399 /* PVWelcomeViewController.swift */; };
 		0154E387EC40EF553FC7BD02 /* StackingRewardFiltersProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26BFF6789F0A11C5D870348 /* StackingRewardFiltersProtocols.swift */; };
@@ -55,6 +56,7 @@
 		0A51635F9E694871C8AF83F0 /* AssetOperationNetworkListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3ADD92DEC7B0142C5C6696 /* AssetOperationNetworkListInteractor.swift */; };
 		0A6114AACBAB1D55BC03F264 /* StartStakingInfoBaseInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2BC4EFADD593325FF122765 /* StartStakingInfoBaseInteractor.swift */; };
 		0AAFEFA17F249F4BEF051F6B /* ControllerAccountConfirmationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FB887490A8B33890B4E0E4 /* ControllerAccountConfirmationPresenter.swift */; };
+		0B23CDC1DA92D3B53E9BA047 /* ParachainAvnLocalSubscriptionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FF4DD368E914F04B1CEA95 /* ParachainAvnLocalSubscriptionFactory.swift */; };
 		0B2B9C6E2BA2E924D6A54F4B /* CrowdloanListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E78D69E8EBC3EB4D01F8EF /* CrowdloanListInteractor.swift */; };
 		0B48B02E973CB304B765BBC9 /* ReferendumDetailsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ABAD23C0039AFA8351C650 /* ReferendumDetailsProtocols.swift */; };
 		0B65DAE0327678679CACE0B1 /* GovernanceDelegateInfoViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E894D4633D04AD4415CE1F2 /* GovernanceDelegateInfoViewFactory.swift */; };
@@ -1452,6 +1454,7 @@
 		120A2EF278301252A6097C23 /* DelegatedSignValidationViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C5AF8C31E4D2202B015131 /* DelegatedSignValidationViewFactory.swift */; };
 		1232A714A96F937330FC0AFA /* GovernanceDelegateConfirmViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B718CE9C51158F87D37894BB /* GovernanceDelegateConfirmViewFactory.swift */; };
 		123A9B65910A504F36333015 /* MythosStakingDetailsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5138BB19BDFFEB8BBF8B82C /* MythosStakingDetailsPresenter.swift */; };
+		12456AEC7EA98AAF8440E8EE /* StakingMainPresenterFactory+ParachainAvn.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E8E06E63183EC1A5974449 /* StakingMainPresenterFactory+ParachainAvn.swift */; };
 		1269C0103216CDBDA25A5101 /* ReferendumFullDetailsWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80D934D47929D2331111AD7 /* ReferendumFullDetailsWireframe.swift */; };
 		126B81512C2A0F7B7D723D07 /* MultisigOperationConfirmWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = E607CFA75CE36C683E535256 /* MultisigOperationConfirmWireframe.swift */; };
 		12734D7CC6ACA5B657F44519 /* DAppAddFavoriteViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DA8D51B588486D304F1B73 /* DAppAddFavoriteViewFactory.swift */; };
@@ -1527,6 +1530,7 @@
 		1F88F3DBFA0BD6D0FDF558F3 /* SelectValidatorsConfirmViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975DECE71DE70DFD866B8E23 /* SelectValidatorsConfirmViewFactory.swift */; };
 		1FE144104EF04E37BE048233 /* MythosStakingDetailsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA5068F5423120E26213B28 /* MythosStakingDetailsProtocols.swift */; };
 		2003738C399EFA9A61343EDD /* StakingConfirmProxyInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49AEF66A11C7B27F947CEA5C /* StakingConfirmProxyInteractor.swift */; };
+		2012DFAA7416C15267306543 /* ParachainAvn+StoragePaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0B53920BCFE285BB6A6EB6 /* ParachainAvn+StoragePaths.swift */; };
 		20B1463FB1F2431A0C913DCE /* StakingMoreOptionsViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC767DE76479F70A8FA3292A /* StakingMoreOptionsViewLayout.swift */; };
 		20B2942A4241F6713A1C70D9 /* StakingRewardDetailsViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2377F8FB07B47637346249F5 /* StakingRewardDetailsViewFactory.swift */; };
 		20ED63C70434AAC0DEB73659 /* GenericLedgerAccountSelectionProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD6001A7E25497F9E34C017 /* GenericLedgerAccountSelectionProtocols.swift */; };
@@ -2706,6 +2710,7 @@
 		3C3C98149DA3BDE3CE692F3C /* NominationPoolBondMoreConfirmWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA576BBCED647C22E93F0202 /* NominationPoolBondMoreConfirmWireframe.swift */; };
 		3C6C738F4AB7AC6FEA290D59 /* WalletsChoosePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525813EB768E636A397C00BB /* WalletsChoosePresenter.swift */; };
 		3C8566B0B4F27531EFF528B5 /* AssetPriceChartViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08478AD9E9AF78370BC7E87 /* AssetPriceChartViewLayout.swift */; };
+		3CBDCC13C1AA8BCBA21C902C /* ParachainAvn+ConstantPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CF985376C46EDFD423C94C /* ParachainAvn+ConstantPaths.swift */; };
 		3CBE411F2E3CC40A0BA2572F /* StakingDashboardViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCA1A3205F91128556F0F11 /* StakingDashboardViewLayout.swift */; };
 		3D5AB0E16D47476A682E8DB9 /* ManualBackupKeyListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6D59DCB2D2148A8DFF4F099 /* ManualBackupKeyListPresenter.swift */; };
 		3D61F07E10ED522E389B2192 /* DelegateVotedReferendaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2883649A5E84DF9B861C83 /* DelegateVotedReferendaViewController.swift */; };
@@ -2741,6 +2746,7 @@
 		42AF4E3B592AF7E40CAC13E0 /* TransactionHistoryWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1A1934B76A5DCC65855EE1 /* TransactionHistoryWireframe.swift */; };
 		42B79A8D0D9540C1D97D991C /* AccountConfirmWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599FEDBD7E8B665F1A93BA70 /* AccountConfirmWireframe.swift */; };
 		42C9DAE9486B1689530979EA /* DAppFavoritesInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AF481FAE3C055585FEDCBF /* DAppFavoritesInteractor.swift */; };
+		42E9334FA56382D30276F88F /* ParachainAvnCollator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633D485DD456CDFCB098D9C1 /* ParachainAvnCollator.swift */; };
 		433A3C2B0D1E4BA5974D681B /* DAppAddFavoriteWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ACF32611D345B87BCE29FE0 /* DAppAddFavoriteWireframe.swift */; };
 		433CA9D0C219954508DCBCCD /* KnownNetworksListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF1830DCCDBD01066DA50AE /* KnownNetworksListInteractor.swift */; };
 		4346F9B838284C40D4F1058B /* CommonDelegationTracksProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627CE71CD8C7CE59B8AFBAD6 /* CommonDelegationTracksProtocols.swift */; };
@@ -2876,6 +2882,7 @@
 		5EBDCC76C4957F83D1DACAD5 /* SwipeGovSetupProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = A558807C44AE52D76B4EE875 /* SwipeGovSetupProtocols.swift */; };
 		5ECC5F9E55FBC5CF2DD8664C /* GovernanceDelegateInfoWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C16637ADA10892106DD304 /* GovernanceDelegateInfoWireframe.swift */; };
 		5F107F52BCEF8BA940800F88 /* AssetDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A479F3338BE7DA2C846023FA /* AssetDetailsViewController.swift */; };
+		5F238F8FEC38D8110F01735C /* ParachainAvn+Calls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FD327CCF7969505E881E391 /* ParachainAvn+Calls.swift */; };
 		5FE687B860FC10AB08518A6E /* WalletHistoryFilterPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9150FEC66FC503CF1BD1D0 /* WalletHistoryFilterPresenter.swift */; };
 		5FF13D27B596CD7B0CA20671 /* NominationPoolBondMoreSetupViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF2717F0CC0A4529C925814 /* NominationPoolBondMoreSetupViewLayout.swift */; };
 		6003DF3EBB77510EFB70B4E4 /* MessageSheetProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C797A5B5863A026E84062AE /* MessageSheetProtocols.swift */; };
@@ -3428,6 +3435,7 @@
 		81ADC94E1CC47A2C6F0F1BEA /* GovernanceEditDelegationTracksProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32F1F0F6F985195CD19EDDB /* GovernanceEditDelegationTracksProtocols.swift */; };
 		821518375113295E41E0481C /* ParitySignerTxQrViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B56BDC7E6221DE292498D3A /* ParitySignerTxQrViewFactory.swift */; };
 		8217DCBEB74527D57AC82070 /* CollatorStakingConfirmViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E27EB6FF31F9D247DEFABB /* CollatorStakingConfirmViewLayout.swift */; };
+		82DCC135BE45141361D794E7 /* ParachainAvnRemoteSubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86CFB04A1F3714A4B49FD399 /* ParachainAvnRemoteSubscriptionService.swift */; };
 		831F4C7E463D374DEED577D5 /* ManualBackupKeyListWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB02245B44D5D1036626E24 /* ManualBackupKeyListWireframe.swift */; };
 		8321399396FA5B25BC93A090 /* DAppPhishingViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22914482F786318D8F6C5E27 /* DAppPhishingViewLayout.swift */; };
 		8324776DA6F43F1408A3ACB5 /* ImportCloudPasswordViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EA837CDC74E8301C0207E5 /* ImportCloudPasswordViewFactory.swift */; };
@@ -5511,6 +5519,7 @@
 		85E6DA35DF2D2C4C73FBE988 /* AHMInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DA7291E053BF3B6F78990C /* AHMInfoViewController.swift */; };
 		8614F070CD3DEEA3D41B3635 /* DAppBrowserTabListViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3861E52C532B8825313B7F9 /* DAppBrowserTabListViewLayout.swift */; };
 		86EB789787B731691B36C827 /* OnChainTransferSetupPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1A2F7E5E278FDCC89FE097 /* OnChainTransferSetupPresenter.swift */; };
+		86EF33CE7D2FE628F5C73FB4 /* ParachainAvnNetworkInfoOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01888DFEBC5E3FB3594E52A2 /* ParachainAvnNetworkInfoOperationFactory.swift */; };
 		873FAB6E5CAD1FD4D02737D0 /* NominationPoolBondMoreSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C9473AB7D1FE4A27403078 /* NominationPoolBondMoreSetupViewController.swift */; };
 		877A27A443F9C4048B7FF99A /* PayCardInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545A70A20C21319141342418 /* PayCardInteractor.swift */; };
 		8786222ADF4643BE7A6FBBEB /* SwapSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEB2BC52266AF493D310834 /* SwapSetupViewController.swift */; };
@@ -5831,6 +5840,7 @@
 		91E4653DFEDBE6605E241144 /* NotificationsSetupViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7300E64DC3C8B3FD476A1D1 /* NotificationsSetupViewLayout.swift */; };
 		920007949A0004A5D91C3F96 /* CloudBackupAddWalletWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703B7D980A748F1B9F51611D /* CloudBackupAddWalletWireframe.swift */; };
 		9202CBF07DA49C807A8687FA /* CloudBackupAddWalletViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA49EE64DC450755353E482 /* CloudBackupAddWalletViewFactory.swift */; };
+		922D577A791EA361E70C7561 /* StartStakingInfoViewFactory+ParachainAvn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B30BAEDC2056E2A8F7DFAEC /* StartStakingInfoViewFactory+ParachainAvn.swift */; };
 		924BADB89E7FA2DC54BF1A02 /* NPoolsClaimRewardsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F1F933F624B01855AA3BA5 /* NPoolsClaimRewardsInteractor.swift */; };
 		92984DFE797C52644C084377 /* SwapSetupProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53775773F2060B4B7F6D62DA /* SwapSetupProtocols.swift */; };
 		92B880FEDD0AE45A36898308 /* PayCardViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731F3692859677E2B67AE629 /* PayCardViewFactory.swift */; };
@@ -6102,6 +6112,7 @@
 		B317AB093D99677D292121C4 /* YourWalletsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84ED3A7899C88876AB3DCA5F /* YourWalletsViewController.swift */; };
 		B322E542E7B9D5EAB745546E /* TransactionHistoryViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7DAF20C447065DA5467696 /* TransactionHistoryViewLayout.swift */; };
 		B33EBF5821B995FE21424705 /* NPoolsUnstakeConfirmViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12C822BAC40271396E36ACBB /* NPoolsUnstakeConfirmViewLayout.swift */; };
+		B3C11FDC87CDA64A5CF12FF8 /* ParachainAvnRewardCalculatorEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D545B533231BFE8F4E4EC7 /* ParachainAvnRewardCalculatorEngine.swift */; };
 		B3E567D46F54E8E735792FE1 /* ParaStkYieldBoostSetupViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8958927F940B9B638EF89D /* ParaStkYieldBoostSetupViewFactory.swift */; };
 		B409644ED1E20062A3EA0316 /* DAppTxDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCDAB970C17F9798AC79B08 /* DAppTxDetailsViewController.swift */; };
 		B41588A787213EB6344F2469 /* GiftPrepareShareViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38BED3D9EBFA08C1DA40A4C /* GiftPrepareShareViewFactory.swift */; };
@@ -6121,6 +6132,7 @@
 		B7CF31A548C02AD7AAC16A8D /* StakingRedeemWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A93673EEA8F71E8DDA84557 /* StakingRedeemWireframe.swift */; };
 		B804BDDC5F3960AA59CE3E5B /* AssetDetailsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 667D74094E813EA3C53EE897 /* AssetDetailsPresenter.swift */; };
 		B8061AAA1DFFB045154569DE /* ParaStkUnstakeConfirmWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E6B5C44D7F43B5C14901ED /* ParaStkUnstakeConfirmWireframe.swift */; };
+		B8176934942B21E49B437DCF /* ParachainAvnRewardCalculatorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F6FE1DD897F54BE53EA9A8 /* ParachainAvnRewardCalculatorService.swift */; };
 		B823DEE94E0979161EE96F59 /* OnboardingImportOptionsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8FE2D2EF1036543F55D410 /* OnboardingImportOptionsInteractor.swift */; };
 		B8349266F061AEFFA9802237 /* TokenManageSingleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADBC3405EEB1F8941FB19BAA /* TokenManageSingleViewController.swift */; };
 		B8DC27C3CAE9846A5E56B4EE /* GovernanceDelegateSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3903A0A93FB8068071F9BD /* GovernanceDelegateSetupViewController.swift */; };
@@ -6241,6 +6253,7 @@
 		CEED39FF1C586C00B56B1F0C /* AddDelegationViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74FF4FE525ADD8E7805481E /* AddDelegationViewLayout.swift */; };
 		CF1272B8CA2C661E931222F0 /* SwipeGovVotingListViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0811515EC834B737A3536329 /* SwipeGovVotingListViewLayout.swift */; };
 		CF2F3A0F0999D6D054CD33D2 /* ReferendumSearchProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536D1CA47A5753B9E0389BEA /* ReferendumSearchProtocols.swift */; };
+		CFA1FBF0F149A10FD005A3E9 /* ParachainAvnStakingConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3754FFC4CD85BD04C4F5411D /* ParachainAvnStakingConstants.swift */; };
 		CFA85B381D80233005140D87 /* StakingMainPresenterFactory+Mythos.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87C048F50461F35E4C1D87B /* StakingMainPresenterFactory+Mythos.swift */; };
 		CFB55CEEDBB7BC41655E03A1 /* GiftPrepareShareInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C421F2837A9F70C467AB47 /* GiftPrepareShareInteractor.swift */; };
 		CFD1B4635D0ED2DC7DAD1EC1 /* CloudBackupRemindPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA24FD142810AEE259CC56C /* CloudBackupRemindPresenter.swift */; };
@@ -6324,6 +6337,7 @@
 		DD7554F36497B3CFA4D4E6AA /* CloudBackupCreateViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD26E02E5EA85D22062142CD /* CloudBackupCreateViewFactory.swift */; };
 		DDA07514BEF3E2FD6EE1BB4E /* InAppUpdatesViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06268C2A9EAC65722D6E8947 /* InAppUpdatesViewLayout.swift */; };
 		DE03CA5AD7F1D0B80DFF13B6 /* DAppBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1855972C88E512AED37FD312 /* DAppBrowserViewController.swift */; };
+		DE45E5D9A857024136CEA969 /* ParachainAvn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05E92DEC6C71D073E5FD4024 /* ParachainAvn.swift */; };
 		DE52F23521D54A07F558EB1B /* ReferendumVoteConfirmInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1A35F4D82F97C9663F1CD4 /* ReferendumVoteConfirmInteractor.swift */; };
 		DEA5D2AB0D4CAEFE26327996 /* TokensManageAddPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5696D203FE1D56D20BA4DA52 /* TokensManageAddPresenter.swift */; };
 		DECE047E7BBE2B9251A09353 /* CollatorStkUnstakeConfirmVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6060CE86A7EA49AD05329C /* CollatorStkUnstakeConfirmVC.swift */; };
@@ -6335,6 +6349,7 @@
 		E0710E487509797C12110D83 /* AssetDetailsViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A42FD5E0D98EFE83883EC56 /* AssetDetailsViewFactory.swift */; };
 		E0CBD1D747361D121555FD51 /* ParaStkRedeemViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BEEFB03BBA45F5143484398 /* ParaStkRedeemViewFactory.swift */; };
 		E14F809C3917EFA4B5388AC8 /* AccountConfirmViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14CA4551FCC2EBD078E2242 /* AccountConfirmViewFactory.swift */; };
+		E1C5BF0DAB2321187BA4A5CB /* ParachainAvnCallsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE0D1FE8E24B3A43BCBCF83 /* ParachainAvnCallsTests.swift */; };
 		E221892A5B6A41A944B88336 /* ParaStkYieldBoostStartProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50829CD47D3F60E3067418B4 /* ParaStkYieldBoostStartProtocols.swift */; };
 		E28F3762EAC9A4E5D21342D4 /* GovernanceUnlockSetupViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E4AF529B896F7E58671A74 /* GovernanceUnlockSetupViewFactory.swift */; };
 		E2A9BC1477D81DDDE519404C /* DAppOperationConfirmWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48CECA2C5A0EFEBFDBB3C90C /* DAppOperationConfirmWireframe.swift */; };
@@ -6534,6 +6549,7 @@
 		F8617BB83CE091445E5087AD /* NetworkDetailsWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13222F73DF179169827365D5 /* NetworkDetailsWireframe.swift */; };
 		F88D85C73094F6A1FC494D87 /* DAppSearchWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A191B92AD171FDDDD8C30E2 /* DAppSearchWireframe.swift */; };
 		F8C0CA3DDBCB5E509295F099 /* MarkdownDescriptionViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF9ED27CF12B7DA8B1378CF /* MarkdownDescriptionViewFactory.swift */; };
+		F8C70EE9D7E41D817F8C1FB5 /* ParachainAvnDurationOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A28A8AA838C6C760252BCA /* ParachainAvnDurationOperationFactory.swift */; };
 		F92E73C24AB577F37B35649E /* WalletConnectSessionDetailsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14339E7BE9FE045C6A2AB52 /* WalletConnectSessionDetailsInteractor.swift */; };
 		F9540A5C434F7E3CE6ED4EB4 /* NetworkManageNodePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78268D2C88E26B680F5CD09D /* NetworkManageNodePresenter.swift */; };
 		F9CEF01779F811AEEED06C43 /* SwapSlippageViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E965356C7C646CB86BBEBB6 /* SwapSlippageViewLayout.swift */; };
@@ -6611,6 +6627,7 @@
 		0043E77B2DBB3546A9E54C4B /* AdvancedWalletProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AdvancedWalletProtocols.swift; sourceTree = "<group>"; };
 		00E1485C7B322E477D445C84 /* ChainAddressDetailsProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChainAddressDetailsProtocols.swift; sourceTree = "<group>"; };
 		0100701AA69652CB91ACBD97 /* AssetListInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetListInteractor.swift; sourceTree = "<group>"; };
+		01888DFEBC5E3FB3594E52A2 /* ParachainAvnNetworkInfoOperationFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnNetworkInfoOperationFactory.swift; sourceTree = "<group>"; };
 		01A9D9D13EC9D921A2C8FB6D /* DAppAuthConfirmWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppAuthConfirmWireframe.swift; sourceTree = "<group>"; };
 		01B2EBE8C02491A06121705A /* GovernanceUnlockConfirmViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceUnlockConfirmViewController.swift; sourceTree = "<group>"; };
 		01D9C4A550C6DDF85491B8A0 /* NPoolsUnstakeSetupInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NPoolsUnstakeSetupInteractor.swift; sourceTree = "<group>"; };
@@ -6632,6 +6649,7 @@
 		0533F9E531CDFB721D697769 /* YourValidatorListPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = YourValidatorListPresenter.swift; sourceTree = "<group>"; };
 		057EF626183878DD2C9E7BC7 /* DAppAddFavoriteViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppAddFavoriteViewController.swift; sourceTree = "<group>"; };
 		05AA59AFC801F52B79DDBBCF /* TokensManageProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokensManageProtocols.swift; sourceTree = "<group>"; };
+		05E92DEC6C71D073E5FD4024 /* ParachainAvn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvn.swift; sourceTree = "<group>"; };
 		060D52F9BFFB646BF9FCC968 /* StakingSelectPoolPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingSelectPoolPresenter.swift; sourceTree = "<group>"; };
 		06268C2A9EAC65722D6E8947 /* InAppUpdatesViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InAppUpdatesViewLayout.swift; sourceTree = "<group>"; };
 		064DAF1CCE3AB24880E37705 /* MultisigOperationConfirmInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MultisigOperationConfirmInteractor.swift; sourceTree = "<group>"; };
@@ -8022,6 +8040,7 @@
 		0D6E67AD564867E121601F18 /* WalletsListPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletsListPresenter.swift; sourceTree = "<group>"; };
 		0D9C85AB0C9D53B522DCF3C5 /* CreateWatchOnlyInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CreateWatchOnlyInteractor.swift; sourceTree = "<group>"; };
 		0DCD5C5B0CCF665B18B0E13A /* NetworkDetailsInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkDetailsInteractor.swift; sourceTree = "<group>"; };
+		0E0B53920BCFE285BB6A6EB6 /* ParachainAvn+StoragePaths.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ParachainAvn+StoragePaths.swift"; sourceTree = "<group>"; };
 		0E1AB5FA9D24E5E53E703005 /* ManualBackupKeyListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualBackupKeyListViewController.swift; sourceTree = "<group>"; };
 		0E1AE1C4FF054023B98969F0 /* CloudBackupReviewChangesViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudBackupReviewChangesViewController.swift; sourceTree = "<group>"; };
 		0E4D3F275296975CA39280D5 /* StartStakingInfoBasePresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StartStakingInfoBasePresenter.swift; sourceTree = "<group>"; };
@@ -8029,6 +8048,7 @@
 		0EC18369BDAF9076681B6E3F /* InAppUpdatesWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InAppUpdatesWireframe.swift; sourceTree = "<group>"; };
 		0FA94E5B74194AABA482F2FD /* WalletConnectSessionDetailsProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletConnectSessionDetailsProtocols.swift; sourceTree = "<group>"; };
 		0FCC7D490906498F89DAE535 /* AHMInfoProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AHMInfoProtocols.swift; sourceTree = "<group>"; };
+		0FD327CCF7969505E881E391 /* ParachainAvn+Calls.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ParachainAvn+Calls.swift"; sourceTree = "<group>"; };
 		1039AA3654461114FBB86844 /* DAppTxDetailsPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppTxDetailsPresenter.swift; sourceTree = "<group>"; };
 		1090AF9D9F18846E5A73F73C /* NominationPoolSearchPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NominationPoolSearchPresenter.swift; sourceTree = "<group>"; };
 		10B808DF32AF89255DD5B0CB /* AppearanceSettingsPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsPresenter.swift; sourceTree = "<group>"; };
@@ -9022,8 +9042,10 @@
 		36AB8804B896E72AC81879C6 /* CollatorStakingSelectPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollatorStakingSelectPresenter.swift; sourceTree = "<group>"; };
 		36AE1C39767C4CBE3229089D /* DAppPhishingViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppPhishingViewFactory.swift; sourceTree = "<group>"; };
 		36D2D8238F708E5D7D141A37 /* TokensManageViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokensManageViewFactory.swift; sourceTree = "<group>"; };
+		36D545B533231BFE8F4E4EC7 /* ParachainAvnRewardCalculatorEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnRewardCalculatorEngine.swift; sourceTree = "<group>"; };
 		374AF5133A7FD39B961B9C84 /* GovernanceUnavailableTracksWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceUnavailableTracksWireframe.swift; sourceTree = "<group>"; };
 		37513C1D98A2D9583348BD66 /* GiftClaimWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiftClaimWireframe.swift; sourceTree = "<group>"; };
+		3754FFC4CD85BD04C4F5411D /* ParachainAvnStakingConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnStakingConstants.swift; sourceTree = "<group>"; };
 		376F2C0E94A454FBBBB903F6 /* ParaStkYieldBoostStopInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParaStkYieldBoostStopInteractor.swift; sourceTree = "<group>"; };
 		377CD0A9ABDBDFCA07B6DB5C /* AHMInfoViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AHMInfoViewFactory.swift; sourceTree = "<group>"; };
 		3789A955202DA7CCADE13E68 /* DAppSettingsProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppSettingsProtocols.swift; sourceTree = "<group>"; };
@@ -9193,6 +9215,7 @@
 		57CDCB8CF3D8EBE5DA7A5A30 /* ReferendumFullDetailsViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumFullDetailsViewLayout.swift; sourceTree = "<group>"; };
 		57E6825E525785A1A12C62E7 /* MarkdownDescriptionWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarkdownDescriptionWireframe.swift; sourceTree = "<group>"; };
 		57F0C615209D923E08357766 /* ImportCloudPasswordViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportCloudPasswordViewController.swift; sourceTree = "<group>"; };
+		57F6FE1DD897F54BE53EA9A8 /* ParachainAvnRewardCalculatorService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnRewardCalculatorService.swift; sourceTree = "<group>"; };
 		58612684146AD03AD7BC30DF /* ChangeWatchOnlyViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChangeWatchOnlyViewLayout.swift; sourceTree = "<group>"; };
 		58F9884EB10C98632C6A41C5 /* WalletImportOptionsViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletImportOptionsViewFactory.swift; sourceTree = "<group>"; };
 		597A3C3F2937333D0EC7ABD5 /* AdvancedWalletViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AdvancedWalletViewController.swift; sourceTree = "<group>"; };
@@ -9237,6 +9260,7 @@
 		62FA66143B25AA70B02CE461 /* ExportSeedViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExportSeedViewFactory.swift; sourceTree = "<group>"; };
 		6310BB090B7DE26C8B489EF2 /* DAppFavoritesPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppFavoritesPresenter.swift; sourceTree = "<group>"; };
 		6325D31600DC2E1464ABE948 /* StakingDashboardProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingDashboardProtocols.swift; sourceTree = "<group>"; };
+		633D485DD456CDFCB098D9C1 /* ParachainAvnCollator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnCollator.swift; sourceTree = "<group>"; };
 		636452DDE0D956DE05A73278 /* GiftPrepareSharePresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiftPrepareSharePresenter.swift; sourceTree = "<group>"; };
 		638A65DAC86BAF9EB4D2F2F8 /* StakingRewardDetailsWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingRewardDetailsWireframe.swift; sourceTree = "<group>"; };
 		641067C2CF2998FD70FE27BE /* OnboardingWalletReadyInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingWalletReadyInteractor.swift; sourceTree = "<group>"; };
@@ -9275,6 +9299,7 @@
 		6A825B6368073B06F32D7C8F /* StakingMainViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingMainViewFactory.swift; sourceTree = "<group>"; };
 		6AD8B98AB03AAF06AA891695 /* TransferConfirmViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransferConfirmViewLayout.swift; sourceTree = "<group>"; };
 		6B0DCF5B544D9B2719CAECF8 /* MythosStkYourCollatorsProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MythosStkYourCollatorsProtocols.swift; sourceTree = "<group>"; };
+		6B30BAEDC2056E2A8F7DFAEC /* StartStakingInfoViewFactory+ParachainAvn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "StartStakingInfoViewFactory+ParachainAvn.swift"; sourceTree = "<group>"; };
 		6B60728FCFBC8A9BE4C7B50B /* YourValidatorListInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = YourValidatorListInteractor.swift; sourceTree = "<group>"; };
 		6BA14E9659FC44A438FFEEB5 /* ParitySignerTxQrWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParitySignerTxQrWireframe.swift; sourceTree = "<group>"; };
 		6C1179A25C22AF0875A1ADCD /* AssetReceiveWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetReceiveWireframe.swift; sourceTree = "<group>"; };
@@ -11792,6 +11817,7 @@
 		8602E65CC4E81A7BE1727CE3 /* VotesViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VotesViewLayout.swift; sourceTree = "<group>"; };
 		862545D6BD501914AE04D776 /* NPoolsRedeemViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NPoolsRedeemViewController.swift; sourceTree = "<group>"; };
 		8632A6D9689942DE89F174FA /* SwapExecutionInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwapExecutionInteractor.swift; sourceTree = "<group>"; };
+		86CFB04A1F3714A4B49FD399 /* ParachainAvnRemoteSubscriptionService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnRemoteSubscriptionService.swift; sourceTree = "<group>"; };
 		86DCB6F3977BDE1BDC7BC3F9 /* ParaStkUnstakeConfirmPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParaStkUnstakeConfirmPresenter.swift; sourceTree = "<group>"; };
 		86F7A369E31DCB9ABD556EE9 /* CrowdloanListPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CrowdloanListPresenter.swift; sourceTree = "<group>"; };
 		86F7ACFB151C31B3A5044DCD /* StakingSelectPoolInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingSelectPoolInteractor.swift; sourceTree = "<group>"; };
@@ -12433,6 +12459,7 @@
 		B56202207DF8BB6684C6EF6C /* AdvancedWalletPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AdvancedWalletPresenter.swift; sourceTree = "<group>"; };
 		B5AEEBB57E40B1FD4F7F354C /* NetworkNodeAddInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkNodeAddInteractor.swift; sourceTree = "<group>"; };
 		B5BC1402B34E341312ABB378 /* LedgerWalletConfirmPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LedgerWalletConfirmPresenter.swift; sourceTree = "<group>"; };
+		B5FF4DD368E914F04B1CEA95 /* ParachainAvnLocalSubscriptionFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnLocalSubscriptionFactory.swift; sourceTree = "<group>"; };
 		B6884DFC1AA1B995C21C274C /* WalletHistoryFilterViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletHistoryFilterViewController.swift; sourceTree = "<group>"; };
 		B718CE9C51158F87D37894BB /* GovernanceDelegateConfirmViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceDelegateConfirmViewFactory.swift; sourceTree = "<group>"; };
 		B727587201B9D6F91A28428A /* ReferendumDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumDetailsViewController.swift; sourceTree = "<group>"; };
@@ -12549,6 +12576,7 @@
 		CF94E6B1ADC9C585B9C008D5 /* GiftPrepareShareWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiftPrepareShareWireframe.swift; sourceTree = "<group>"; };
 		CFA54AB88E24A2053F289D74 /* GovernanceUnlockSetupInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceUnlockSetupInteractor.swift; sourceTree = "<group>"; };
 		CFC64F8EEE9C87E40C642915 /* CustomNetworkViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomNetworkViewFactory.swift; sourceTree = "<group>"; };
+		CFE0D1FE8E24B3A43BCBCF83 /* ParachainAvnCallsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnCallsTests.swift; sourceTree = "<group>"; };
 		D02E38ABE379CA48E63328C4 /* DAppBrowserProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppBrowserProtocols.swift; sourceTree = "<group>"; };
 		D031A00440DE64D47DC9C4A7 /* DAppBrowserTabListInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppBrowserTabListInteractor.swift; sourceTree = "<group>"; };
 		D043AA10042F3C0D07583330 /* CrowdloanUnlockWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CrowdloanUnlockWireframe.swift; sourceTree = "<group>"; };
@@ -12575,6 +12603,7 @@
 		D46DF4E6D8DAF6913474DED5 /* GovernanceYourDelegationsInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceYourDelegationsInteractor.swift; sourceTree = "<group>"; };
 		D4B1A8B64F18CC2D0745B6B8 /* GovernanceNotificationsPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceNotificationsPresenter.swift; sourceTree = "<group>"; };
 		D4C391292F22D16427C77CD9 /* SelectValidatorsStartViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SelectValidatorsStartViewFactory.swift; sourceTree = "<group>"; };
+		D4CF985376C46EDFD423C94C /* ParachainAvn+ConstantPaths.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ParachainAvn+ConstantPaths.swift"; sourceTree = "<group>"; };
 		D4EA837CDC74E8301C0207E5 /* ImportCloudPasswordViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportCloudPasswordViewFactory.swift; sourceTree = "<group>"; };
 		D4F15BAE6D32E19B150EC96E /* NotificationsManagementPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationsManagementPresenter.swift; sourceTree = "<group>"; };
 		D4FF4B9F6D622879D5058790 /* MythosStakingRedeemInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MythosStakingRedeemInteractor.swift; sourceTree = "<group>"; };
@@ -12654,6 +12683,7 @@
 		E283DABBC3BA910B8FC92271 /* NetworkManageNodeViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkManageNodeViewLayout.swift; sourceTree = "<group>"; };
 		E29DAC8F2DB0F7BF909812FA /* DAppTxDetailsViewLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DAppTxDetailsViewLayout.swift; sourceTree = "<group>"; };
 		E2E005960E331E8882A8C6FD /* StakingRebagConfirmWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingRebagConfirmWireframe.swift; sourceTree = "<group>"; };
+		E2E8E06E63183EC1A5974449 /* StakingMainPresenterFactory+ParachainAvn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "StakingMainPresenterFactory+ParachainAvn.swift"; sourceTree = "<group>"; };
 		E2F3E725280823CF00CF31B5 /* ETHAccountInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETHAccountInjection.swift; sourceTree = "<group>"; };
 		E30E541992BF608923DABE5F /* LocksWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocksWireframe.swift; sourceTree = "<group>"; };
 		E32BD0DD899F0FA996D02C55 /* CloudBackupAddWalletInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudBackupAddWalletInteractor.swift; sourceTree = "<group>"; };
@@ -12676,6 +12706,7 @@
 		E6DDBA4DD86CEFAAE236B23B /* GovernanceDelegateSetupPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceDelegateSetupPresenter.swift; sourceTree = "<group>"; };
 		E6FE9E98CB265815986BE909 /* ReferendumVotersProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferendumVotersProtocols.swift; sourceTree = "<group>"; };
 		E765FD856EB60BBF344205F3 /* TokensAddSelectNetworkWireframe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokensAddSelectNetworkWireframe.swift; sourceTree = "<group>"; };
+		E7A28A8AA838C6C760252BCA /* ParachainAvnDurationOperationFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnDurationOperationFactory.swift; sourceTree = "<group>"; };
 		E7B01586B548A0AB92695B40 /* CommonDelegationTracksViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CommonDelegationTracksViewController.swift; sourceTree = "<group>"; };
 		E7B77D655A395946E9405285 /* GovernanceNotificationsProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GovernanceNotificationsProtocols.swift; sourceTree = "<group>"; };
 		E7BA4C5AB8F2334E97AEBAE9 /* SwipeGovPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwipeGovPresenter.swift; sourceTree = "<group>"; };
@@ -12761,6 +12792,7 @@
 		F41CEBE32731617A00C06154 /* CrowdloanRewardDestinationVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrowdloanRewardDestinationVM.swift; sourceTree = "<group>"; };
 		F41CEBE9273161DE00C06154 /* CrowdloanRewardDestinationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrowdloanRewardDestinationView.swift; sourceTree = "<group>"; };
 		F429324E26280F6B00752C2C /* StakingRewardDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingRewardDetailsViewModel.swift; sourceTree = "<group>"; };
+		F42A866274E3DDA80AE0DCF0 /* ParachainAvnStakePosition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParachainAvnStakePosition.swift; sourceTree = "<group>"; };
 		F436BB9D2726FBF7004B1794 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		F43A596926D520E0005E973D /* EmptyStateViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateViewCell.swift; sourceTree = "<group>"; };
 		F43A8A94265B9CF400A8A5A8 /* CustomValidatorCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomValidatorCell.swift; sourceTree = "<group>"; };
@@ -13040,6 +13072,19 @@
 				A82E373FFFBF708D7CF0973E /* StakingUnbondSetupViewFactory.swift */,
 			);
 			path = StakingUnbondSetup;
+			sourceTree = "<group>";
+		};
+		05537F00DE205F65F6DD03AC /* ParachainAvnStaking */ = {
+			isa = PBXGroup;
+			children = (
+				447FBF815A55C3922200E854 /* Model */,
+				C8EE8A7F0B711C1359ED8EB4 /* Calls */,
+				C166E022EDECD29C3FC5E711 /* Types */,
+				3713ADCC062EA366106994AC /* Tests */,
+				730D52BA024B6958970FE2BA /* Service */,
+			);
+			name = ParachainAvnStaking;
+			path = ParachainAvnStaking;
 			sourceTree = "<group>";
 		};
 		06305D6FCB11AE0ECF219556 /* CollatorFilters */ = {
@@ -19311,6 +19356,15 @@
 			path = YourDelegations;
 			sourceTree = "<group>";
 		};
+		3713ADCC062EA366106994AC /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				CFE0D1FE8E24B3A43BCBCF83 /* ParachainAvnCallsTests.swift */,
+			);
+			name = Tests;
+			path = Tests;
+			sourceTree = "<group>";
+		};
 		37A08AC22D31094D2909AC22 /* MythosStkUnstakeConfirm */ = {
 			isa = PBXGroup;
 			children = (
@@ -19474,6 +19528,18 @@
 				77A0B2F22A3CA37E00CBF653 /* StakingMoreOptionsViewModelFactory.swift */,
 			);
 			path = StakingMoreOptions;
+			sourceTree = "<group>";
+		};
+		447FBF815A55C3922200E854 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				05E92DEC6C71D073E5FD4024 /* ParachainAvn.swift */,
+				3754FFC4CD85BD04C4F5411D /* ParachainAvnStakingConstants.swift */,
+				633D485DD456CDFCB098D9C1 /* ParachainAvnCollator.swift */,
+				F42A866274E3DDA80AE0DCF0 /* ParachainAvnStakePosition.swift */,
+			);
+			name = Model;
+			path = Model;
 			sourceTree = "<group>";
 		};
 		47A0D9585B152172BA52336C /* CloudBackupCreate */ = {
@@ -19937,6 +20003,20 @@
 				E83916DF00BA41516B94304E /* DelegationReferendumVotersViewFactory.swift */,
 			);
 			path = DelegationReferendumVoters;
+			sourceTree = "<group>";
+		};
+		730D52BA024B6958970FE2BA /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				36D545B533231BFE8F4E4EC7 /* ParachainAvnRewardCalculatorEngine.swift */,
+				57F6FE1DD897F54BE53EA9A8 /* ParachainAvnRewardCalculatorService.swift */,
+				B5FF4DD368E914F04B1CEA95 /* ParachainAvnLocalSubscriptionFactory.swift */,
+				86CFB04A1F3714A4B49FD399 /* ParachainAvnRemoteSubscriptionService.swift */,
+				E7A28A8AA838C6C760252BCA /* ParachainAvnDurationOperationFactory.swift */,
+				01888DFEBC5E3FB3594E52A2 /* ParachainAvnNetworkInfoOperationFactory.swift */,
+			);
+			name = Service;
+			path = Service;
 			sourceTree = "<group>";
 		};
 		74B077FD58F192DB7C7158C2 /* StakingRewardsNotifications */ = {
@@ -21224,6 +21304,7 @@
 				841E5552282E35D000C8438F /* StakingParachainPresenter.swift */,
 				84C34203283124C600156569 /* StakingParachainWireframe.swift */,
 				846FB02D28C7524200CA5444 /* StakingParachainInteractor+Provide.swift */,
+				E2E8E06E63183EC1A5974449 /* StakingMainPresenterFactory+ParachainAvn.swift */,
 			);
 			path = Parachain;
 			sourceTree = "<group>";
@@ -27324,6 +27405,7 @@
 				17432B4B5D8D9DC5C22CA238 /* StakingType */,
 				92CDAD21CEED554306CAF5D8 /* StartStakingConfirm */,
 				7750CC352B5FB29300002991 /* StakingProxy */,
+				05537F00DE205F65F6DD03AC /* ParachainAvnStaking */,
 			);
 			path = Staking;
 			sourceTree = "<group>";
@@ -29210,6 +29292,16 @@
 			path = PayCard;
 			sourceTree = "<group>";
 		};
+		C166E022EDECD29C3FC5E711 /* Types */ = {
+			isa = PBXGroup;
+			children = (
+				0E0B53920BCFE285BB6A6EB6 /* ParachainAvn+StoragePaths.swift */,
+				D4CF985376C46EDFD423C94C /* ParachainAvn+ConstantPaths.swift */,
+			);
+			name = Types;
+			path = Types;
+			sourceTree = "<group>";
+		};
 		C3AD18EBC1E8396B610D9FCB /* CloudBackupReviewChanges */ = {
 			isa = PBXGroup;
 			children = (
@@ -29266,6 +29358,15 @@
 				2AFF4BA1274D1E5C00D790B4 /* UsernameSetupViewLayout.swift */,
 			);
 			path = UsernameSetup;
+			sourceTree = "<group>";
+		};
+		C8EE8A7F0B711C1359ED8EB4 /* Calls */ = {
+			isa = PBXGroup;
+			children = (
+				0FD327CCF7969505E881E391 /* ParachainAvn+Calls.swift */,
+			);
+			name = Calls;
+			path = Calls;
 			sourceTree = "<group>";
 		};
 		C9850B4B70AEFEABB96269FF /* TransactionHistory */ = {
@@ -29333,6 +29434,7 @@
 				694E15BA7E0C59E46D0A6612 /* StartStakingInfoViewFactory.swift */,
 				0CF193D62A861D7E003F12F6 /* StartStakingInfoConstants.swift */,
 				0C0F6D8A2D3A927D00943A7C /* StartStakingInfoViewFactory+Mythos.swift */,
+				6B30BAEDC2056E2A8F7DFAEC /* StartStakingInfoViewFactory+ParachainAvn.swift */,
 			);
 			path = StartStakingInfo;
 			sourceTree = "<group>";
@@ -30341,7 +30443,7 @@
 				0C8FCEA02E672BB000034ED3 /* XCRemoteSwiftPackageReference "UIKit-iOS" */,
 				0C8FCEA62E672BFB00034ED3 /* XCRemoteSwiftPackageReference "Foundation-iOS" */,
 				0C8FCEA92E672C5500034ED3 /* XCRemoteSwiftPackageReference "SwiftyBeaver" */,
-				0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability" */,
+				0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability.swift" */,
 				0C8FCEAF2E672CFA00034ED3 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				0C8FCEB22E672D3900034ED3 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				0C8FCEB52E672D8100034ED3 /* XCRemoteSwiftPackageReference "SwiftDraw" */,
@@ -30353,7 +30455,7 @@
 				0C8FCEC72E6734E900034ED3 /* XCRemoteSwiftPackageReference "ZMarkupParser" */,
 				0C8FCECA2E6735F300034ED3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				0C8FCED32E67363000034ED3 /* XCRemoteSwiftPackageReference "metadata-shortener-ios" */,
-				0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */,
+				0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */,
 				0CF8F68E2E673E73007E41C4 /* XCRemoteSwiftPackageReference "Cuckoo" */,
 				0C32522B2E67477700E322DB /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */,
 				0C2BAA1B2E677B6E008157E7 /* XCRemoteSwiftPackageReference "web3swift" */,
@@ -36845,6 +36947,21 @@
 				33096BCF84A6ABA8416678FF /* CrowdloanUnlockViewController.swift in Sources */,
 				F170C0900DB942030B2107C7 /* CrowdloanUnlockViewLayout.swift in Sources */,
 				6B19F3A772108FBED12A7260 /* CrowdloanUnlockViewFactory.swift in Sources */,
+				DE45E5D9A857024136CEA969 /* ParachainAvn.swift in Sources */,
+				CFA1FBF0F149A10FD005A3E9 /* ParachainAvnStakingConstants.swift in Sources */,
+				42E9334FA56382D30276F88F /* ParachainAvnCollator.swift in Sources */,
+				00C0486D0E219C78A9230119 /* ParachainAvnStakePosition.swift in Sources */,
+				5F238F8FEC38D8110F01735C /* ParachainAvn+Calls.swift in Sources */,
+				2012DFAA7416C15267306543 /* ParachainAvn+StoragePaths.swift in Sources */,
+				3CBDCC13C1AA8BCBA21C902C /* ParachainAvn+ConstantPaths.swift in Sources */,
+				B3C11FDC87CDA64A5CF12FF8 /* ParachainAvnRewardCalculatorEngine.swift in Sources */,
+				B8176934942B21E49B437DCF /* ParachainAvnRewardCalculatorService.swift in Sources */,
+				0B23CDC1DA92D3B53E9BA047 /* ParachainAvnLocalSubscriptionFactory.swift in Sources */,
+				82DCC135BE45141361D794E7 /* ParachainAvnRemoteSubscriptionService.swift in Sources */,
+				922D577A791EA361E70C7561 /* StartStakingInfoViewFactory+ParachainAvn.swift in Sources */,
+				12456AEC7EA98AAF8440E8EE /* StakingMainPresenterFactory+ParachainAvn.swift in Sources */,
+				F8C70EE9D7E41D817F8C1FB5 /* ParachainAvnDurationOperationFactory.swift in Sources */,
+				86EF33CE7D2FE628F5C73FB4 /* ParachainAvnNetworkInfoOperationFactory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -37027,6 +37144,7 @@
 				84AA004326C5DFD800BCB4DC /* RuntimeSyncServiceTests.swift in Sources */,
 				8413B27A29507F3A00F8E2E4 /* DataProviderRepositoryStub.swift in Sources */,
 				F4897BB126AED13D0075F291 /* EraCountdownOperationFactoryStub.swift in Sources */,
+				E1C5BF0DAB2321187BA4A5CB /* ParachainAvnCallsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -37035,15 +37153,15 @@
 /* Begin PBXTargetDependency section */
 		0C1995CB2E6B2DE600E0B909 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 0C1995CA2E6B2DE600E0B909 /* RswiftGenerateInternalResources */;
+			productRef = 0C1995CA2E6B2DE600E0B909 /* plugin:RswiftGenerateInternalResources */;
 		};
 		0C1A0F502E69C04E00254E20 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 0C1A0F4F2E69C04E00254E20 /* CuckooPluginSingleFile */;
+			productRef = 0C1A0F4F2E69C04E00254E20 /* plugin:CuckooPluginSingleFile */;
 		};
 		0C6A9E2D2E6B1FC40088C2BA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 0C6A9E2C2E6B1FC40088C2BA /* RswiftGenerateInternalResources */;
+			productRef = 0C6A9E2C2E6B1FC40088C2BA /* plugin:RswiftGenerateInternalResources */;
 		};
 		77CAF4352B8E96A400E4297C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -38037,7 +38155,7 @@
 				version = 2.1.1;
 			};
 		};
-		0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability" */ = {
+		0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ashleymills/Reachability.swift";
 			requirement = {
@@ -38133,7 +38251,7 @@
 				version = 0.2.1;
 			};
 		};
-		0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */ = {
+		0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mac-cain13/R.swift";
 			requirement = {
@@ -38192,24 +38310,24 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0C1995CA2E6B2DE600E0B909 /* RswiftGenerateInternalResources */ = {
+		0C1995CA2E6B2DE600E0B909 /* plugin:RswiftGenerateInternalResources */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = "plugin:RswiftGenerateInternalResources";
 		};
 		0C1A0F472E68E01C00254E20 /* RswiftLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = RswiftLibrary;
 		};
-		0C1A0F4F2E69C04E00254E20 /* CuckooPluginSingleFile */ = {
+		0C1A0F4F2E69C04E00254E20 /* plugin:CuckooPluginSingleFile */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0CF8F68E2E673E73007E41C4 /* XCRemoteSwiftPackageReference "Cuckoo" */;
 			productName = "plugin:CuckooPluginSingleFile";
 		};
 		0C1A0F562E69EC5C00254E20 /* RswiftLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = RswiftLibrary;
 		};
 		0C2BAA1C2E677B6E008157E7 /* web3swift */ = {
@@ -38224,7 +38342,7 @@
 		};
 		0C2BAA332E67841C008157E7 /* RswiftLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = RswiftLibrary;
 		};
 		0C2BAA552E687BD0008157E7 /* HydraMathApi */ = {
@@ -38262,9 +38380,9 @@
 			package = 0C8FCE972E6725D700034ED3 /* XCRemoteSwiftPackageReference "web3swift" */;
 			productName = web3swift;
 		};
-		0C6A9E2C2E6B1FC40088C2BA /* RswiftGenerateInternalResources */ = {
+		0C6A9E2C2E6B1FC40088C2BA /* plugin:RswiftGenerateInternalResources */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R" */;
+			package = 0C8FCED62E6736E900034ED3 /* XCRemoteSwiftPackageReference "R.swift" */;
 			productName = "plugin:RswiftGenerateInternalResources";
 		};
 		0C8FCE752E65ED3400034ED3 /* DGCharts */ = {
@@ -38309,7 +38427,7 @@
 		};
 		0C8FCEAD2E672CB000034ED3 /* Reachability */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability" */;
+			package = 0C8FCEAC2E672CB000034ED3 /* XCRemoteSwiftPackageReference "Reachability.swift" */;
 			productName = Reachability;
 		};
 		0C8FCEB02E672CFA00034ED3 /* SnapKit */ = {

--- a/novawallet/Common/Configs/ApplicationConfigs.swift
+++ b/novawallet/Common/Configs/ApplicationConfigs.swift
@@ -155,7 +155,19 @@ extension ApplicationConfig: ApplicationConfigProtocol {
         #if F_RELEASE
             URL(string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/chains/v22/chains.json")!
         #else
-            URL(string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/chains/v22/chains_dev.json")!
+            // Plan 05 EWT iOS manual QA override: in dev builds, point at a
+            // local HTTP server (python3 -m http.server 8787) serving an
+            // EWT-staking-enabled chains_dev.json fixture from ~/Desktop/tao-ewt-staking.
+            // This gives Energy Web X the "staking":["parachain-avn"] array that
+            // nova-utils upstream doesn't have yet (Plan 04 not merged).
+            // Remove this override before any PR to novasamatech.
+            #if F_DEV
+                return URL(string: "http://127.0.0.1:8787/chains_dev_ewt.json")!
+            #else
+                return URL(
+                    string: "https://raw.githubusercontent.com/novasamatech/nova-utils/master/chains/v22/chains_dev.json"
+                )!
+            #endif
         #endif
     }
 

--- a/novawallet/Common/Model/ChainRegistry/LocalChain/AssetModel+Remote.swift
+++ b/novawallet/Common/Model/ChainRegistry/LocalChain/AssetModel+Remote.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 extension AssetModel {
+    // [TEMP-QA-HACK] EWT staking: inject "parachain-avn" type for EWT on EWX
+    // until nova-utils upstream PR adds it to chains.json / chains_dev.json.
+    // Remove this set and the priceId check once the PR lands.
+    private static let ewtStakingOverrides: [PriceId: [StakingType]] = [
+        "energy-web-token": [.parachainAvn]
+    ]
+
     init(remoteModel: RemoteAssetModel, enabled: Bool) {
         assetId = remoteModel.assetId
         icon = remoteModel.icon
@@ -8,12 +15,19 @@ extension AssetModel {
         symbol = remoteModel.symbol
         precision = remoteModel.precision
         priceId = remoteModel.priceId
-        stakings = remoteModel.staking?.map { StakingType(rawType: $0) }
         type = remoteModel.type
         typeExtras = remoteModel.typeExtras
         buyProviders = remoteModel.buyProviders
         sellProviders = remoteModel.sellProviders
         self.enabled = enabled
         source = .remote
+
+        // [TEMP-QA-HACK] Inject staking type for EWT if not already present in remote
+        if let override = remoteModel.priceId.flatMap({ Self.ewtStakingOverrides[$0] }),
+           remoteModel.staking == nil || remoteModel.staking?.isEmpty == true {
+            stakings = override
+        } else {
+            stakings = remoteModel.staking?.map { StakingType(rawType: $0) }
+        }
     }
 }

--- a/novawallet/Common/Services/Multistaking/MultistakingServices.swift
+++ b/novawallet/Common/Services/Multistaking/MultistakingServices.swift
@@ -14,7 +14,7 @@ extension MultistakingOffchainOperationFactoryProtocol {
         defaultAccountResponse: ChainAccountResponse
     ) -> AccountId? {
         switch option.type {
-        case .relaychain, .auraRelaychain, .azero, .parachain, .turing, .mythos, .unsupported:
+        case .relaychain, .auraRelaychain, .azero, .parachain, .turing, .mythos, .parachainAvn, .unsupported:
             return accounts[option] ?? defaultAccountResponse.accountId
         case .nominationPools:
             // we don't want to use default account as it might be connected to direct staking

--- a/novawallet/Common/Services/Multistaking/MultistakingSyncService.swift
+++ b/novawallet/Common/Services/Multistaking/MultistakingSyncService.swift
@@ -193,7 +193,7 @@ final class MultistakingSyncService {
                 for: chainAssetOption.chainAsset,
                 stakingType: chainAssetOption.type
             )
-        case .parachain, .turing:
+        case .parachain, .turing, .parachainAvn:
             createParachainStaking(
                 for: chainAssetOption.chainAsset,
                 stakingType: chainAssetOption.type
@@ -299,10 +299,11 @@ final class MultistakingSyncService {
         for chainAsset: ChainAsset,
         stakingType: StakingType
     ) -> OnchainSyncServiceProtocol? {
-        guard
-            let account = wallet.fetch(for: chainAsset.chain.accountRequest()),
-            let connection = chainRegistry.getConnection(for: chainAsset.chain.chainId),
-            let runtimeService = chainRegistry.getRuntimeProvider(for: chainAsset.chain.chainId) else {
+        let account = wallet.fetch(for: chainAsset.chain.accountRequest())
+        let connection = chainRegistry.getConnection(for: chainAsset.chain.chainId)
+        let runtimeService = chainRegistry.getRuntimeProvider(for: chainAsset.chain.chainId)
+
+        guard let account, let connection, let runtimeService else {
             return nil
         }
 

--- a/novawallet/Common/Services/Multistaking/MultistakingSyncService.swift
+++ b/novawallet/Common/Services/Multistaking/MultistakingSyncService.swift
@@ -193,8 +193,13 @@ final class MultistakingSyncService {
                 for: chainAssetOption.chainAsset,
                 stakingType: chainAssetOption.type
             )
-        case .parachain, .turing, .parachainAvn:
+        case .parachain, .turing:
             createParachainStaking(
+                for: chainAssetOption.chainAsset,
+                stakingType: chainAssetOption.type
+            )
+        case .parachainAvn:
+            createParachainAvnStaking(
                 for: chainAssetOption.chainAsset,
                 stakingType: chainAssetOption.type
             )
@@ -332,6 +337,58 @@ final class MultistakingSyncService {
         )
 
         return ParachainMultistakingUpdateService(
+            walletId: wallet.metaId,
+            accountId: account.accountId,
+            chainAsset: chainAsset,
+            stakingType: stakingType,
+            dashboardRepository: multistakingRepositoryFactory.createParachainRepository(),
+            cacheRepository: substrateRepositoryFactory.createChainStorageItemRepository(),
+            connection: connection,
+            runtimeService: runtimeService,
+            operationFactory: operationFactory,
+            operationQueue: operationQueue,
+            workingQueue: workingQueue,
+            logger: logger
+        )
+    }
+
+    private func createParachainAvnStaking(
+        for chainAsset: ChainAsset,
+        stakingType: StakingType
+    ) -> OnchainSyncServiceProtocol? {
+        let account = wallet.fetch(for: chainAsset.chain.accountRequest())
+        let connection = chainRegistry.getConnection(for: chainAsset.chain.chainId)
+        let runtimeService = chainRegistry.getRuntimeProvider(for: chainAsset.chain.chainId)
+
+        guard let account, let connection, let runtimeService else {
+            return nil
+        }
+
+        let requestFactory = StorageRequestFactory(
+            remoteFactory: StorageKeyFactory(),
+            operationManager: OperationManager(operationQueue: operationQueue)
+        )
+
+        let identityFactory = IdentityOperationFactory(
+            requestFactory: requestFactory,
+            emptyIdentitiesWhenNoStorage: true
+        )
+
+        let identityProxyFactory = IdentityProxyFactory(
+            originChain: chainAsset.chain,
+            chainRegistry: chainRegistry,
+            identityOperationFactory: identityFactory
+        )
+
+        let operationFactory = ParaStkCollatorsOperationFactory(
+            requestFactory: requestFactory,
+            connection: connection,
+            runtimeProvider: runtimeService,
+            identityFactory: identityProxyFactory,
+            chainFormat: chainAsset.chain.chainFormat
+        )
+
+        return ParachainAvnMultistakingUpdateService(
             walletId: wallet.metaId,
             accountId: account.accountId,
             chainAsset: chainAsset,

--- a/novawallet/Common/Services/Multistaking/ParachainAvnMultistakingUpdateService.swift
+++ b/novawallet/Common/Services/Multistaking/ParachainAvnMultistakingUpdateService.swift
@@ -1,0 +1,212 @@
+import Foundation
+import SubstrateSdk
+import Operation_iOS
+
+/// EWX-specific dashboard sync service.
+///
+/// Mirrors `ParachainMultistakingUpdateService` (Moonbeam) but subscribes
+/// to `NominatorState` instead of `DelegatorState`. The Moonbeam class
+/// hardcodes `delegatorStatePath` at two sites — that storage item is
+/// absent from EWX runtime metadata, so the dashboard tile for EWT
+/// always read as "not staking" until this fork landed.
+final class ParachainAvnMultistakingUpdateService: ObservableSyncService, AnyCancellableCleaning {
+    let accountId: AccountId
+    let walletId: MetaAccountModel.Id
+    let chainAsset: ChainAsset
+    let stakingType: StakingType
+    let connection: JSONRPCEngine
+    let runtimeService: RuntimeCodingServiceProtocol
+    let dashboardRepository: AnyDataProviderRepository<Multistaking.DashboardItemParachainPart>
+    let cacheRepository: AnyDataProviderRepository<ChainStorageItem>
+    let operationFactory: ParaStkCollatorsOperationFactoryProtocol
+    let operationQueue: OperationQueue
+    let workingQueue: DispatchQueue
+
+    private var subscription: CallbackStorageSubscription<ParachainStaking.Delegator>?
+    private var collatorsCall: CancellableCall?
+
+    init(
+        walletId: MetaAccountModel.Id,
+        accountId: AccountId,
+        chainAsset: ChainAsset,
+        stakingType: StakingType,
+        dashboardRepository: AnyDataProviderRepository<Multistaking.DashboardItemParachainPart>,
+        cacheRepository: AnyDataProviderRepository<ChainStorageItem>,
+        connection: JSONRPCEngine,
+        runtimeService: RuntimeCodingServiceProtocol,
+        operationFactory: ParaStkCollatorsOperationFactoryProtocol,
+        operationQueue: OperationQueue,
+        workingQueue: DispatchQueue,
+        logger: LoggerProtocol
+    ) {
+        self.walletId = walletId
+        self.accountId = accountId
+        self.chainAsset = chainAsset
+        self.stakingType = stakingType
+        self.dashboardRepository = dashboardRepository
+        self.cacheRepository = cacheRepository
+        self.connection = connection
+        self.runtimeService = runtimeService
+        self.operationFactory = operationFactory
+        self.operationQueue = operationQueue
+        self.workingQueue = workingQueue
+
+        super.init(logger: logger)
+    }
+
+    override func performSyncUp() {
+        clearSubscription()
+        subscribeNominatorState(for: accountId)
+    }
+
+    override func stopSyncUp() {
+        clearSubscription()
+    }
+
+    private func clearSubscription() {
+        subscription = nil
+        clearCollatorsFetchRequest()
+    }
+
+    private func subscribeNominatorState(for accountId: AccountId) {
+        do {
+            let localKey = try LocalStorageKeyFactory().createFromStoragePath(
+                ParachainAvn.nominatorStatePath,
+                accountId: accountId,
+                chainId: chainAsset.chain.chainId
+            )
+
+            let request = MapSubscriptionRequest(
+                storagePath: ParachainAvn.nominatorStatePath,
+                localKey: localKey
+            ) { BytesCodable(wrappedValue: accountId) }
+
+            subscription = CallbackStorageSubscription<ParachainStaking.Delegator>(
+                request: request,
+                connection: connection,
+                runtimeService: runtimeService,
+                repository: cacheRepository,
+                operationQueue: operationQueue,
+                callbackQueue: workingQueue
+            ) { [weak self] result in
+                self?.mutex.lock()
+
+                self?.handleNominatorState(result: result)
+
+                self?.mutex.unlock()
+            }
+        } catch {
+            logger.error("Subscription error: \(error)")
+
+            completeImmediate(error)
+        }
+    }
+
+    private func handleNominatorState(result: Result<ParachainStaking.Delegator?, Error>) {
+        switch result {
+        case let .success(delegator):
+            clearCollatorsFetchRequest()
+
+            markSyncingImmediate()
+
+            if let delegator = delegator {
+                fetchCollatorsAndSaveState(for: delegator)
+            } else {
+                saveState(for: delegator, collators: [:])
+            }
+        case let .failure(error):
+            completeImmediate(error)
+        }
+    }
+
+    private func clearCollatorsFetchRequest() {
+        clear(cancellable: &collatorsCall)
+    }
+
+    private func fetchCollatorsAndSaveState(for delegator: ParachainStaking.Delegator) {
+        let collatorIds = delegator.collators()
+
+        let wrapper = operationFactory.createMetadataWrapper(
+            for: { collatorIds }
+        )
+
+        wrapper.targetOperation.completionBlock = { [weak self] in
+            guard let workingQueue = self?.workingQueue, let mutex = self?.mutex else {
+                return
+            }
+
+            dispatchInConcurrent(queue: workingQueue, locking: mutex) {
+                guard self?.collatorsCall === wrapper else {
+                    return
+                }
+
+                self?.collatorsCall = nil
+
+                do {
+                    let collatorList = try wrapper.targetOperation.extractNoCancellableResultData()
+                    let collatorDict = zip(collatorIds, collatorList).reduce(
+                        into: [AccountId: ParachainStaking.CandidateMetadata]()
+                    ) {
+                        $0[$1.0] = $1.1
+                    }
+
+                    self?.saveState(for: delegator, collators: collatorDict)
+                } catch {
+                    self?.completeImmediate(error)
+                }
+            }
+        }
+
+        collatorsCall = wrapper
+
+        operationQueue.addOperations(wrapper.allOperations, waitUntilFinished: false)
+    }
+
+    private func saveState(
+        for delegator: ParachainStaking.Delegator?,
+        collators: [AccountId: ParachainStaking.CandidateMetadata]
+    ) {
+        let shouldHaveActiveCollator = delegator?.delegations.contains { bond in
+            guard let metadata = collators[bond.owner] else {
+                return false
+            }
+
+            return metadata.isStakeShouldBeActive(for: bond.amount)
+        } ?? false
+
+        let state = Multistaking.ParachainState(
+            stake: delegator?.staked,
+            shouldHaveActiveCollator: shouldHaveActiveCollator
+        )
+
+        let stakingOption = Multistaking.OptionWithWallet(
+            walletId: walletId,
+            option: .init(chainAssetId: chainAsset.chainAssetId, type: stakingType)
+        )
+
+        let dashboardItem = Multistaking.DashboardItemParachainPart(
+            stakingOption: stakingOption,
+            state: state
+        )
+
+        let operation = dashboardRepository.saveOperation({
+            [dashboardItem]
+        }, {
+            []
+        })
+
+        operation.completionBlock = { [weak self] in
+            self?.workingQueue.async {
+                do {
+                    _ = try operation.extractNoCancellableResultData()
+
+                    self?.complete(nil)
+                } catch {
+                    self?.complete(error)
+                }
+            }
+        }
+
+        operationQueue.addOperation(operation)
+    }
+}

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/ParachainAvnAccountSubscribeHandlingFactory.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/ParachainAvnAccountSubscribeHandlingFactory.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Operation_iOS
+import SubstrateSdk
+
+final class ParachainAvnAccountSubscribeHandlingFactory: RemoteSubscriptionHandlingFactoryProtocol {
+    let chainId: ChainModel.Id
+    let accountId: AccountId
+    let chainRegistry: ChainRegistryProtocol
+
+    init(
+        chainId: ChainModel.Id,
+        accountId: AccountId,
+        chainRegistry: ChainRegistryProtocol
+    ) {
+        self.chainId = chainId
+        self.accountId = accountId
+        self.chainRegistry = chainRegistry
+    }
+
+    func createHandler(
+        remoteStorageKey: Data,
+        localStorageKey: String,
+        storage: AnyDataProviderRepository<ChainStorageItem>,
+        operationManager: OperationManagerProtocol,
+        logger: LoggerProtocol
+    ) -> StorageChildSubscribing {
+        let storageRequestFactory = StorageRequestFactory(
+            remoteFactory: StorageKeyFactory(),
+            operationManager: operationManager
+        )
+        let queryWrapperFactory = ParachainAvnScheduledRequestsQueryWrapperFactory(
+            storageRequestFactory: storageRequestFactory,
+            operationManager: operationManager
+        )
+
+        return ParachainAvnScheduledRequestsUpdater(
+            remoteStorageKey: remoteStorageKey,
+            localStorageKey: localStorageKey,
+            chainRegistry: chainRegistry,
+            delegatorStorage: storage,
+            accountId: accountId,
+            chainId: chainId,
+            operationManager: operationManager,
+            queryWrapperFactory: queryWrapperFactory,
+            logger: logger
+        )
+    }
+}

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/ParachainAvnAccountSubscriptionService.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/ParachainAvnAccountSubscriptionService.swift
@@ -1,0 +1,48 @@
+import Foundation
+import SubstrateSdk
+import Operation_iOS
+
+extension ParachainAvn {
+    final class AccountSubscriptionService: RemoteSubscriptionService {
+        private static let storagePaths: [StorageCodingPath] = [
+            ParachainAvn.nominatorStatePath
+        ]
+    }
+}
+
+extension ParachainAvn.AccountSubscriptionService: StakingRemoteAccountSubscriptionServiceProtocol {
+    func attachToAccountData(
+        for chainAccountId: ChainAccountId,
+        queue: DispatchQueue?,
+        closure: RemoteSubscriptionClosure?
+    ) -> UUID? {
+        let subscriptionHandlingFactory = ParachainAvnAccountSubscribeHandlingFactory(
+            chainId: chainAccountId.chainId,
+            accountId: chainAccountId.accountId,
+            chainRegistry: chainRegistry
+        )
+
+        return attachToAccountDataWithStoragePaths(
+            Self.storagePaths,
+            chainAccountId: chainAccountId,
+            queue: queue,
+            closure: closure,
+            subscriptionHandlingFactory: subscriptionHandlingFactory
+        )
+    }
+
+    func detachFromAccountData(
+        for subscriptionId: UUID,
+        chainAccountId: ChainAccountId,
+        queue: DispatchQueue?,
+        closure: RemoteSubscriptionClosure?
+    ) {
+        detachFromAccountDataStoragePaths(
+            Self.storagePaths,
+            subscriptionId: subscriptionId,
+            chainAccountId: chainAccountId,
+            queue: queue,
+            closure: closure
+        )
+    }
+}

--- a/novawallet/Common/Services/RemoteSubscription/Substrate/ParachainAvnScheduledRequestsUpdater.swift
+++ b/novawallet/Common/Services/RemoteSubscription/Substrate/ParachainAvnScheduledRequestsUpdater.swift
@@ -1,0 +1,218 @@
+import Foundation
+import Operation_iOS
+import SubstrateSdk
+
+/// EWX-specific scheduled-requests updater.
+///
+/// Mirrors `ParaStkScheduledRequestsUpdater` (Moonbeam) but operates on EWX
+/// storage paths: decodes NominatorState (via the dual-decode `Delegator`
+/// fix) and reads/writes the local key derived from
+/// `nominationScheduledRequestsPath`. The Moonbeam updater hardcodes
+/// `delegatorStatePath` and `delegationRequestsPath` which produce
+/// different remote/local keys on EWX, so a separate class is required.
+final class ParachainAvnScheduledRequestsUpdater: BaseStorageChildSubscription {
+    let chainRegistry: ChainRegistryProtocol
+    let accountId: AccountId
+    let chainId: ChainModel.Id
+    let queryWrapperFactory: ParachainAvnScheduledRequestsQueryWrapperFactoryProtocol
+
+    private lazy var localKeyFactory = LocalStorageKeyFactory()
+
+    init(
+        remoteStorageKey: Data,
+        localStorageKey: String,
+        chainRegistry: ChainRegistryProtocol,
+        delegatorStorage: AnyDataProviderRepository<ChainStorageItem>,
+        accountId: AccountId,
+        chainId: ChainModel.Id,
+        operationManager: OperationManagerProtocol,
+        queryWrapperFactory: ParachainAvnScheduledRequestsQueryWrapperFactoryProtocol,
+        logger: LoggerProtocol
+    ) {
+        self.chainRegistry = chainRegistry
+        self.accountId = accountId
+        self.chainId = chainId
+        self.queryWrapperFactory = queryWrapperFactory
+
+        super.init(
+            remoteStorageKey: remoteStorageKey,
+            localStorageKey: localStorageKey,
+            storage: delegatorStorage,
+            operationManager: operationManager,
+            logger: logger
+        )
+    }
+
+    private func createUpdateOperation(
+        for requestsClosure: @escaping () throws -> [ParachainStaking.DelegatorScheduledRequest],
+        localKey: String
+    ) -> BaseOperation<Void> {
+        storage.saveOperation({
+            let requests = try requestsClosure()
+
+            if !requests.isEmpty {
+                let data = try JSONEncoder().encode(requests)
+                return [ChainStorageItem(identifier: localKey, data: data)]
+            } else {
+                return []
+            }
+        }, {
+            let requests = try requestsClosure()
+            if requests.isEmpty {
+                return [localKey]
+            } else {
+                return []
+            }
+        })
+    }
+
+    private func createMappingOperation(
+        for collatorsClosure: @escaping () throws -> [AccountId],
+        requestResponsesClosure: @escaping () throws -> [StorageResponse<[ParachainStaking.ScheduledRequest]>],
+        delegatorId: AccountId
+    ) -> BaseOperation<[ParachainStaking.DelegatorScheduledRequest]> {
+        ClosureOperation<[ParachainStaking.DelegatorScheduledRequest]> {
+            let collators = try collatorsClosure()
+            let responses = try requestResponsesClosure()
+
+            return zip(collators, responses).compactMap { collator, response in
+                // Reject any request whose `delegator`/`nominator` field
+                // doesn't match the current user. On EWX the field is named
+                // `nominator`; the dual-decode in `ScheduledRequest` populates
+                // `delegator` from either name. If the field is genuinely
+                // absent (older pallet shape), skip — never auto-attribute,
+                // because per-collator entries can hold many users' requests.
+                let delegationRequest = response.value?.first { request in
+                    guard let requestDelegator = request.delegator else { return false }
+                    return requestDelegator.wrappedValue == delegatorId
+                }
+
+                guard let delegationRequest else { return nil }
+
+                return ParachainStaking.DelegatorScheduledRequest(
+                    collatorId: collator,
+                    whenExecutable: delegationRequest.whenExecutable,
+                    action: delegationRequest.action
+                )
+            }
+        }
+    }
+
+    private func createDecodingOperation(
+        for data: Data,
+        dependingOn codingFactoryOperation: BaseOperation<RuntimeCoderFactoryProtocol>
+    ) -> BaseOperation<ParachainStaking.Delegator> {
+        let decodingOperation = StorageDecodingOperation<ParachainStaking.Delegator>(
+            path: ParachainAvn.nominatorStatePath,
+            data: data
+        )
+
+        decodingOperation.configurationBlock = {
+            do {
+                decodingOperation.codingFactory = try codingFactoryOperation.extractNoCancellableResultData()
+            } catch {
+                decodingOperation.result = .failure(error)
+            }
+        }
+
+        return decodingOperation
+    }
+
+    private func createRemoteFetchWrapper(
+        dependingOn codingFactoryOperation: BaseOperation<RuntimeCoderFactoryProtocol>,
+        decodingOperation: BaseOperation<ParachainStaking.Delegator>,
+        connection: JSONRPCEngine,
+        blockHash: Data?
+    ) -> CompoundOperationWrapper<[StorageResponse<[ParachainStaking.ScheduledRequest]>]> {
+        let delegatorId = accountId
+
+        return queryWrapperFactory.createQueryWrapper(
+            using: connection,
+            with: {
+                try decodingOperation
+                    .extractNoCancellableResultData()
+                    .collators()
+                    .map { BytesCodable(wrappedValue: $0) }
+            },
+            delegator: { delegatorId },
+            codingFactory: { try codingFactoryOperation.extractNoCancellableResultData() },
+            at: blockHash
+        )
+    }
+
+    private func createLocalKey() -> String? {
+        try? localKeyFactory.createRestorableRecurrentKey(
+            from: ParachainAvn.nominationScheduledRequestsPath,
+            chainId: chainId,
+            items: [accountId]
+        )
+    }
+
+    override func handle(
+        result _: Result<DataProviderChange<ChainStorageItem>?, Error>,
+        remoteItem: ChainStorageItem?,
+        blockHash: Data?
+    ) {
+        process(data: remoteItem?.data, blockHash: blockHash)
+    }
+}
+
+extension ParachainAvnScheduledRequestsUpdater {
+    func process(data: Data?, blockHash: Data?) {
+        guard
+            let connection = chainRegistry.getConnection(for: chainId),
+            let runtimeProvider = chainRegistry.getRuntimeProvider(for: chainId),
+            let localKey = createLocalKey() else {
+            logger.error("Unexpected error during preparation")
+            return
+        }
+
+        let wrapper: CompoundOperationWrapper<Void>
+
+        if let data = data {
+            let codingFactoryOperation = runtimeProvider.fetchCoderFactoryOperation()
+
+            let decodingOperation = createDecodingOperation(for: data, dependingOn: codingFactoryOperation)
+
+            decodingOperation.addDependency(codingFactoryOperation)
+
+            let remoteFetchWrapper = createRemoteFetchWrapper(
+                dependingOn: codingFactoryOperation,
+                decodingOperation: decodingOperation,
+                connection: connection,
+                blockHash: blockHash
+            )
+
+            remoteFetchWrapper.addDependency(operations: [decodingOperation])
+
+            let mapOperation = createMappingOperation(
+                for: { try decodingOperation.extractNoCancellableResultData().collators() },
+                requestResponsesClosure: { try remoteFetchWrapper.targetOperation.extractNoCancellableResultData() },
+                delegatorId: accountId
+            )
+
+            mapOperation.addDependency(remoteFetchWrapper.targetOperation)
+
+            let replaceOperation = createUpdateOperation(
+                for: { try mapOperation.extractNoCancellableResultData() },
+                localKey: localKey
+            )
+
+            replaceOperation.addDependency(mapOperation)
+
+            let dependencies = [codingFactoryOperation, decodingOperation] + remoteFetchWrapper.allOperations +
+                [mapOperation]
+
+            wrapper = CompoundOperationWrapper(targetOperation: replaceOperation, dependencies: dependencies)
+        } else {
+            let replaceOperation = createUpdateOperation(
+                for: { [] },
+                localKey: localKey
+            )
+
+            wrapper = CompoundOperationWrapper(targetOperation: replaceOperation)
+        }
+
+        operationManager.enqueue(operations: wrapper.allOperations, in: .transient)
+    }
+}

--- a/novawallet/Common/Substrate/Types/ParachainStaking/ParachainStakingCandidateMetadata.swift
+++ b/novawallet/Common/Substrate/Types/ParachainStaking/ParachainStakingCandidateMetadata.swift
@@ -62,12 +62,12 @@ extension ParachainStaking {
         }
     }
 
-    struct CandidateMetadata: Decodable, Equatable {
-        @StringCodable var delegationCount: UInt32
-        @StringCodable var lowestTopDelegationAmount: BigUInt
-        @StringCodable var lowestBottomDelegationAmount: BigUInt
-        @StringCodable var totalCounted: BigUInt
-        @StringCodable var bond: BigUInt
+    struct CandidateMetadata: Equatable {
+        let delegationCount: UInt32
+        let lowestTopDelegationAmount: BigUInt
+        let lowestBottomDelegationAmount: BigUInt
+        let totalCounted: BigUInt
+        let bond: BigUInt
 
         let topCapacity: CapacityStatus
         let bottomCapacity: CapacityStatus
@@ -93,6 +93,65 @@ extension ParachainStaking {
 
         func isStakeShouldBeActive(for stake: BigUInt) -> Bool {
             !topCapacity.isFull || stake > lowestTopDelegationAmount
+        }
+    }
+}
+
+// MARK: - Decodable (handles both Moonbeam and EWX field names)
+
+extension ParachainStaking.CandidateMetadata: Decodable {
+    /// Moonbeam uses `delegation_count`, `lowest_top_delegation_amount`, etc.
+    /// EWX (AvN fork) uses `nomination_count`, `lowest_top_nomination_amount`, etc.
+    /// The struct layout is identical — only field names differ.
+    private enum CodingKeys: String, CodingKey {
+        case bond
+        case totalCounted
+        case topCapacity
+        case bottomCapacity
+        case status
+
+        // Moonbeam field names
+        case delegationCount
+        case lowestTopDelegationAmount
+        case lowestBottomDelegationAmount
+
+        // EWX (AvN) field names
+        case nominationCount
+        case lowestTopNominationAmount
+        case lowestBottomNominationAmount
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        bond = try container.decode(StringScaleMapper<BigUInt>.self, forKey: .bond).value
+        totalCounted = try container.decode(StringScaleMapper<BigUInt>.self, forKey: .totalCounted).value
+        topCapacity = try container.decode(ParachainStaking.CapacityStatus.self, forKey: .topCapacity)
+        bottomCapacity = try container.decode(ParachainStaking.CapacityStatus.self, forKey: .bottomCapacity)
+        status = try container.decode(ParachainStaking.CollatorStatus.self, forKey: .status)
+
+        if let count = try? container.decode(StringScaleMapper<UInt32>.self, forKey: .delegationCount) {
+            delegationCount = count.value
+        } else {
+            delegationCount = try container.decode(
+                StringScaleMapper<UInt32>.self, forKey: .nominationCount
+            ).value
+        }
+
+        if let amount = try? container.decode(StringScaleMapper<BigUInt>.self, forKey: .lowestTopDelegationAmount) {
+            lowestTopDelegationAmount = amount.value
+        } else {
+            lowestTopDelegationAmount = try container.decode(
+                StringScaleMapper<BigUInt>.self, forKey: .lowestTopNominationAmount
+            ).value
+        }
+
+        if let amount = try? container.decode(StringScaleMapper<BigUInt>.self, forKey: .lowestBottomDelegationAmount) {
+            lowestBottomDelegationAmount = amount.value
+        } else {
+            lowestBottomDelegationAmount = try container.decode(
+                StringScaleMapper<BigUInt>.self, forKey: .lowestBottomNominationAmount
+            ).value
         }
     }
 }

--- a/novawallet/Common/Substrate/Types/ParachainStaking/ParachainStakingCollatorSnapshot.swift
+++ b/novawallet/Common/Substrate/Types/ParachainStaking/ParachainStakingCollatorSnapshot.swift
@@ -27,11 +27,50 @@ extension ParachainStaking {
         }
     }
 
-    struct CollatorSnapshot: Equatable, Codable {
-        @StringCodable var bond: BigUInt
-
+    struct CollatorSnapshot: Equatable {
+        let bond: BigUInt
         let delegations: [Bond]
+        let total: BigUInt
+    }
+}
 
-        @StringCodable var total: BigUInt
+// MARK: - Codable (handles both Moonbeam and EWX field names)
+
+extension ParachainStaking.CollatorSnapshot: Codable {
+    /// Moonbeam encodes the bonds list under `delegations`. EWX (AvN fork)
+    /// encodes the same list under `nominations`. The SCALE layout is
+    /// identical (`{bond: u128, vec<Bond>, total: u128}`) — only the
+    /// outer JSON key differs after the runtime-metadata-driven decode.
+    /// Same pattern as `ParachainStaking.Delegator` and `CandidateMetadata`.
+    private enum CodingKeys: String, CodingKey {
+        case bond
+        case total
+
+        // Moonbeam field name
+        case delegations
+
+        // EWX (AvN) field name
+        case nominations
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        bond = try container.decode(StringScaleMapper<BigUInt>.self, forKey: .bond).value
+        total = try container.decode(StringScaleMapper<BigUInt>.self, forKey: .total).value
+
+        if let bonds = try? container.decode([ParachainStaking.Bond].self, forKey: .delegations) {
+            delegations = bonds
+        } else {
+            delegations = try container.decode([ParachainStaking.Bond].self, forKey: .nominations)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(StringScaleMapper(value: bond), forKey: .bond)
+        try container.encode(StringScaleMapper(value: total), forKey: .total)
+        try container.encode(delegations, forKey: .delegations)
     }
 }

--- a/novawallet/Common/Substrate/Types/ParachainStaking/ParachainStakingDelegator.swift
+++ b/novawallet/Common/Substrate/Types/ParachainStaking/ParachainStakingDelegator.swift
@@ -3,10 +3,10 @@ import SubstrateSdk
 import BigInt
 
 extension ParachainStaking {
-    struct Delegator: Codable, Equatable {
+    struct Delegator: Equatable {
         let delegations: [ParachainStaking.Bond]
-        @StringCodable var total: BigUInt
-        @StringCodable var lessTotal: BigUInt
+        let total: BigUInt
+        let lessTotal: BigUInt
 
         var staked: BigUInt {
             total >= lessTotal ? total - lessTotal : 0
@@ -23,10 +23,13 @@ extension ParachainStaking {
         }
     }
 
-    struct ScheduledRequest: Decodable, Encodable, Equatable {
-        /// legacy field to comply with older parachain-staking pallet version
+    struct ScheduledRequest: Equatable {
+        /// Account that scheduled the request. On older Moonbeam pallets this
+        /// field was named `delegator`; on EWX (AvN fork) it's `nominator`.
+        /// Some pallet versions omit it entirely (the request is implicitly
+        /// keyed by the iterating delegator). Optional in all cases.
         var delegator: BytesCodable?
-        @StringCodable var whenExecutable: RoundIndex
+        let whenExecutable: RoundIndex
         let action: DelegationAction
     }
 
@@ -67,5 +70,83 @@ extension ParachainStaking {
                 try container.encode(StringScaleMapper(value: amount))
             }
         }
+    }
+}
+
+// MARK: - ScheduledRequest Codable (dual-decode delegator ↔ nominator)
+
+extension ParachainStaking.ScheduledRequest: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case whenExecutable
+        case action
+
+        // Moonbeam (legacy)
+        case delegator
+
+        // EWX (AvN fork)
+        case nominator
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        whenExecutable = try container
+            .decode(StringScaleMapper<ParachainStaking.RoundIndex>.self, forKey: .whenExecutable).value
+        action = try container.decode(ParachainStaking.DelegationAction.self, forKey: .action)
+
+        if let value = try container.decodeIfPresent(BytesCodable.self, forKey: .delegator) {
+            delegator = value
+        } else if let value = try container.decodeIfPresent(BytesCodable.self, forKey: .nominator) {
+            delegator = value
+        } else {
+            delegator = nil
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encodeIfPresent(delegator, forKey: .delegator)
+        try container.encode(StringScaleMapper(value: whenExecutable), forKey: .whenExecutable)
+        try container.encode(action, forKey: .action)
+    }
+}
+
+// MARK: - Codable (handles both Moonbeam and EWX field names)
+
+extension ParachainStaking.Delegator: Codable {
+    /// Moonbeam encodes the bonds list under the field name `delegations`.
+    /// EWX (AvN fork) encodes the same list under `nominations`.
+    /// The shape of each bond is identical — only the outer field name differs.
+    private enum CodingKeys: String, CodingKey {
+        case total
+        case lessTotal
+
+        // Moonbeam field name
+        case delegations
+
+        // EWX (AvN) field name
+        case nominations
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let bonds = try? container.decode([ParachainStaking.Bond].self, forKey: .delegations) {
+            delegations = bonds
+        } else {
+            delegations = try container.decode([ParachainStaking.Bond].self, forKey: .nominations)
+        }
+
+        total = try container.decode(StringScaleMapper<BigUInt>.self, forKey: .total).value
+        lessTotal = try container.decode(StringScaleMapper<BigUInt>.self, forKey: .lessTotal).value
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(delegations, forKey: .delegations)
+        try container.encode(StringScaleMapper(value: total), forKey: .total)
+        try container.encode(StringScaleMapper(value: lessTotal), forKey: .lessTotal)
     }
 }

--- a/novawallet/Info.plist
+++ b/novawallet/Info.plist
@@ -2,6 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- TEMP-QA-HACK (Plan 05 EWT iOS): allow plain HTTP to 127.0.0.1 so
+	     a local python http.server on :8787 can serve the EWT-staking-enabled
+	     chains_dev.json fixture. Remove before any PR to novasamatech. -->
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>127.0.0.1</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/novawallet/Modules/Staking/CollatorStaking/SelectCollators/CollatorStakingSelectViewFactory+ParachainStaking.swift
+++ b/novawallet/Modules/Staking/CollatorStaking/SelectCollators/CollatorStakingSelectViewFactory+ParachainStaking.swift
@@ -58,7 +58,13 @@ extension CollatorStakingSelectViewFactory {
             operationManager: operationManager
         )
 
-        let identityOperationFactory = IdentityOperationFactory(requestFactory: requestFactory)
+        // EWX has no `pallet-identity` in its runtime; without this flag the
+        // operation factory throws when the storage isn't found. The flag is
+        // a no-op on chains where the pallet exists (Moonbeam, Turing).
+        let identityOperationFactory = IdentityOperationFactory(
+            requestFactory: requestFactory,
+            emptyIdentitiesWhenNoStorage: true
+        )
         let identityProxyFactory = IdentityProxyFactory(
             originChain: chain,
             chainRegistry: chainRegistry,

--- a/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModelFactory.swift
+++ b/novawallet/Modules/Staking/Dashboard/ViewModel/StakingDashboardViewModelFactory.swift
@@ -145,7 +145,7 @@ final class StakingDashboardViewModelFactory {
                 title: R.string(preferredLanguages: locale.rLanguages).localizable.stakingPool().uppercased(),
                 icon: R.image.iconStakingPool()
             )
-        case .parachain, .turing, .mythos, .unsupported:
+        case .parachain, .turing, .mythos, .parachainAvn, .unsupported:
             return nil
         }
     }

--- a/novawallet/Modules/Staking/Model/RelayStakingConsensusType.swift
+++ b/novawallet/Modules/Staking/Model/RelayStakingConsensusType.swift
@@ -13,7 +13,7 @@ enum RelayStkConsensusType {
             self = .auraGeneral
         case .azero:
             self = .auraAzero
-        case .parachain, .turing, .mythos, .unsupported, .nominationPools:
+        case .parachain, .turing, .mythos, .parachainAvn, .unsupported, .nominationPools:
             return nil
         }
     }

--- a/novawallet/Modules/Staking/Model/StakingSharedState/StakingSharedStateFactory.swift
+++ b/novawallet/Modules/Staking/Model/StakingSharedState/StakingSharedStateFactory.swift
@@ -571,9 +571,11 @@ extension StakingSharedStateFactory: StakingSharedStateFactoryProtocol {
         let repositoryFactory = SubstrateRepositoryFactory()
         let repository = repositoryFactory.createChainStorageItemRepository()
 
-        // Use EWX-specific account subscription that queries NominatorState
-        // instead of Moonbeam's DelegatorState
-        let stakingAccountService = ParachainStaking.AccountSubscriptionService(
+        // EWX-specific account subscription that queries NominatorState +
+        // NominationScheduledRequests (Moonbeam's class subscribes to
+        // DelegatorState / DelegationScheduledRequests, which don't exist
+        // in EWX runtime metadata).
+        let stakingAccountService = ParachainAvn.AccountSubscriptionService(
             chainRegistry: chainRegistry,
             repository: repository,
             syncOperationManager: OperationManager(operationQueue: syncOperationQueue),

--- a/novawallet/Modules/Staking/Model/StakingSharedState/StakingSharedStateFactory.swift
+++ b/novawallet/Modules/Staking/Model/StakingSharedState/StakingSharedStateFactory.swift
@@ -25,6 +25,10 @@ protocol StakingSharedStateFactoryProtocol {
     func createMythosStaking(
         for stakingOption: Multistaking.ChainAssetOption
     ) throws -> MythosStakingSharedStateProtocol
+
+    func createParachainAvn(
+        for stakingOption: Multistaking.ChainAssetOption
+    ) throws -> ParachainStakingSharedStateProtocol
 }
 
 enum StakingSharedStateFactoryError: Error {
@@ -556,6 +560,101 @@ extension StakingSharedStateFactory: StakingSharedStateFactoryProtocol {
             ),
             preferredCollatorsProvider: preferredValidatorsProvider,
             operationQueue: syncOperationQueue,
+            logger: logger
+        )
+    }
+
+    // swiftlint:disable:next function_body_length
+    func createParachainAvn(
+        for stakingOption: Multistaking.ChainAssetOption
+    ) throws -> ParachainStakingSharedStateProtocol {
+        let repositoryFactory = SubstrateRepositoryFactory()
+        let repository = repositoryFactory.createChainStorageItemRepository()
+
+        // Use EWX-specific account subscription that queries NominatorState
+        // instead of Moonbeam's DelegatorState
+        let stakingAccountService = ParachainStaking.AccountSubscriptionService(
+            chainRegistry: chainRegistry,
+            repository: repository,
+            syncOperationManager: OperationManager(operationQueue: syncOperationQueue),
+            repositoryOperationManager: OperationManager(operationQueue: repositoryOperationQueue),
+            logger: logger
+        )
+
+        // Use EWX-specific remote subscription (Era, DefaultCollatorCommission)
+        let stakingAssetService = ParachainAvn.StakingRemoteSubscriptionService(
+            chainRegistry: chainRegistry,
+            repository: repository,
+            syncOperationManager: OperationManager(operationQueue: syncOperationQueue),
+            repositoryOperationManager: OperationManager(operationQueue: repositoryOperationQueue),
+            logger: logger
+        )
+
+        // Use EWX-specific local subscription factory (Era, DefaultCollatorCommission paths)
+        let localSubscriptionFactory = ParachainAvnLocalSubscriptionFactory(
+            chainRegistry: chainRegistry,
+            storageFacade: storageFacade,
+            operationManager: OperationManager(operationQueue: repositoryOperationQueue),
+            logger: logger
+        )
+
+        let rewardsSubscriptionFactory = StakingRewardsLocalSubscriptionFactory(
+            chainRegistry: chainRegistry,
+            storageFacade: storageFacade,
+            operationManager: OperationManager(operationQueue: repositoryOperationQueue),
+            logger: logger
+        )
+
+        // Use the EWX local subscription factory for the service factory too.
+        // EWX DefaultCollatorCommission is a struct (CommissionSetting), not a
+        // bare Perbill, so the normal subscription can't decode it.  Pre-set
+        // the known mainnet value (10% = 100_000_000 Perbill) as a fallback.
+        let serviceFactory = ParachainStakingServiceFactory(
+            stakingProviderFactory: localSubscriptionFactory,
+            chainRegisty: chainRegistry,
+            storageFacade: storageFacade,
+            eventCenter: eventCenter,
+            operationQueue: syncOperationQueue,
+            logger: logger,
+            defaultCollatorCommission: 100_000_000
+        )
+
+        let chainId = stakingOption.chainAsset.chain.chainId
+
+        let collatorService = try serviceFactory.createSelectedCollatorsService(for: chainId)
+
+        let timelineChain = try chainRegistry.getTimelineChainOrError(for: chainId)
+        let blockTimeService = try serviceFactory.createBlockTimeService(for: timelineChain.chainId)
+        let rewardService = try serviceFactory.createRewardCalculatorService(
+            for: chainId,
+            stakingType: stakingOption.type,
+            assetPrecision: stakingOption.chainAsset.asset.decimalPrecision,
+            collatorService: collatorService
+        )
+
+        let generalLocalSubscriptionFactory = GeneralStorageSubscriptionFactory(
+            chainRegistry: chainRegistry,
+            storageFacade: storageFacade,
+            operationManager: OperationManager(operationQueue: repositoryOperationQueue),
+            logger: logger
+        )
+
+        let preferredValidatorsProvider = PreferredValidatorsProvider(
+            remoteUrl: applicationConfig.preferredValidatorsURL
+        )
+
+        return ParachainStakingSharedState(
+            stakingOption: stakingOption,
+            chainRegistry: chainRegistry,
+            globalRemoteSubscriptionService: stakingAssetService,
+            accountRemoteSubscriptionService: stakingAccountService,
+            collatorService: collatorService,
+            rewardCalculationService: rewardService,
+            blockTimeService: blockTimeService,
+            stakingLocalSubscriptionFactory: localSubscriptionFactory,
+            stakingRewardsLocalSubscriptionFactory: rewardsSubscriptionFactory,
+            generalLocalSubscriptionFactory: generalLocalSubscriptionFactory,
+            preferredCollatorsProvider: preferredValidatorsProvider,
             logger: logger
         )
     }

--- a/novawallet/Modules/Staking/Model/StakingType.swift
+++ b/novawallet/Modules/Staking/Model/StakingType.swift
@@ -8,6 +8,7 @@ enum StakingType: String, Codable, Equatable, Hashable {
     case turing
     case nominationPools = "nomination-pools"
     case mythos
+    case parachainAvn = "parachain-avn"
     case unsupported
 
     init(rawType: String?) {
@@ -47,7 +48,7 @@ enum StakingClass {
         switch stakingType {
         case .relaychain, .azero, .auraRelaychain:
             self = .relaychain
-        case .parachain, .turing, .mythos:
+        case .parachain, .turing, .mythos, .parachainAvn:
             self = .parachain
         case .nominationPools:
             self = .nominationPools

--- a/novawallet/Modules/Staking/Operations/ParachainStaking/ParaStkCollatorsOperationFactory.swift
+++ b/novawallet/Modules/Staking/Operations/ParachainStaking/ParaStkCollatorsOperationFactory.swift
@@ -185,12 +185,19 @@ extension ParaStkCollatorsOperationFactory: ParaStkCollatorsOperationFactoryProt
         identityWrapper.addDependency(operations: [selectedCollatorsOperation])
 
         let minTechStakeOperation: BaseOperation<BigUInt> = PrimitiveConstantOperation.operation(
-            oneOfPaths: [ParachainStaking.minDelegatorStk, ParachainStaking.minDelegation],
+            oneOfPaths: [
+                ParachainStaking.minDelegatorStk,
+                ParachainStaking.minDelegation,
+                ParachainAvn.minNominationPerCollator
+            ],
             dependingOn: codingFactoryOperation
         )
 
         let maxRewardedDelegationsOperation: BaseOperation<UInt32> = PrimitiveConstantOperation.operation(
-            for: ParachainStaking.maxTopDelegationsPerCandidate,
+            oneOfPaths: [
+                ParachainStaking.maxTopDelegationsPerCandidate,
+                ParachainAvn.maxTopNominationsPerCandidate
+            ],
             dependingOn: codingFactoryOperation
         )
 
@@ -242,12 +249,19 @@ extension ParaStkCollatorsOperationFactory: ParaStkCollatorsOperationFactoryProt
         )
 
         let minTechStakeOperation: BaseOperation<BigUInt> = PrimitiveConstantOperation.operation(
-            oneOfPaths: [ParachainStaking.minDelegatorStk, ParachainStaking.minDelegation],
+            oneOfPaths: [
+                ParachainStaking.minDelegatorStk,
+                ParachainStaking.minDelegation,
+                ParachainAvn.minNominationPerCollator
+            ],
             dependingOn: codingFactoryOperation
         )
 
         let maxRewardedDelegationsOperation: BaseOperation<UInt32> = PrimitiveConstantOperation.operation(
-            for: ParachainStaking.maxTopDelegationsPerCandidate,
+            oneOfPaths: [
+                ParachainStaking.maxTopDelegationsPerCandidate,
+                ParachainAvn.maxTopNominationsPerCandidate
+            ],
             dependingOn: codingFactoryOperation
         )
 

--- a/novawallet/Modules/Staking/Operations/ParachainStaking/ParachainAvnScheduledRequestsQueryWrapperFactory.swift
+++ b/novawallet/Modules/Staking/Operations/ParachainStaking/ParachainAvnScheduledRequestsQueryWrapperFactory.swift
@@ -1,0 +1,100 @@
+import Foundation
+import SubstrateSdk
+import Operation_iOS
+
+protocol ParachainAvnScheduledRequestsQueryWrapperFactoryProtocol {
+    func createQueryWrapper<K1, K2>(
+        using connection: JSONRPCEngine,
+        with collators: @escaping () throws -> [K1],
+        delegator: @escaping () throws -> K2,
+        codingFactory: @escaping () throws -> RuntimeCoderFactoryProtocol,
+        at blockHash: Data?
+    ) -> CompoundOperationWrapper<DelegationRequestsQueryResult> where K1: Encodable, K2: Encodable
+}
+
+extension ParachainAvnScheduledRequestsQueryWrapperFactoryProtocol {
+    func createQueryWrapper<K1, K2>(
+        using connection: JSONRPCEngine,
+        with collators: @escaping () throws -> [K1],
+        delegator: @escaping () throws -> K2,
+        codingFactory: @escaping () throws -> RuntimeCoderFactoryProtocol,
+        at blockHash: Data? = nil
+    ) -> CompoundOperationWrapper<DelegationRequestsQueryResult> where K1: Encodable, K2: Encodable {
+        createQueryWrapper(
+            using: connection,
+            with: collators,
+            delegator: delegator,
+            codingFactory: codingFactory,
+            at: blockHash
+        )
+    }
+}
+
+/// EWX-specific scheduled-requests query factory.
+///
+/// Identical structure to the Moonbeam `ParaStkScheduledRequestsQueryWrapperFactory`
+/// but routes runtime metadata lookups and storage queries through
+/// `ParachainAvn.nominationScheduledRequestsPath` instead of
+/// `ParachainStaking.delegationRequestsPath`. The Moonbeam factory's
+/// hardcoded path throws `storageMetadataNotFound` on EWX because that
+/// runtime exposes `NominationScheduledRequests`, not
+/// `DelegationScheduledRequests`.
+final class ParachainAvnScheduledRequestsQueryWrapperFactory {
+    private let storageRequestFactory: StorageRequestFactoryProtocol
+    private let operationManager: OperationManagerProtocol
+
+    init(
+        storageRequestFactory: StorageRequestFactoryProtocol,
+        operationManager: OperationManagerProtocol
+    ) {
+        self.storageRequestFactory = storageRequestFactory
+        self.operationManager = operationManager
+    }
+}
+
+extension ParachainAvnScheduledRequestsQueryWrapperFactory: ParachainAvnScheduledRequestsQueryWrapperFactoryProtocol {
+    func createQueryWrapper<K1, K2>(
+        using connection: JSONRPCEngine,
+        with collators: @escaping () throws -> [K1],
+        delegator: @escaping () throws -> K2,
+        codingFactory: @escaping () throws -> RuntimeCoderFactoryProtocol,
+        at blockHash: Data?
+    ) -> CompoundOperationWrapper<DelegationRequestsQueryResult> where K1: Encodable, K2: Encodable {
+        OperationCombiningService.compoundNonOptionalWrapper(
+            operationManager: operationManager
+        ) { [weak self] in
+            guard let self else { throw BaseOperationError.parentOperationCancelled }
+
+            let codingFactory = try codingFactory()
+            let metadata = codingFactory.metadata
+
+            let storageMetadata = metadata.getStorageMetadata(
+                for: ParachainAvn.nominationScheduledRequestsPath
+            )
+
+            guard let storageMetadata else { throw ParaStkRequestsQueryError.storageMetadataNotFound }
+
+            return switch storageMetadata.type {
+            case .map:
+                storageRequestFactory.queryItems(
+                    engine: connection,
+                    keyParams: collators,
+                    factory: { codingFactory },
+                    storagePath: ParachainAvn.nominationScheduledRequestsPath,
+                    at: blockHash
+                )
+            case .doubleMap:
+                storageRequestFactory.queryItems(
+                    engine: connection,
+                    keyParams1: collators,
+                    keyParams2: { try Array(repeating: try delegator(), count: collators().count) },
+                    factory: { codingFactory },
+                    storagePath: ParachainAvn.nominationScheduledRequestsPath,
+                    at: blockHash
+                )
+            default:
+                throw ParaStkRequestsQueryError.unexpectedStorageType
+            }
+        }
+    }
+}

--- a/novawallet/Modules/Staking/Parachain/Model/DelegationCallWrapper.swift
+++ b/novawallet/Modules/Staking/Parachain/Model/DelegationCallWrapper.swift
@@ -21,7 +21,7 @@ struct DelegationCallWrapper {
         codingFactory: RuntimeCoderFactoryProtocol
     ) throws -> ExtrinsicBuilderProtocol {
         if existingBond != nil {
-            return try acceptForStakeMore(builder: builder)
+            return try acceptForStakeMore(builder: builder, codingFactory: codingFactory)
         } else {
             return try acceptForStartStaking(
                 builder: builder,
@@ -36,10 +36,20 @@ private extension DelegationCallWrapper {
         builder: ExtrinsicBuilderProtocol,
         codingFactory: RuntimeCoderFactoryProtocol
     ) throws -> ExtrinsicBuilderProtocol {
-        if codingFactory.hasCall(
+        // EWX (AvN fork) uses "nominate" with nomination-count params
+        if codingFactory.hasCall(for: ParachainAvn.NominateCall.callCodingPath) {
+            let call = ParachainAvn.NominateCall(
+                candidate: collator,
+                amount: amount,
+                candidateNominationCount: collatorDelegationsCount,
+                nominationCount: delegationsCount
+            )
+
+            return try builder.adding(call: call.runtimeCall)
+        } else if codingFactory.hasCall(
             for: ParachainStaking.DelegateWithAutocompoundCall.callCodingPath
         ) {
-            // we currently don't support auto compound in ui
+            // Moonbeam with auto-compound
             let call = ParachainStaking.DelegateWithAutocompoundCall(
                 candidate: collator,
                 amount: amount,
@@ -51,6 +61,7 @@ private extension DelegationCallWrapper {
 
             return try builder.adding(call: call.runtimeCall)
         } else {
+            // Moonbeam legacy delegate
             let call = ParachainStaking.DelegateCall(
                 candidate: collator,
                 amount: amount,
@@ -63,13 +74,24 @@ private extension DelegationCallWrapper {
     }
 
     func acceptForStakeMore(
-        builder: ExtrinsicBuilderProtocol
+        builder: ExtrinsicBuilderProtocol,
+        codingFactory: RuntimeCoderFactoryProtocol
     ) throws -> ExtrinsicBuilderProtocol {
-        let call = ParachainStaking.DelegatorBondMoreCall(
-            candidate: collator,
-            more: amount
-        )
+        // EWX (AvN fork) uses "bond_extra"
+        if codingFactory.hasCall(for: ParachainAvn.BondExtraCall.callCodingPath) {
+            let call = ParachainAvn.BondExtraCall(
+                candidate: collator,
+                more: amount
+            )
 
-        return try builder.adding(call: call.runtimeCall)
+            return try builder.adding(call: call.runtimeCall)
+        } else {
+            let call = ParachainStaking.DelegatorBondMoreCall(
+                candidate: collator,
+                more: amount
+            )
+
+            return try builder.adding(call: call.runtimeCall)
+        }
     }
 }

--- a/novawallet/Modules/Staking/Parachain/Model/UnstakeCallWrapper.swift
+++ b/novawallet/Modules/Staking/Parachain/Model/UnstakeCallWrapper.swift
@@ -20,15 +20,30 @@ struct UnstakeCallWrapper {
         }
     }
 
-    func accept(builder: ExtrinsicBuilderProtocol) throws -> ExtrinsicBuilderProtocol {
+    func accept(
+        builder: ExtrinsicBuilderProtocol,
+        codingFactory: RuntimeCoderFactoryProtocol
+    ) throws -> ExtrinsicBuilderProtocol {
+        // Probe each EWX (AvN-fork) call independently — mirrors the per-call
+        // pattern in `DelegationCallWrapper`. If a future runtime renames or
+        // splits the two calls we don't want to silently dispatch a missing one.
         switch action {
         case let .bondLess(amount):
+            if codingFactory.hasCall(for: ParachainAvn.ScheduleNominatorUnbondCall.callCodingPath) {
+                let call = ParachainAvn.ScheduleNominatorUnbondCall(candidate: collator, less: amount)
+                return try builder.adding(call: call.runtimeCall)
+            }
+
             let call = ParachainStaking.ScheduleBondLessCall(candidate: collator, less: amount)
-
             return try builder.adding(call: call.runtimeCall)
-        case .revoke:
-            let call = ParachainStaking.ScheduleRevokeCall(collator: collator)
 
+        case .revoke:
+            if codingFactory.hasCall(for: ParachainAvn.ScheduleRevokeNominationCall.callCodingPath) {
+                let call = ParachainAvn.ScheduleRevokeNominationCall(collator: collator)
+                return try builder.adding(call: call.runtimeCall)
+            }
+
+            let call = ParachainStaking.ScheduleRevokeCall(collator: collator)
             return try builder.adding(call: call.runtimeCall)
         }
     }

--- a/novawallet/Modules/Staking/Parachain/ParaStkRebond/ParaStkRebondInteractor.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkRebond/ParaStkRebondInteractor.swift
@@ -14,6 +14,7 @@ final class ParaStkRebondInteractor: AnyCancellableCleaning {
     let signer: SigningWrapperProtocol
     let stakingLocalSubscriptionFactory: ParachainStakingLocalSubscriptionFactoryProtocol
     let identityProxyFactory: IdentityProxyFactoryProtocol
+    let runtimeProvider: RuntimeCodingServiceProtocol
     let operationQueue: OperationQueue
 
     private var balanceProvider: StreamableProvider<AssetBalance>?
@@ -33,6 +34,7 @@ final class ParaStkRebondInteractor: AnyCancellableCleaning {
         signer: SigningWrapperProtocol,
         stakingLocalSubscriptionFactory: ParachainStakingLocalSubscriptionFactoryProtocol,
         identityProxyFactory: IdentityProxyFactoryProtocol,
+        runtimeProvider: RuntimeCodingServiceProtocol,
         currencyManager: CurrencyManagerProtocol,
         operationQueue: OperationQueue
     ) {
@@ -45,6 +47,7 @@ final class ParaStkRebondInteractor: AnyCancellableCleaning {
         self.signer = signer
         self.stakingLocalSubscriptionFactory = stakingLocalSubscriptionFactory
         self.identityProxyFactory = identityProxyFactory
+        self.runtimeProvider = runtimeProvider
         self.operationQueue = operationQueue
         self.currencyManager = currencyManager
     }
@@ -62,7 +65,18 @@ final class ParaStkRebondInteractor: AnyCancellableCleaning {
         }
     }
 
-    private func prepareExtrisicBuilderClosure(for collator: AccountId) -> ExtrinsicBuilderClosure {
+    private func prepareExtrisicBuilderClosure(
+        for collator: AccountId,
+        codingFactory: RuntimeCoderFactoryProtocol
+    ) -> ExtrinsicBuilderClosure {
+        // EWX (AvN fork) uses "cancel_nomination_request"
+        if codingFactory.hasCall(for: ParachainAvn.CancelNominationRequestCall.callCodingPath) {
+            let call = ParachainAvn.CancelNominationRequestCall(candidate: collator)
+            return { builder in
+                try builder.adding(call: call.runtimeCall)
+            }
+        }
+
         let call = ParachainStaking.CancelDelegatorRequest(candidate: collator)
 
         return { builder in
@@ -94,17 +108,40 @@ extension ParaStkRebondInteractor: ParaStkRebondInteractorInputProtocol {
     }
 
     func estimateFee(for collator: AccountId) {
-        let extrinsicBuilderClosure = prepareExtrisicBuilderClosure(for: collator)
-
-        feeProxy.estimateFee(
-            using: extrinsicService,
-            reuseIdentifier: collator.toHex(),
-            setupBy: extrinsicBuilderClosure
+        runtimeProvider.fetchCoderFactory(
+            runningIn: operationQueue,
+            completion: { [weak self] codingFactory in
+                guard let self else { return }
+                let closure = self.prepareExtrisicBuilderClosure(for: collator, codingFactory: codingFactory)
+                self.feeProxy.estimateFee(
+                    using: self.extrinsicService,
+                    reuseIdentifier: collator.toHex(),
+                    setupBy: closure
+                )
+            },
+            errorClosure: { [weak self] error in
+                self?.presenter?.didReceiveFee(.failure(error))
+            }
         )
     }
 
     func submit(for collator: AccountId) {
-        let builderClosure = prepareExtrisicBuilderClosure(for: collator)
+        runtimeProvider.fetchCoderFactory(
+            runningIn: operationQueue,
+            completion: { [weak self] codingFactory in
+                self?.doSubmit(for: collator, codingFactory: codingFactory)
+            },
+            errorClosure: { [weak self] error in
+                self?.presenter?.didCompleteExtrinsicSubmission(for: .failure(error))
+            }
+        )
+    }
+
+    private func doSubmit(
+        for collator: AccountId,
+        codingFactory: RuntimeCoderFactoryProtocol
+    ) {
+        let builderClosure = prepareExtrisicBuilderClosure(for: collator, codingFactory: codingFactory)
 
         let subscriptionIdClosure: ExtrinsicSubscriptionIdClosure = { [weak self] subscriptionId in
             self?.extrinsicSubscriptionId = subscriptionId

--- a/novawallet/Modules/Staking/Parachain/ParaStkRebond/ParaStkRebondViewFactory.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkRebond/ParaStkRebondViewFactory.swift
@@ -115,6 +115,7 @@ struct ParaStkRebondViewFactory {
             signer: signer,
             stakingLocalSubscriptionFactory: state.stakingLocalSubscriptionFactory,
             identityProxyFactory: identityProxyFactory,
+            runtimeProvider: runtimeProvider,
             currencyManager: currencyManager,
             operationQueue: OperationManagerFacade.sharedDefaultQueue
         )

--- a/novawallet/Modules/Staking/Parachain/ParaStkRedeem/ParaStkRedeemInteractor.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkRedeem/ParaStkRedeemInteractor.swift
@@ -13,6 +13,8 @@ final class ParaStkRedeemInteractor {
     let feeProxy: ExtrinsicFeeProxyProtocol
     let signer: SigningWrapperProtocol
     let stakingLocalSubscriptionFactory: ParachainStakingLocalSubscriptionFactoryProtocol
+    let runtimeProvider: RuntimeCodingServiceProtocol
+    let operationQueue: OperationQueue
 
     private var balanceProvider: StreamableProvider<AssetBalance>?
     private var priceProvider: StreamableProvider<PriceData>?
@@ -31,6 +33,8 @@ final class ParaStkRedeemInteractor {
         feeProxy: ExtrinsicFeeProxyProtocol,
         signer: SigningWrapperProtocol,
         stakingLocalSubscriptionFactory: ParachainStakingLocalSubscriptionFactoryProtocol,
+        runtimeProvider: RuntimeCodingServiceProtocol,
+        operationQueue: OperationQueue,
         currencyManager: CurrencyManagerProtocol
     ) {
         self.chainAsset = chainAsset
@@ -41,6 +45,8 @@ final class ParaStkRedeemInteractor {
         self.feeProxy = feeProxy
         self.signer = signer
         self.stakingLocalSubscriptionFactory = stakingLocalSubscriptionFactory
+        self.runtimeProvider = runtimeProvider
+        self.operationQueue = operationQueue
         self.currencyManager = currencyManager
     }
 
@@ -85,22 +91,33 @@ extension ParaStkRedeemInteractor: ParaStkRedeemInteractorInputProtocol {
         feeProxy.delegate = self
     }
 
-    private func prepareCalls(for collatorIds: Set<AccountId>) -> [ParachainStaking.ExecuteDelegatorRequest] {
+    private func prepareExtrisicBuilderClosure(
+        for collatorIds: Set<AccountId>,
+        codingFactory: RuntimeCoderFactoryProtocol
+    ) -> ExtrinsicBuilderClosure {
         let delegator = selectedAccount.chainAccount.accountId
-
-        return collatorIds.map { collator in
-            ParachainStaking.ExecuteDelegatorRequest(delegator: delegator, candidate: collator)
-        }
-    }
-
-    private func prepareExtrisicBuilderClosure(for collatorIds: Set<AccountId>) -> ExtrinsicBuilderClosure {
-        let calls = prepareCalls(for: collatorIds)
+        // EWX (AvN fork) uses "execute_nomination_request" with named args.
+        let useAvnCall = codingFactory.hasCall(
+            for: ParachainAvn.ExecuteNominationRequestCall.callCodingPath
+        )
 
         return { builder in
             var newBuilder = builder
 
-            for call in calls {
-                newBuilder = try newBuilder.adding(call: call.runtimeCall)
+            for collator in collatorIds {
+                if useAvnCall {
+                    let call = ParachainAvn.ExecuteNominationRequestCall(
+                        nominator: delegator,
+                        candidate: collator
+                    )
+                    newBuilder = try newBuilder.adding(call: call.runtimeCall)
+                } else {
+                    let call = ParachainStaking.ExecuteDelegatorRequest(
+                        delegator: delegator,
+                        candidate: collator
+                    )
+                    newBuilder = try newBuilder.adding(call: call.runtimeCall)
+                }
             }
 
             return newBuilder
@@ -115,21 +132,46 @@ extension ParaStkRedeemInteractor: ParaStkRedeemInteractorInputProtocol {
 
             let extrinsicId = try Data(compoundId).blake2b16().toHex()
 
-            let extrinsicBuilderClosure = prepareExtrisicBuilderClosure(for: collatorIds)
-
-            feeProxy.estimateFee(
-                using: extrinsicService,
-                reuseIdentifier: extrinsicId,
-                setupBy: extrinsicBuilderClosure
+            runtimeProvider.fetchCoderFactory(
+                runningIn: operationQueue,
+                completion: { [weak self] codingFactory in
+                    guard let self else { return }
+                    let extrinsicBuilderClosure = self.prepareExtrisicBuilderClosure(
+                        for: collatorIds,
+                        codingFactory: codingFactory
+                    )
+                    self.feeProxy.estimateFee(
+                        using: self.extrinsicService,
+                        reuseIdentifier: extrinsicId,
+                        setupBy: extrinsicBuilderClosure
+                    )
+                },
+                errorClosure: { [weak self] error in
+                    self?.presenter?.didReceiveFee(.failure(error))
+                }
             )
-
         } catch {
             presenter?.didReceiveFee(.failure(error))
         }
     }
 
     func submit(for collatorIds: Set<AccountId>) {
-        let builderClosure = prepareExtrisicBuilderClosure(for: collatorIds)
+        runtimeProvider.fetchCoderFactory(
+            runningIn: operationQueue,
+            completion: { [weak self] codingFactory in
+                self?.doSubmit(for: collatorIds, codingFactory: codingFactory)
+            },
+            errorClosure: { [weak self] error in
+                self?.presenter?.didCompleteExtrinsicSubmission(for: .failure(error))
+            }
+        )
+    }
+
+    private func doSubmit(
+        for collatorIds: Set<AccountId>,
+        codingFactory: RuntimeCoderFactoryProtocol
+    ) {
+        let builderClosure = prepareExtrisicBuilderClosure(for: collatorIds, codingFactory: codingFactory)
 
         let subscriptionIdClosure: ExtrinsicSubscriptionIdClosure = { [weak self] subscriptionId in
             self?.extrinsicSubscriptionId = subscriptionId

--- a/novawallet/Modules/Staking/Parachain/ParaStkRedeem/ParaStkRedeemViewFactory.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkRedeem/ParaStkRedeemViewFactory.swift
@@ -95,6 +95,8 @@ struct ParaStkRedeemViewFactory {
             feeProxy: ExtrinsicFeeProxy(),
             signer: signer,
             stakingLocalSubscriptionFactory: state.stakingLocalSubscriptionFactory,
+            runtimeProvider: runtimeProvider,
+            operationQueue: OperationManagerFacade.sharedDefaultQueue,
             currencyManager: currencyManager
         )
     }

--- a/novawallet/Modules/Staking/Parachain/ParaStkStakeConfirm/ParaStkStakeConfirmInteractor.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkStakeConfirm/ParaStkStakeConfirmInteractor.swift
@@ -113,7 +113,11 @@ final class ParaStkStakeConfirmInteractor: RuntimeConstantFetching {
 
     private func provideMinTechStake() {
         fetchConstant(
-            oneOfPaths: [ParachainStaking.minDelegatorStk, ParachainStaking.minDelegation],
+            oneOfPaths: [
+                ParachainStaking.minDelegatorStk,
+                ParachainStaking.minDelegation,
+                ParachainAvn.minNominationPerCollator
+            ],
             runtimeCodingService: runtimeProvider,
             operationQueue: operationQueue
         ) { [weak self] (result: Result<BigUInt, Error>) in
@@ -128,7 +132,10 @@ final class ParaStkStakeConfirmInteractor: RuntimeConstantFetching {
 
     private func provideMinDelegationAmount() {
         fetchConstant(
-            for: ParachainStaking.minDelegation,
+            oneOfPaths: [
+                ParachainStaking.minDelegation,
+                ParachainAvn.minNominationPerCollator
+            ],
             runtimeCodingService: runtimeProvider,
             operationQueue: operationQueue
         ) { [weak self] (result: Result<BigUInt, Error>) in
@@ -143,7 +150,10 @@ final class ParaStkStakeConfirmInteractor: RuntimeConstantFetching {
 
     private func provideMaxDelegationsPerDelegator() {
         fetchConstant(
-            for: ParachainStaking.maxDelegations,
+            oneOfPaths: [
+                ParachainStaking.maxDelegations,
+                ParachainAvn.maxNominationsPerNominator
+            ],
             runtimeCodingService: runtimeProvider,
             operationQueue: operationQueue
         ) { [weak self] (result: Result<UInt32, Error>) in

--- a/novawallet/Modules/Staking/Parachain/ParaStkStakeConfirm/ParaStkStakeConfirmPresenter.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkStakeConfirm/ParaStkStakeConfirmPresenter.swift
@@ -169,10 +169,11 @@ final class ParaStkStakeConfirmPresenter {
     func submitExtrinsic() {
         guard
             let amountInPlank = amount.toSubstrateAmount(precision: chainAsset.assetDisplayInfo.assetPrecision),
-            let collatorId = try? collator.address.toAccountId(),
-            let collatorDelegationsCount = collatorMetadata?.delegationCount else {
+            let collatorId = try? collator.address.toAccountId() else {
             return
         }
+
+        let collatorDelegationsCount = collatorMetadata?.delegationCount ?? 0
 
         let delegationsCount = delegator?.delegations.count ?? 0
 

--- a/novawallet/Modules/Staking/Parachain/ParaStkStakeSetup/ParaStkStakeSetupInteractor.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkStakeSetup/ParaStkStakeSetupInteractor.swift
@@ -156,7 +156,11 @@ final class ParaStkStakeSetupInteractor: RuntimeConstantFetching {
 
     private func provideMinTechStake() {
         fetchConstant(
-            oneOfPaths: [ParachainStaking.minDelegatorStk, ParachainStaking.minDelegation],
+            oneOfPaths: [
+                ParachainStaking.minDelegatorStk,
+                ParachainStaking.minDelegation,
+                ParachainAvn.minNominationPerCollator
+            ],
             runtimeCodingService: runtimeProvider,
             operationQueue: operationQueue
         ) { [weak self] (result: Result<BigUInt, Error>) in
@@ -171,7 +175,10 @@ final class ParaStkStakeSetupInteractor: RuntimeConstantFetching {
 
     private func provideMinDelegationAmount() {
         fetchConstant(
-            for: ParachainStaking.minDelegation,
+            oneOfPaths: [
+                ParachainStaking.minDelegation,
+                ParachainAvn.minNominationPerCollator
+            ],
             runtimeCodingService: runtimeProvider,
             operationQueue: operationQueue
         ) { [weak self] (result: Result<BigUInt, Error>) in
@@ -186,7 +193,10 @@ final class ParaStkStakeSetupInteractor: RuntimeConstantFetching {
 
     private func provideMaxDelegationsPerDelegator() {
         fetchConstant(
-            for: ParachainStaking.maxDelegations,
+            oneOfPaths: [
+                ParachainStaking.maxDelegations,
+                ParachainAvn.maxNominationsPerNominator
+            ],
             runtimeCodingService: runtimeProvider,
             operationQueue: operationQueue
         ) { [weak self] (result: Result<UInt32, Error>) in

--- a/novawallet/Modules/Staking/Parachain/ParaStkUnstake/Base/ParaStkBaseUnstakeInteractor.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkUnstake/Base/ParaStkBaseUnstakeInteractor.swift
@@ -118,12 +118,24 @@ class ParaStkBaseUnstakeInteractor {
 
 extension ParaStkBaseUnstakeInteractor: ParaStkBaseUnstakeInteractorInputProtocol {
     func estimateFee(for callWrapper: UnstakeCallWrapper) {
-        feeProxy.estimateFee(
-            using: extrinsicService,
-            reuseIdentifier: callWrapper.extrinsicId()
-        ) { builder in
-            try callWrapper.accept(builder: builder)
-        }
+        let identifier = callWrapper.extrinsicId()
+
+        runtimeProvider.fetchCoderFactory(
+            runningIn: operationQueue,
+            completion: { [weak self] codingFactory in
+                guard let self else { return }
+
+                self.feeProxy.estimateFee(
+                    using: self.extrinsicService,
+                    reuseIdentifier: identifier
+                ) { builder in
+                    try callWrapper.accept(builder: builder, codingFactory: codingFactory)
+                }
+            },
+            errorClosure: { [weak self] error in
+                self?.basePresenter?.didReceiveError(error)
+            }
+        )
     }
 }
 

--- a/novawallet/Modules/Staking/Parachain/ParaStkUnstake/ParaStkUnstakeInteractor.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkUnstake/ParaStkUnstakeInteractor.swift
@@ -99,7 +99,11 @@ final class ParaStkUnstakeInteractor: ParaStkBaseUnstakeInteractor, AnyCancellab
 
     private func provideMinTechStake() {
         fetchConstant(
-            oneOfPaths: [ParachainStaking.minDelegatorStk, ParachainStaking.minDelegation],
+            oneOfPaths: [
+                ParachainStaking.minDelegatorStk,
+                ParachainStaking.minDelegation,
+                ParachainAvn.minNominationPerCollator
+            ],
             runtimeCodingService: runtimeProvider,
             operationQueue: operationQueue
         ) { [weak self] (result: Result<BigUInt, Error>) in
@@ -114,7 +118,10 @@ final class ParaStkUnstakeInteractor: ParaStkBaseUnstakeInteractor, AnyCancellab
 
     private func provideMinDelegationAmount() {
         fetchConstant(
-            for: ParachainStaking.minDelegation,
+            oneOfPaths: [
+                ParachainStaking.minDelegation,
+                ParachainAvn.minNominationPerCollator
+            ],
             runtimeCodingService: runtimeProvider,
             operationQueue: operationQueue
         ) { [weak self] (result: Result<BigUInt, Error>) in

--- a/novawallet/Modules/Staking/Parachain/ParaStkUnstakeConfirm/ParaStkUnstakeConfirmInteractor.swift
+++ b/novawallet/Modules/Staking/Parachain/ParaStkUnstakeConfirm/ParaStkUnstakeConfirmInteractor.swift
@@ -61,8 +61,23 @@ final class ParaStkUnstakeConfirmInteractor: ParaStkBaseUnstakeInteractor {
 
 extension ParaStkUnstakeConfirmInteractor: ParaStkUnstakeConfirmInteractorInputProtocol {
     func confirm(for callWrapper: UnstakeCallWrapper) {
+        runtimeProvider.fetchCoderFactory(
+            runningIn: operationQueue,
+            completion: { [weak self] codingFactory in
+                self?.doConfirmExtrinsic(for: callWrapper, codingFactory: codingFactory)
+            },
+            errorClosure: { [weak self] error in
+                self?.presenter?.didCompleteExtrinsicSubmission(for: .failure(error))
+            }
+        )
+    }
+
+    private func doConfirmExtrinsic(
+        for callWrapper: UnstakeCallWrapper,
+        codingFactory: RuntimeCoderFactoryProtocol
+    ) {
         let builderClosure: (ExtrinsicBuilderProtocol) throws -> ExtrinsicBuilderProtocol = { builder in
-            try callWrapper.accept(builder: builder)
+            try callWrapper.accept(builder: builder, codingFactory: codingFactory)
         }
 
         let subscriptionIdClosure: ExtrinsicSubscriptionIdClosure = { [weak self] subscriptionId in

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Calls/ParachainAvn+Calls.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Calls/ParachainAvn+Calls.swift
@@ -1,0 +1,215 @@
+import Foundation
+import SubstrateSdk
+import BigInt
+
+/// Substrate call structs for Energy Web X's `ParachainStaking` pallet
+/// (Aventus AvN fork). Each call mirrors the on-chain SCALE name exactly
+/// — verified against EWX mainnet runtime metadata v15 (spec version 105,
+/// 2026-04-11) via `state_getMetadata`.
+///
+/// EWX kept the pre-rename API that Moonbeam later migrated away from:
+///
+///   EWX (this file)                    Moonbeam (ParaStkCalls.swift)
+///   -----------------                   -----------------------------
+///   nominate                            delegate
+///   bond_extra                          delegator_bond_more
+///   schedule_nominator_unbond           schedule_delegator_bond_less
+///   schedule_revoke_nomination          schedule_revoke_delegation
+///   execute_nomination_request          execute_delegation_request
+///   cancel_nomination_request           cancel_delegation_request
+///
+/// Do NOT refactor to share code with `ParaStkCalls.swift`. The call
+/// names differ, and so does the parameter naming inside most calls
+/// (e.g. `candidate_nomination_count` vs `candidate_delegation_count`).
+extension ParachainAvn {
+    /// `parachainStaking.nominate(candidate, amount, candidate_nomination_count, nomination_count)`
+    ///
+    /// First-time nomination of a collator. The two `*_count` fields
+    /// are required by the pallet to pre-validate storage iteration
+    /// costs: `candidate_nomination_count` is the current nominator
+    /// count on the target candidate (read from `candidateInfo`),
+    /// `nomination_count` is how many nominations the caller already
+    /// holds (read from `nominatorState`).
+    struct NominateCall: Codable {
+        enum CodingKeys: String, CodingKey {
+            case candidate
+            case amount
+            case candidateNominationCount = "candidate_nomination_count"
+            case nominationCount = "nomination_count"
+        }
+
+        @BytesCodable var candidate: AccountId
+        @StringCodable var amount: BigUInt
+        @StringCodable var candidateNominationCount: UInt32
+        @StringCodable var nominationCount: UInt32
+    }
+
+    /// `parachainStaking.bond_extra(candidate, more)`
+    ///
+    /// Increases an existing nomination by `more` wei.
+    struct BondExtraCall: Codable {
+        enum CodingKeys: String, CodingKey {
+            case candidate
+            case more
+        }
+
+        @BytesCodable var candidate: AccountId
+        @StringCodable var more: BigUInt
+    }
+
+    /// `parachainStaking.schedule_nominator_unbond(candidate, less)`
+    ///
+    /// Schedules a partial unbond that becomes executable after the
+    /// `ParachainStaking.Delay` storage value (currently ~2 eras).
+    struct ScheduleNominatorUnbondCall: Codable {
+        enum CodingKeys: String, CodingKey {
+            case candidate
+            case less
+        }
+
+        @BytesCodable var candidate: AccountId
+        @StringCodable var less: BigUInt
+    }
+
+    /// `parachainStaking.schedule_revoke_nomination(collator)`
+    ///
+    /// Schedules a full revoke of a nomination on the given collator.
+    /// Executable after the same delay as a partial unbond.
+    struct ScheduleRevokeNominationCall: Codable {
+        enum CodingKeys: String, CodingKey {
+            case collator
+        }
+
+        @BytesCodable var collator: AccountId
+    }
+
+    /// `parachainStaking.execute_nomination_request(nominator, candidate)`
+    ///
+    /// Executes a previously-scheduled unbond or revoke after the delay
+    /// has elapsed. Any account can call this — it's not self-service.
+    struct ExecuteNominationRequestCall: Codable {
+        enum CodingKeys: String, CodingKey {
+            case nominator
+            case candidate
+        }
+
+        @BytesCodable var nominator: AccountId
+        @BytesCodable var candidate: AccountId
+    }
+
+    /// `parachainStaking.cancel_nomination_request(candidate)`
+    ///
+    /// Cancels a previously-scheduled unbond or revoke before it has
+    /// been executed.
+    struct CancelNominationRequestCall: Codable {
+        enum CodingKeys: String, CodingKey {
+            case candidate
+        }
+
+        @BytesCodable var candidate: AccountId
+    }
+}
+
+// MARK: - RuntimeCall wrappers
+
+extension ParachainAvn.NominateCall {
+    static var callCodingPath: CallCodingPath {
+        CallCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            callName: "nominate"
+        )
+    }
+
+    var runtimeCall: RuntimeCall<Self> {
+        RuntimeCall(
+            moduleName: Self.callCodingPath.moduleName,
+            callName: Self.callCodingPath.callName,
+            args: self
+        )
+    }
+}
+
+extension ParachainAvn.BondExtraCall {
+    static var callCodingPath: CallCodingPath {
+        CallCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            callName: "bond_extra"
+        )
+    }
+
+    var runtimeCall: RuntimeCall<Self> {
+        RuntimeCall(
+            moduleName: Self.callCodingPath.moduleName,
+            callName: Self.callCodingPath.callName,
+            args: self
+        )
+    }
+}
+
+extension ParachainAvn.ScheduleNominatorUnbondCall {
+    static var callCodingPath: CallCodingPath {
+        CallCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            callName: "schedule_nominator_unbond"
+        )
+    }
+
+    var runtimeCall: RuntimeCall<Self> {
+        RuntimeCall(
+            moduleName: Self.callCodingPath.moduleName,
+            callName: Self.callCodingPath.callName,
+            args: self
+        )
+    }
+}
+
+extension ParachainAvn.ScheduleRevokeNominationCall {
+    static var callCodingPath: CallCodingPath {
+        CallCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            callName: "schedule_revoke_nomination"
+        )
+    }
+
+    var runtimeCall: RuntimeCall<Self> {
+        RuntimeCall(
+            moduleName: Self.callCodingPath.moduleName,
+            callName: Self.callCodingPath.callName,
+            args: self
+        )
+    }
+}
+
+extension ParachainAvn.ExecuteNominationRequestCall {
+    static var callCodingPath: CallCodingPath {
+        CallCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            callName: "execute_nomination_request"
+        )
+    }
+
+    var runtimeCall: RuntimeCall<Self> {
+        RuntimeCall(
+            moduleName: Self.callCodingPath.moduleName,
+            callName: Self.callCodingPath.callName,
+            args: self
+        )
+    }
+}
+
+extension ParachainAvn.CancelNominationRequestCall {
+    static var callCodingPath: CallCodingPath {
+        CallCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            callName: "cancel_nomination_request"
+        )
+    }
+
+    var runtimeCall: RuntimeCall<Self> {
+        RuntimeCall(
+            moduleName: Self.callCodingPath.moduleName,
+            callName: Self.callCodingPath.callName,
+            args: self
+        )
+    }
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Model/ParachainAvn.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Model/ParachainAvn.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Empty namespace enum for Energy Web X's `ParachainStaking` pallet
+/// integration (Aventus AvN fork). Call structs, storage-path factories,
+/// and constant-path factories all live under `extension ParachainAvn`
+/// in sibling files so consumers see a single `ParachainAvn.*` prefix.
+///
+/// This is deliberately separate from Nova's existing `ParachainStaking`
+/// namespace (used by the Moonbeam-family integration). The two chains
+/// share a pallet name and many storage item names, but the call names
+/// diverged when Moonbeam renamed `nominate`/`nominator_*` to
+/// `delegate`/`delegator_*`. EWX kept the older AvN names. Mixing the
+/// two namespaces would produce invalid extrinsics at sign time.
+enum ParachainAvn {}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Model/ParachainAvnCollator.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Model/ParachainAvnCollator.swift
@@ -1,0 +1,37 @@
+import Foundation
+import BigInt
+
+/// View-model struct describing a single EWX collator ("candidate"),
+/// populated entirely from live on-chain queries. No value in this
+/// struct comes from a third-party API or a hardcoded Swift literal:
+///
+///   accountId       ← `parachainStaking.candidatePool` entries (owner)
+///   identity        ← `identity.identityOf(accountId)` (optional)
+///   totalStake      ← `parachainStaking.candidateInfo(accountId).totalCounted`
+///   ownStake        ← `parachainStaking.candidateInfo(accountId).bond`
+///   delegatedStake  ← totalStake - ownStake (derived)
+///   nominationCount ← `parachainStaking.candidateInfo(accountId).nominationCount`
+///   commission      ← `parachainStaking.defaultCollatorCommission.current`
+///                     (global Perbill, applies to all collators)
+///   estimatedApr    ← derived from `parachainStaking.growth` accumulators
+///                     via `ParachainAvnAprCalculator`
+///   isActive        ← membership in `parachainStaking.selectedCandidates`
+struct ParachainAvnCollator {
+    let accountId: AccountId
+    let identity: String?
+    let totalStake: BigUInt
+    let ownStake: BigUInt
+    let delegatedStake: BigUInt
+    let nominationCount: UInt32
+    /// Commission as a decimal fraction in [0, 1]. EWX commission is
+    /// global, so every collator in a given fetch carries the same
+    /// value — the field is per-collator here for future-proofing
+    /// against a pallet upgrade that introduces per-collator rates.
+    let commission: Decimal
+    /// Client-computed APR estimate as a decimal fraction in [0, 1].
+    /// `nil` when the current growth period has accumulated fewer
+    /// than the minimum number of eras the calculator considers
+    /// reliable (avoids wild swings from a single-era sample).
+    let estimatedApr: Decimal?
+    let isActive: Bool
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Model/ParachainAvnCommissionSetting.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Model/ParachainAvnCommissionSetting.swift
@@ -1,0 +1,45 @@
+import Foundation
+import SubstrateSdk
+import BigInt
+
+extension ParachainAvn {
+    /// EWX `DefaultCollatorCommission` storage value.
+    ///
+    /// Shape: `{ current: Perbill, scheduled: Option<Perbill> }`.
+    /// `current` is the active collator commission (10% = 100_000_000 on
+    /// mainnet). `scheduled` is set when governance has voted in a new
+    /// commission that takes effect at the next era boundary.
+    ///
+    /// Moonbeam stores `CollatorCommission` as a bare `Perbill` (4 bytes)
+    /// — that's why this CommissionSetting value (5+ bytes) cannot be
+    /// decoded as `BigUInt` via `getCollatorCommissionProvider`.
+    struct CommissionSetting: Decodable, Equatable {
+        let current: BigUInt
+        let scheduled: BigUInt?
+
+        private enum CodingKeys: String, CodingKey {
+            case current
+            case scheduled
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            current = try container.decode(StringScaleMapper<BigUInt>.self, forKey: .current).value
+
+            // `decodeIfPresent` correctly maps both an absent key and a
+            // JSON-`null` value (SubstrateSdk's representation of `Option<T>`
+            // when the option is `None`) to nil while still propagating real
+            // type-mismatch errors. A `try?` here would silently swallow
+            // those errors and mask real runtime/encoder changes.
+            scheduled = try container.decodeIfPresent(
+                StringScaleMapper<BigUInt>.self, forKey: .scheduled
+            )?.value
+        }
+
+        init(current: BigUInt, scheduled: BigUInt? = nil) {
+            self.current = current
+            self.scheduled = scheduled
+        }
+    }
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Model/ParachainAvnGrowthInfo.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Model/ParachainAvnGrowthInfo.swift
@@ -1,0 +1,81 @@
+import Foundation
+import SubstrateSdk
+import BigInt
+
+extension ParachainAvn {
+    /// Pointer to the current `Growth` period on EWX.
+    ///
+    /// Storage shape: `{ startEraIndex: u32, index: u32 }` at
+    /// `ParachainStaking.GrowthPeriod`. `index` is the current period
+    /// number; the most recent completed period is `index - 1`.
+    struct GrowthPeriod: Decodable, Equatable {
+        let startEraIndex: UInt32
+        let index: UInt32
+
+        private enum CodingKeys: String, CodingKey {
+            case startEraIndex
+            case start // some chain versions encode it as `start`
+            case index
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            if let mapper = try? container.decode(StringScaleMapper<UInt32>.self, forKey: .startEraIndex) {
+                startEraIndex = mapper.value
+            } else if let mapper = try? container.decode(StringScaleMapper<UInt32>.self, forKey: .start) {
+                startEraIndex = mapper.value
+            } else {
+                startEraIndex = 0
+            }
+
+            index = try container.decode(StringScaleMapper<UInt32>.self, forKey: .index).value
+        }
+
+        init(startEraIndex: UInt32, index: UInt32) {
+            self.startEraIndex = startEraIndex
+            self.index = index
+        }
+    }
+
+    /// Reward accumulation snapshot for a single growth period.
+    ///
+    /// Storage shape: `{ numberOfAccumulations, totalStakeAccumulated,
+    ///   totalStakerReward, totalPoints, collatorScores, txId,
+    ///   triggered }` at `ParachainStaking.Growth(period_index)`.
+    /// Only the first three fields are needed for APR computation;
+    /// the rest are decoded leniently and ignored.
+    ///
+    /// APR = (totalStakerReward / totalStakeAccumulated) *
+    ///       (eras_per_year / numberOfAccumulations)
+    /// On EWX `numberOfAccumulations` is typically 28 (a 28-era period)
+    /// and `eras_per_year` is 365 (one era per day).
+    struct GrowthInfo: Decodable, Equatable {
+        let numberOfAccumulations: UInt32
+        let totalStakeAccumulated: BigUInt
+        let totalStakerReward: BigUInt
+
+        private enum CodingKeys: String, CodingKey {
+            case numberOfAccumulations
+            case totalStakeAccumulated
+            case totalStakerReward
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            numberOfAccumulations = try container
+                .decode(StringScaleMapper<UInt32>.self, forKey: .numberOfAccumulations).value
+            totalStakeAccumulated = try container
+                .decode(StringScaleMapper<BigUInt>.self, forKey: .totalStakeAccumulated).value
+            totalStakerReward = try container
+                .decode(StringScaleMapper<BigUInt>.self, forKey: .totalStakerReward).value
+        }
+
+        init(numberOfAccumulations: UInt32, totalStakeAccumulated: BigUInt, totalStakerReward: BigUInt) {
+            self.numberOfAccumulations = numberOfAccumulations
+            self.totalStakeAccumulated = totalStakeAccumulated
+            self.totalStakerReward = totalStakerReward
+        }
+    }
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Model/ParachainAvnStakePosition.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Model/ParachainAvnStakePosition.swift
@@ -1,0 +1,41 @@
+import Foundation
+import BigInt
+
+/// User's open nominations on Energy Web X, decoded from the union of
+/// `parachainStaking.nominatorState(accountId)` and
+/// `parachainStaking.nominationScheduledRequests(candidate)` for each
+/// active nomination.
+struct ParachainAvnStakePosition {
+    let nominator: AccountId
+    let nominations: [Nomination]
+    /// Sum of `amount` across every nomination in the list. Convenience
+    /// field — re-derivable from `nominations` but stored so "total
+    /// staked" labels don't rebuild it on every render.
+    let totalLocked: BigUInt
+
+    struct Nomination {
+        let candidate: AccountId
+        let candidateIdentity: String?
+        let amount: BigUInt
+        /// Scheduled unbond or revoke request, if any. `nil` means the
+        /// nomination is fully active and there's nothing pending.
+        let pendingRequest: PendingRequest?
+    }
+
+    struct PendingRequest {
+        enum Action: Equatable {
+            /// `scheduleNominatorUnbond(candidate, less)` — partial
+            /// unbond for `less` wei.
+            case unbond(less: BigUInt)
+            /// `scheduleRevokeNomination(collator)` — full revoke.
+            /// `amount` is the full staked balance at scheduling time,
+            /// mirrored in `NominationScheduledRequests`.
+            case revoke(amount: BigUInt)
+        }
+
+        let action: Action
+        /// Era at which `executeNominationRequest` becomes valid.
+        /// Read from the scheduled request's `whenExecutable` field.
+        let executableAtEra: UInt32
+    }
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Model/ParachainAvnStakingConstants.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Model/ParachainAvnStakingConstants.swift
@@ -1,0 +1,59 @@
+import Foundation
+import BigInt
+
+/// Compile-time constants for the Energy Web X parachain-staking
+/// (AvN fork) integration.
+///
+/// The design goal is that almost nothing in this file is a hardcoded
+/// numeric value. Every meaningful quantity (commission, min stake,
+/// unbond delay, era length, active collator count, growth rewards)
+/// is queried live against the EWX chain via Nova's existing
+/// `PrimitiveConstantOperation` and `StorageRequestFactory` patterns.
+///
+/// The fallbacks below exist only so:
+/// (a) UI code can render a placeholder label before a live query
+///     completes, and
+/// (b) unit tests can construct fixture values without an online runtime.
+///
+/// Verified live against EWX mainnet (spec version 105, 2026-04-11)
+/// via `wss://public-rpc.mainnet.energywebx.com/`:
+///
+///   Pallet name                       ParachainStaking
+///   MinNominationPerCollator (const)  1000000000000000000 wei  (1 EWT)
+///   MaxNominationsPerNominator (const) 100
+///   RewardPaymentDelay (const)        2 eras
+///   ErasPerGrowthPeriod (const)       28 eras
+///   DefaultCollatorCommission (stor)  100000000 Perbill  (10%)
+///   Total staked (storage)            ~25.5M EWT
+///   Era length (storage)              7200 blocks  (~24 hours @ 12s)
+///   Delay (storage)                   2 eras
+enum ParachainAvnStakingConstants {
+    /// Pallet name as emitted by the EWX runtime metadata. Used when
+    /// constructing `StorageCodingPath`, `ConstantCodingPath`, and
+    /// `CallCodingPath` values. Matches Moonbeam's value but DO NOT
+    /// share code between the two integrations — the call names
+    /// inside the pallet differ.
+    static let palletName = "ParachainStaking"
+
+    /// Fallback minimum nomination in wei (1 EWT). The real value is
+    /// read from the `MinNominationPerCollator` runtime constant at
+    /// service init time. This fallback is used only if the metadata
+    /// query fails. Written as an integer literal so SwiftFormat won't
+    /// strip the type annotation into a force-unwrapped string literal
+    /// (`BigUInt("...")` resolves ambiguously between the optional
+    /// String init and the non-optional ExpressibleByStringLiteral init,
+    /// which breaks the build if the linter drops `: BigUInt`).
+    static let fallbackMinNominationWei: BigUInt = 1_000_000_000_000_000_000
+
+    /// Fallback scheduled-unbond delay in eras. The real value is read
+    /// from the `ParachainStaking.Delay` storage item. Exists so the
+    /// Start Staking info screen can render an unstaking-time label
+    /// before the storage read lands.
+    static let fallbackUnbondDelayEras: UInt32 = 2
+
+    /// Fallback era length in blocks. Real value is read from the
+    /// `ParachainStaking.Era` storage item (`length` field). EWX
+    /// configures this via `set_blocks_per_era` to 7200 blocks on
+    /// mainnet, which is ~24 hours at the typical 12-second block time.
+    static let fallbackEraBlocks: UInt32 = 7200
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnDurationOperationFactory.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnDurationOperationFactory.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Operation_iOS
+import SubstrateSdk
+
+/// Duration operation factory for Energy Web X staking.
+///
+/// EWX differences from Moonbeam:
+/// - Round info is at storage item "Era" (not "Round")
+/// - Unbond delay is a storage item "Delay" (u32 eras), not a
+///   runtime constant like Moonbeam's "DelegationBondLessDelay"
+final class ParachainAvnDurationOperationFactory: ParaStkDurationOperationFactoryProtocol {
+    let blockTimeOperationFactory: BlockTimeOperationFactoryProtocol
+    let storageRequestFactory: StorageRequestFactoryProtocol
+
+    init(
+        storageRequestFactory: StorageRequestFactoryProtocol,
+        blockTimeOperationFactory: BlockTimeOperationFactoryProtocol
+    ) {
+        self.storageRequestFactory = storageRequestFactory
+        self.blockTimeOperationFactory = blockTimeOperationFactory
+    }
+
+    func createDurationOperation(
+        from runtimeService: RuntimeCodingServiceProtocol,
+        connection: JSONRPCEngine,
+        blockTimeEstimationService: BlockTimeEstimationServiceProtocol
+    ) -> CompoundOperationWrapper<ParachainStakingDuration> {
+        let codingFactoryOperation = runtimeService.fetchCoderFactoryOperation()
+
+        let blockTimeWrapper = blockTimeOperationFactory.createBlockTimeOperation(
+            from: runtimeService,
+            blockTimeEstimationService: blockTimeEstimationService
+        )
+
+        // Query Era storage (EWX name for round info — same type as RoundInfo)
+        let eraWrapper: CompoundOperationWrapper<StorageResponse<ParachainStaking.RoundInfo>>
+        eraWrapper = storageRequestFactory.queryItem(
+            engine: connection,
+            factory: { try codingFactoryOperation.extractNoCancellableResultData() },
+            storagePath: ParachainAvn.eraPath
+        )
+        eraWrapper.addDependency(operations: [codingFactoryOperation])
+
+        // Query Delay storage (u32 — number of eras for unbond delay)
+        let delayWrapper: CompoundOperationWrapper<StorageResponse<StringScaleMapper<UInt32>>>
+        delayWrapper = storageRequestFactory.queryItem(
+            engine: connection,
+            factory: { try codingFactoryOperation.extractNoCancellableResultData() },
+            storagePath: ParachainAvn.delayPath
+        )
+        delayWrapper.addDependency(operations: [codingFactoryOperation])
+
+        let mapOperation = ClosureOperation<ParachainStakingDuration> {
+            let blockTime = try blockTimeWrapper.targetOperation.extractNoCancellableResultData()
+
+            let eraLength = try eraWrapper.targetOperation
+                .extractNoCancellableResultData().value?.length
+                ?? ParachainAvnStakingConstants.fallbackEraBlocks
+
+            let unbondDelayEras = try delayWrapper.targetOperation
+                .extractNoCancellableResultData().value?.value
+                ?? ParachainAvnStakingConstants.fallbackUnbondDelayEras
+
+            let blockTimeInterval = TimeInterval(blockTime).seconds
+            let roundDuration = TimeInterval(eraLength) * blockTimeInterval
+            let unstakingDuration = TimeInterval(unbondDelayEras) * roundDuration
+
+            return ParachainStakingDuration(
+                block: blockTimeInterval,
+                round: roundDuration,
+                unstaking: unstakingDuration
+            )
+        }
+
+        let dependencies = [codingFactoryOperation]
+            + eraWrapper.allOperations
+            + delayWrapper.allOperations
+            + blockTimeWrapper.allOperations
+
+        dependencies.forEach { mapOperation.addDependency($0) }
+
+        return CompoundOperationWrapper(
+            targetOperation: mapOperation,
+            dependencies: dependencies
+        )
+    }
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnLocalSubscriptionFactory.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnLocalSubscriptionFactory.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Operation_iOS
+
+/// Local subscription factory for Energy Web X staking.
+///
+/// Overrides the round (era) and commission storage paths to match
+/// EWX's AvN-fork naming (`Era` instead of `Round`,
+/// `DefaultCollatorCommission` instead of `CollatorCommission`).
+/// All other providers fall through to the base Moonbeam implementation
+/// since the storage item names and types match.
+final class ParachainAvnLocalSubscriptionFactory: SubstrateLocalSubscriptionFactory,
+    ParachainStakingLocalSubscriptionFactoryProtocol {
+    func getRoundProvider(
+        for chainId: ChainModel.Id
+    ) throws -> AnyDataProvider<ParachainStaking.DecodedRoundInfo> {
+        // EWX calls its round info "Era" (same shape as Moonbeam's "Round")
+        try getPlainProvider(for: chainId, storagePath: ParachainAvn.eraPath)
+    }
+
+    func getCollatorCommissionProvider(
+        for chainId: ChainModel.Id
+    ) throws -> AnyDataProvider<DecodedBigUInt> {
+        // EWX uses "DefaultCollatorCommission" (global, not per-collator)
+        try getPlainProvider(for: chainId, storagePath: ParachainAvn.defaultCollatorCommissionPath)
+    }
+
+    func getTotalIssuanceProvider(
+        for chainId: ChainModel.Id
+    ) throws -> AnyDataProvider<DecodedBigUInt> {
+        try getPlainProvider(for: chainId, storagePath: StorageCodingPath.totalIssuance)
+    }
+
+    func getInflationProvider(
+        for chainId: ChainModel.Id
+    ) throws -> AnyDataProvider<ParachainStaking.DecodedInflationConfig> {
+        // EWX does not have InflationConfig — this will return nil/empty
+        try getPlainProvider(for: chainId, storagePath: ParachainStaking.inflationConfigPath)
+    }
+
+    func getParachainBondProvider(
+        for chainId: ChainModel.Id
+    ) throws -> AnyDataProvider<ParachainStaking.DecodedParachainBondConfig> {
+        try getPlainProvider(for: chainId, storagePath: ParachainStaking.parachainBondInfoPath)
+    }
+
+    func getInflationDistributionInfoProvider(
+        for chainId: ChainModel.Id
+    ) throws -> AnyDataProvider<ParachainStaking.DecodedInflationDistributionInfo> {
+        try getPlainProvider(for: chainId, storagePath: ParachainStaking.inflationDistributionInfoPath)
+    }
+
+    func getDelegatorStateProvider(
+        for chainId: ChainModel.Id,
+        accountId: AccountId
+    ) throws -> AnyDataProvider<ParachainStaking.DecodedDelegator> {
+        // EWX uses "NominatorState" — same structure as Moonbeam's "DelegatorState"
+        try getAccountProvider(
+            for: chainId,
+            accountId: accountId,
+            storagePath: ParachainAvn.nominatorStatePath
+        )
+    }
+
+    func getScheduledRequestsProvider(
+        for chainId: ChainModel.Id,
+        delegatorId: AccountId
+    ) throws -> StreamableProvider<ParachainStaking.MappedScheduledRequest> {
+        // EWX uses "NominationScheduledRequests"
+        let localKey = try LocalStorageKeyFactory().createRestorableRecurrentKey(
+            from: ParachainAvn.nominationScheduledRequestsPath,
+            chainId: chainId,
+            items: [delegatorId]
+        )
+
+        if let provider = getProvider(for: localKey) as? StreamableProvider<ParachainStaking.MappedScheduledRequest> {
+            return provider
+        }
+
+        let source = EmptyStreamableSource<ParachainStaking.MappedScheduledRequest>()
+        let mapper = ParaStkScheduledRequestsMapper()
+        let filter = NSPredicate.filterStorageItemsBy(identifier: localKey)
+        let repository = storageFacade.createRepository(
+            filter: filter,
+            sortDescriptors: [],
+            mapper: AnyCoreDataMapper(mapper)
+        )
+
+        let observable = CoreDataContextObservable(
+            service: storageFacade.databaseService,
+            mapper: AnyCoreDataMapper(mapper),
+            predicate: { $0.identifier == localKey },
+            processingQueue: nil
+        )
+
+        observable.start { [weak self] error in
+            if let error = error {
+                self?.logger.error("Unexpected error \(error)")
+            }
+        }
+
+        let streamableProvider = StreamableProvider(
+            source: AnyStreamableSource(source),
+            repository: AnyDataProviderRepository(repository),
+            observable: AnyDataProviderRepositoryObservable(observable),
+            operationManager: operationManager
+        )
+
+        saveProvider(streamableProvider, for: localKey)
+
+        return streamableProvider
+    }
+
+    func getCandidateMetadataProvider(
+        for chainId: ChainModel.Id,
+        accountId: AccountId
+    ) throws -> AnyDataProvider<ParachainStaking.DecodedCandidateMetadata> {
+        // EWX and Moonbeam both call this "CandidateInfo"
+        try getAccountProvider(
+            for: chainId,
+            accountId: accountId,
+            storagePath: ParachainAvn.candidateInfoPath
+        )
+    }
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnNetworkInfoOperationFactory.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnNetworkInfoOperationFactory.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Operation_iOS
+import BigInt
+
+/// Network info operation factory for Energy Web X staking.
+///
+/// EWX differences from Moonbeam:
+/// - Min stake constant: "MinNominationPerCollator" (not "MinDelegatorStk"/"MinDelegation")
+/// - Max top nominations: "MaxTopNominationsPerCandidate" (not "MaxTopDelegationsPerCandidate")
+final class ParachainAvnNetworkInfoOperationFactory: ParaStkNetworkInfoOperationFactoryProtocol {
+    private func deriveMinimalStake(
+        from collatorsInfo: SelectedRoundCollators,
+        limitedBy maxDelegators: UInt32
+    ) -> BigUInt {
+        let allFull = collatorsInfo.collators.allSatisfy { collator in
+            collator.snapshot.delegations.count == maxDelegators
+        }
+
+        guard allFull else {
+            return BigUInt(0)
+        }
+
+        return collatorsInfo.collators.map {
+            $0.snapshot.delegations.last?.amount ?? BigUInt(0)
+        }.min() ?? BigUInt(0)
+    }
+
+    private func deriveActiveDelegatorsCount(
+        from collatorsInfo: SelectedRoundCollators
+    ) -> Int {
+        collatorsInfo.collators.reduce(into: Set<AccountId>()) { result, collator in
+            collator.snapshot.delegations.forEach { delegation in
+                result.insert(delegation.owner)
+            }
+        }.count
+    }
+
+    func networkStakingOperation(
+        for collatorService: ParachainStakingCollatorServiceProtocol,
+        rewardCalculatorService: CollatorStakingRewardCalculatorServiceProtocol,
+        runtimeService: RuntimeCodingServiceProtocol
+    ) -> CompoundOperationWrapper<ParachainStaking.NetworkInfo> {
+        let codingFactoryOperation = runtimeService.fetchCoderFactoryOperation()
+
+        // EWX uses MinNominationPerCollator (not MinDelegatorStk / MinDelegation)
+        let minStakeOperation: BaseOperation<BigUInt> = PrimitiveConstantOperation.operation(
+            for: ParachainAvn.minNominationPerCollator,
+            dependingOn: codingFactoryOperation
+        )
+
+        // EWX uses MaxTopNominationsPerCandidate (not MaxTopDelegationsPerCandidate)
+        let maxDelegatorsOperation: BaseOperation<UInt32> = PrimitiveConstantOperation.operation(
+            for: ParachainAvn.maxTopNominationsPerCandidate,
+            dependingOn: codingFactoryOperation
+        )
+
+        let constantsOperations = [minStakeOperation, maxDelegatorsOperation]
+        constantsOperations.forEach { $0.addDependency(codingFactoryOperation) }
+
+        let collatorsOperation = collatorService.fetchInfoOperation()
+        let rewardEngineOperation = rewardCalculatorService.fetchCalculatorOperation()
+
+        let mapOperation = ClosureOperation<ParachainStaking.NetworkInfo> {
+            let minStake = try minStakeOperation.extractNoCancellableResultData()
+            let maxDelegators = try maxDelegatorsOperation.extractNoCancellableResultData()
+            let collatorsInfo = try collatorsOperation.extractNoCancellableResultData()
+            let rewardEngine = try rewardEngineOperation.extractNoCancellableResultData()
+
+            let activeDelegatorsCount = self.deriveActiveDelegatorsCount(from: collatorsInfo)
+            let minDelegatorStake = self.deriveMinimalStake(from: collatorsInfo, limitedBy: maxDelegators)
+
+            return ParachainStaking.NetworkInfo(
+                totalStake: rewardEngine.totalStaked,
+                minStakeForRewards: minDelegatorStake,
+                minTechStake: minStake,
+                maxRewardableDelegators: maxDelegators,
+                activeDelegatorsCount: activeDelegatorsCount
+            )
+        }
+
+        let dependencies = [
+            codingFactoryOperation,
+            minStakeOperation,
+            maxDelegatorsOperation,
+            collatorsOperation,
+            rewardEngineOperation
+        ]
+
+        dependencies.forEach { mapOperation.addDependency($0) }
+
+        return CompoundOperationWrapper(targetOperation: mapOperation, dependencies: dependencies)
+    }
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnRemoteSubscriptionService.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnRemoteSubscriptionService.swift
@@ -1,0 +1,49 @@
+import Foundation
+import SubstrateSdk
+
+/// Remote subscription service for Energy Web X staking.
+///
+/// Subscribes to the EWX-specific storage paths: `Era` (not `Round`),
+/// `DefaultCollatorCommission` (not `CollatorCommission`), and
+/// `TotalIssuance`. EWX does not have `InflationConfig`,
+/// `InflationDistributionInfo`, or `ParachainBondInfo`, so those are
+/// omitted from the subscription.
+extension ParachainAvn {
+    final class StakingRemoteSubscriptionService: RemoteSubscriptionService,
+        StakingRemoteSubscriptionServiceProtocol {
+        private static let globalDataStoragePaths: [StorageCodingPath] = [
+            ParachainAvn.eraPath,
+            ParachainAvn.defaultCollatorCommissionPath,
+            StorageCodingPath.totalIssuance
+        ]
+
+        func attachToGlobalData(
+            for chainId: ChainModel.Id,
+            queue: DispatchQueue?,
+            closure: RemoteSubscriptionClosure?
+        ) -> UUID? {
+            attachToGlobalDataWithStoragePaths(
+                Self.globalDataStoragePaths,
+                chainId: chainId,
+                queue: queue,
+                closure: closure,
+                subscriptionHandlingFactory: nil
+            )
+        }
+
+        func detachFromGlobalData(
+            for subscriptionId: UUID,
+            chainId: ChainModel.Id,
+            queue: DispatchQueue?,
+            closure: RemoteSubscriptionClosure?
+        ) {
+            detachFromGlobalDataStoragePaths(
+                Self.globalDataStoragePaths,
+                subscriptionId: subscriptionId,
+                chainId: chainId,
+                queue: queue,
+                closure: closure
+            )
+        }
+    }
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnRewardCalculatorEngine.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnRewardCalculatorEngine.swift
@@ -1,0 +1,76 @@
+import Foundation
+import BigInt
+
+/// Reward calculator engine for Energy Web X staking.
+///
+/// EWX does not use Moonbeam's inflation-config model. Instead,
+/// APR is computed from the on-chain `Growth` storage which
+/// accumulates actual rewards per growth period:
+///
+///   APR = (totalStakerReward / totalStakeAccumulated)
+///         * (365 / numberOfAccumulations)
+///
+/// Commission is global (`DefaultCollatorCommission`), not
+/// per-collator. All collators receive the same commission rate.
+final class ParachainAvnRewardCalculatorEngine {
+    let annualApr: Decimal
+    let commission: Decimal
+    let totalStakedAmount: BigUInt
+    let selectedCollators: SelectedRoundCollators
+    let assetPrecision: Int16
+
+    init(
+        annualApr: Decimal,
+        commission: Decimal,
+        totalStakedAmount: BigUInt,
+        selectedCollators: SelectedRoundCollators,
+        assetPrecision: Int16
+    ) {
+        self.annualApr = annualApr
+        self.commission = commission
+        self.totalStakedAmount = totalStakedAmount
+        self.selectedCollators = selectedCollators
+        self.assetPrecision = assetPrecision
+    }
+
+    private lazy var averageStake: Decimal = {
+        let count = selectedCollators.collators.count
+        guard count > 0 else { return 0 }
+        let total = selectedCollators.collators.reduce(BigUInt(0)) { $0 + $1.snapshot.total }
+        return (Decimal.fromSubstrateAmount(total, precision: assetPrecision) ?? 0) / Decimal(count)
+    }()
+
+    private lazy var minStake: Decimal = {
+        guard let minTotal = selectedCollators.collators.min(
+            by: { $0.snapshot.total < $1.snapshot.total }
+        )?.snapshot.total else { return 0 }
+        return Decimal.fromSubstrateAmount(minTotal, precision: assetPrecision) ?? 0
+    }()
+}
+
+extension ParachainAvnRewardCalculatorEngine: CollatorStakingRewardCalculatorEngineProtocol {
+    var totalStaked: Balance { totalStakedAmount }
+
+    func calculateEarnings(
+        amount: Decimal,
+        collatorAccountId: AccountId,
+        period: CalculationPeriod
+    ) throws -> Decimal {
+        guard selectedCollators.collators.contains(where: { $0.accountId == collatorAccountId }) else {
+            throw CollatorStkRewardCalculatorEngineError.missingCollator(collatorAccountId)
+        }
+
+        let netApr = annualApr * (1 - commission)
+        let dailyReturn = netApr / CalculationPeriod.daysInYear
+        return amount * dailyReturn * Decimal(period.inDays)
+    }
+
+    func calculateMaxEarnings(
+        amount: Decimal,
+        period: CalculationPeriod
+    ) -> Decimal {
+        let netApr = annualApr * (1 - commission)
+        let dailyReturn = netApr / CalculationPeriod.daysInYear
+        return amount * dailyReturn * Decimal(period.inDays)
+    }
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnRewardCalculatorService.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnRewardCalculatorService.swift
@@ -1,0 +1,175 @@
+import Foundation
+import BigInt
+import SubstrateSdk
+import Operation_iOS
+
+/// Snapshot of the values needed to compute EWX staking APR.
+struct ParachainAvnRewardSnapshot {
+    let annualApr: Decimal
+    let commission: Decimal
+    let totalStaked: BigUInt
+}
+
+/// Reward calculator service for Energy Web X.
+///
+/// Fetches the `Growth` storage for the current growth period and
+/// computes APR from: (totalStakerReward / totalStakeAccumulated) *
+/// (365 / numberOfAccumulations). Falls back to the `Total` storage
+/// item and annual inflation constants if growth data is unavailable.
+final class ParachainAvnRewardCalculatorService: CollatorStakingRewardService<ParachainAvnRewardSnapshot> {
+    let chainId: ChainModel.Id
+    let collatorsService: ParachainStakingCollatorServiceProtocol
+    let connection: JSONRPCEngine
+    let runtimeCodingService: RuntimeProviderProtocol
+    let operationQueue: OperationQueue
+    let assetPrecision: Int16
+
+    private var fetchCancellable = CancellableCallStore()
+
+    init(
+        chainId: ChainModel.Id,
+        collatorsService: ParachainStakingCollatorServiceProtocol,
+        connection: JSONRPCEngine,
+        runtimeCodingService: RuntimeProviderProtocol,
+        operationQueue: OperationQueue,
+        assetPrecision: Int16,
+        eventCenter: EventCenterProtocol,
+        logger: LoggerProtocol
+    ) {
+        self.chainId = chainId
+        self.collatorsService = collatorsService
+        self.connection = connection
+        self.runtimeCodingService = runtimeCodingService
+        self.operationQueue = operationQueue
+        self.assetPrecision = assetPrecision
+
+        let syncQueue = DispatchQueue(
+            label: "com.novawallet.parachainavn.rewcalculator.\(UUID().uuidString)",
+            qos: .userInitiated
+        )
+
+        super.init(eventCenter: eventCenter, logger: logger, syncQueue: syncQueue)
+    }
+
+    override func start() {
+        NSLog("[EWT-DEBUG] ParachainAvnRewardCalculatorService start() called for chain %@", chainId)
+        fetchGrowthData()
+    }
+
+    override func stop() {
+        fetchCancellable.cancel()
+    }
+
+    override func deliver(snapshot: ParachainAvnRewardSnapshot, to pendingRequest: PendingRequest) {
+        let collatorsOperation = collatorsService.fetchInfoOperation()
+
+        let assetPrecision = self.assetPrecision
+
+        let mapOperation = ClosureOperation<CollatorStakingRewardCalculatorEngineProtocol> {
+            let selectedCollators = try collatorsOperation.extractNoCancellableResultData()
+
+            return ParachainAvnRewardCalculatorEngine(
+                annualApr: snapshot.annualApr,
+                commission: snapshot.commission,
+                totalStakedAmount: snapshot.totalStaked,
+                selectedCollators: selectedCollators,
+                assetPrecision: assetPrecision
+            )
+        }
+
+        mapOperation.addDependency(collatorsOperation)
+
+        mapOperation.completionBlock = {
+            dispatchInQueueWhenPossible(pendingRequest.queue) {
+                switch mapOperation.result {
+                case let .success(calculator):
+                    pendingRequest.resultClosure(calculator)
+                case let .failure(error):
+                    self.logger.error("ParachainAvn reward calculator error: \(error)")
+                case .none:
+                    self.logger.warning("ParachainAvn reward calculator cancelled")
+                }
+            }
+        }
+
+        operationQueue.addOperations([collatorsOperation, mapOperation], waitUntilFinished: false)
+    }
+
+    // MARK: - Private
+
+    private func fetchGrowthData() {
+        fetchCancellable.cancel()
+
+        let requestFactory = StorageRequestFactory(
+            remoteFactory: StorageKeyFactory(),
+            operationManager: OperationManager(operationQueue: operationQueue),
+            timeout: JSONRPCTimeout.hour
+        )
+
+        let codingFactoryOperation = runtimeCodingService.fetchCoderFactoryOperation()
+
+        // Query total staked (u128 → BigUInt)
+        let totalWrapper: CompoundOperationWrapper<StorageResponse<StringScaleMapper<BigUInt>>>
+        totalWrapper = requestFactory.queryItem(
+            engine: connection,
+            factory: { try codingFactoryOperation.extractNoCancellableResultData() },
+            storagePath: ParachainAvn.totalPath,
+            at: nil
+        )
+        totalWrapper.addDependency(operations: [codingFactoryOperation])
+
+        // NOTE: DefaultCollatorCommission is CommissionSetting (struct),
+        // not a bare Perbill. Use the known mainnet value (10%) directly.
+        let commissionPerbill: BigUInt = 100_000_000
+
+        let mergeOperation = ClosureOperation<ParachainAvnRewardSnapshot> {
+            // Use try? so a decode failure still produces a usable snapshot
+            let totalResponse = try? totalWrapper.targetOperation.extractNoCancellableResultData()
+            let totalStaked = totalResponse?.value?.value ?? 0
+
+            let commission = Decimal.fromSubstratePerbill(value: commissionPerbill) ?? Decimal(0.10)
+
+            // Estimate APR from known EWX economics:
+            // 2M EWT annual growth rewards / total staked EWT
+            let precision: Int16 = 18
+            let totalStakedDecimal = Decimal.fromSubstrateAmount(
+                totalStaked, precision: precision
+            ) ?? 1
+
+            let annualRewards: Decimal = 2_000_000
+            let grossApr = totalStakedDecimal > 0 ? annualRewards / totalStakedDecimal : 0
+
+            return ParachainAvnRewardSnapshot(
+                annualApr: grossApr,
+                commission: commission,
+                totalStaked: totalStaked
+            )
+        }
+
+        mergeOperation.addDependency(totalWrapper.targetOperation)
+
+        let allDependencies = [codingFactoryOperation] + totalWrapper.allOperations
+        let fullWrapper = CompoundOperationWrapper(
+            targetOperation: mergeOperation,
+            dependencies: allDependencies
+        )
+
+        executeCancellable(
+            wrapper: fullWrapper,
+            inOperationQueue: operationQueue,
+            backingCallIn: fetchCancellable,
+            runningCallbackIn: syncQueue
+        ) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case let .success(snapshot):
+                let apr = NSDecimalNumber(decimal: snapshot.annualApr).doubleValue
+                NSLog("[EWT-DEBUG] Reward snapshot: apr=%.4f total=%@", apr, snapshot.totalStaked.description)
+                self.updateSnapshotAndNotify(snapshot, chainId: self.chainId)
+            case let .failure(error):
+                NSLog("[EWT-DEBUG] Reward fetch FAILED: %@", error.localizedDescription)
+                self.logger.error("ParachainAvn growth data fetch error: \(error)")
+            }
+        }
+    }
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnRewardCalculatorService.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Service/ParachainAvnRewardCalculatorService.swift
@@ -12,11 +12,19 @@ struct ParachainAvnRewardSnapshot {
 
 /// Reward calculator service for Energy Web X.
 ///
-/// Fetches the `Growth` storage for the current growth period and
-/// computes APR from: (totalStakerReward / totalStakeAccumulated) *
-/// (365 / numberOfAccumulations). Falls back to the `Total` storage
-/// item and annual inflation constants if growth data is unavailable.
+/// Fetches the `Growth` storage for the latest completed growth period
+/// and computes APR from
+/// `(totalStakerReward / totalStakeAccumulated) * (365 / numberOfAccumulations)`.
+/// Falls back to a 2M EWT annual-rewards estimate divided by total
+/// staked when Growth data isn't available (e.g. before period 1).
 final class ParachainAvnRewardCalculatorService: CollatorStakingRewardService<ParachainAvnRewardSnapshot> {
+    /// EWX runs one era per day, so a year = 365 accumulation eras.
+    private static let erasPerYear: Decimal = 365
+    /// Last-resort APR estimate when Growth storage hasn't accumulated yet.
+    private static let fallbackAnnualRewardsEwt: Decimal = 2_000_000
+    /// Last-resort commission when `DefaultCollatorCommission` can't be decoded.
+    private static let fallbackCommissionPerbill: BigUInt = 100_000_000
+
     let chainId: ChainModel.Id
     let collatorsService: ParachainStakingCollatorServiceProtocol
     let connection: JSONRPCEngine
@@ -52,7 +60,6 @@ final class ParachainAvnRewardCalculatorService: CollatorStakingRewardService<Pa
     }
 
     override func start() {
-        NSLog("[EWT-DEBUG] ParachainAvnRewardCalculatorService start() called for chain %@", chainId)
         fetchGrowthData()
     }
 
@@ -100,55 +107,56 @@ final class ParachainAvnRewardCalculatorService: CollatorStakingRewardService<Pa
     private func fetchGrowthData() {
         fetchCancellable.cancel()
 
+        let operationManager = OperationManager(operationQueue: operationQueue)
+
         let requestFactory = StorageRequestFactory(
             remoteFactory: StorageKeyFactory(),
-            operationManager: OperationManager(operationQueue: operationQueue),
+            operationManager: operationManager,
             timeout: JSONRPCTimeout.hour
         )
 
         let codingFactoryOperation = runtimeCodingService.fetchCoderFactoryOperation()
 
-        // Query total staked (u128 → BigUInt)
-        let totalWrapper: CompoundOperationWrapper<StorageResponse<StringScaleMapper<BigUInt>>>
-        totalWrapper = requestFactory.queryItem(
-            engine: connection,
-            factory: { try codingFactoryOperation.extractNoCancellableResultData() },
+        let totalWrapper = makeQueryWrapper(
+            requestFactory: requestFactory,
+            codingFactoryOperation: codingFactoryOperation,
             storagePath: ParachainAvn.totalPath,
-            at: nil
+            type: StringScaleMapper<BigUInt>.self
         )
-        totalWrapper.addDependency(operations: [codingFactoryOperation])
+        let commissionWrapper = makeQueryWrapper(
+            requestFactory: requestFactory,
+            codingFactoryOperation: codingFactoryOperation,
+            storagePath: ParachainAvn.defaultCollatorCommissionPath,
+            type: ParachainAvn.CommissionSetting.self
+        )
+        let growthPeriodWrapper = makeQueryWrapper(
+            requestFactory: requestFactory,
+            codingFactoryOperation: codingFactoryOperation,
+            storagePath: ParachainAvn.growthPeriodPath,
+            type: ParachainAvn.GrowthPeriod.self
+        )
+        let growthInfoWrapper = makeGrowthInfoWrapper(
+            requestFactory: requestFactory,
+            operationManager: operationManager,
+            codingFactoryOperation: codingFactoryOperation,
+            growthPeriodWrapper: growthPeriodWrapper
+        )
 
-        // NOTE: DefaultCollatorCommission is CommissionSetting (struct),
-        // not a bare Perbill. Use the known mainnet value (10%) directly.
-        let commissionPerbill: BigUInt = 100_000_000
-
-        let mergeOperation = ClosureOperation<ParachainAvnRewardSnapshot> {
-            // Use try? so a decode failure still produces a usable snapshot
-            let totalResponse = try? totalWrapper.targetOperation.extractNoCancellableResultData()
-            let totalStaked = totalResponse?.value?.value ?? 0
-
-            let commission = Decimal.fromSubstratePerbill(value: commissionPerbill) ?? Decimal(0.10)
-
-            // Estimate APR from known EWX economics:
-            // 2M EWT annual growth rewards / total staked EWT
-            let precision: Int16 = 18
-            let totalStakedDecimal = Decimal.fromSubstrateAmount(
-                totalStaked, precision: precision
-            ) ?? 1
-
-            let annualRewards: Decimal = 2_000_000
-            let grossApr = totalStakedDecimal > 0 ? annualRewards / totalStakedDecimal : 0
-
-            return ParachainAvnRewardSnapshot(
-                annualApr: grossApr,
-                commission: commission,
-                totalStaked: totalStaked
-            )
-        }
+        let mergeOperation = makeMergeOperation(
+            totalWrapper: totalWrapper,
+            commissionWrapper: commissionWrapper,
+            growthInfoWrapper: growthInfoWrapper
+        )
 
         mergeOperation.addDependency(totalWrapper.targetOperation)
+        mergeOperation.addDependency(commissionWrapper.targetOperation)
+        mergeOperation.addDependency(growthInfoWrapper.targetOperation)
 
-        let allDependencies = [codingFactoryOperation] + totalWrapper.allOperations
+        let allDependencies = [codingFactoryOperation]
+            + totalWrapper.allOperations
+            + commissionWrapper.allOperations
+            + growthPeriodWrapper.allOperations
+            + growthInfoWrapper.allOperations
         let fullWrapper = CompoundOperationWrapper(
             targetOperation: mergeOperation,
             dependencies: allDependencies
@@ -163,13 +171,132 @@ final class ParachainAvnRewardCalculatorService: CollatorStakingRewardService<Pa
             guard let self = self else { return }
             switch result {
             case let .success(snapshot):
-                let apr = NSDecimalNumber(decimal: snapshot.annualApr).doubleValue
-                NSLog("[EWT-DEBUG] Reward snapshot: apr=%.4f total=%@", apr, snapshot.totalStaked.description)
                 self.updateSnapshotAndNotify(snapshot, chainId: self.chainId)
             case let .failure(error):
-                NSLog("[EWT-DEBUG] Reward fetch FAILED: %@", error.localizedDescription)
                 self.logger.error("ParachainAvn growth data fetch error: \(error)")
             }
         }
+    }
+
+    private func makeQueryWrapper<T: Decodable>(
+        requestFactory: StorageRequestFactoryProtocol,
+        codingFactoryOperation: BaseOperation<RuntimeCoderFactoryProtocol>,
+        storagePath: StorageCodingPath,
+        type _: T.Type
+    ) -> CompoundOperationWrapper<StorageResponse<T>> {
+        let wrapper: CompoundOperationWrapper<StorageResponse<T>> = requestFactory.queryItem(
+            engine: connection,
+            factory: { try codingFactoryOperation.extractNoCancellableResultData() },
+            storagePath: storagePath,
+            at: nil
+        )
+        wrapper.addDependency(operations: [codingFactoryOperation])
+        return wrapper
+    }
+
+    /// Query `Growth(period.index - 1)` once `GrowthPeriod` is resolved.
+    /// We use the previous (completed) period because the current one is
+    /// still accumulating and would understate APR.
+    private func makeGrowthInfoWrapper(
+        requestFactory: StorageRequestFactoryProtocol,
+        operationManager: OperationManagerProtocol,
+        codingFactoryOperation: BaseOperation<RuntimeCoderFactoryProtocol>,
+        growthPeriodWrapper: CompoundOperationWrapper<StorageResponse<ParachainAvn.GrowthPeriod>>
+    ) -> CompoundOperationWrapper<[StorageResponse<ParachainAvn.GrowthInfo>]> {
+        let connection = self.connection
+        let wrapper: CompoundOperationWrapper<[StorageResponse<ParachainAvn.GrowthInfo>]>
+        wrapper = OperationCombiningService.compoundNonOptionalWrapper(
+            operationManager: operationManager
+        ) {
+            let codingFactory = try codingFactoryOperation.extractNoCancellableResultData()
+            let periodResponse = try growthPeriodWrapper.targetOperation.extractNoCancellableResultData()
+
+            guard let period = periodResponse.value, period.index > 0 else {
+                let emptyOp = ClosureOperation<[StorageResponse<ParachainAvn.GrowthInfo>]> { [] }
+                return CompoundOperationWrapper(targetOperation: emptyOp)
+            }
+
+            let prevIndex = period.index - 1
+
+            return requestFactory.queryItems(
+                engine: connection,
+                keyParams: { [StringScaleMapper(value: UInt32(prevIndex))] },
+                factory: { codingFactory },
+                storagePath: ParachainAvn.growthPath,
+                at: nil
+            )
+        }
+        wrapper.addDependency(operations: [
+            growthPeriodWrapper.targetOperation,
+            codingFactoryOperation
+        ])
+        return wrapper
+    }
+
+    private func makeMergeOperation(
+        totalWrapper: CompoundOperationWrapper<StorageResponse<StringScaleMapper<BigUInt>>>,
+        commissionWrapper: CompoundOperationWrapper<StorageResponse<ParachainAvn.CommissionSetting>>,
+        growthInfoWrapper: CompoundOperationWrapper<[StorageResponse<ParachainAvn.GrowthInfo>]>
+    ) -> ClosureOperation<ParachainAvnRewardSnapshot> {
+        let assetPrecision = self.assetPrecision
+        return ClosureOperation<ParachainAvnRewardSnapshot> {
+            let totalResponse = try? totalWrapper.targetOperation.extractNoCancellableResultData()
+            let totalStaked = totalResponse?.value?.value ?? 0
+
+            let commissionResponse = try? commissionWrapper.targetOperation.extractNoCancellableResultData()
+            let commissionPerbill = commissionResponse?.value?.current ?? Self.fallbackCommissionPerbill
+            let commission = Decimal.fromSubstratePerbill(value: commissionPerbill) ?? Decimal(0.10)
+
+            // Use 0 (not 1) so a conversion failure surfaces as 0% APR via
+            // the `totalStakedDecimal > 0` guard inside `computeApr`. With
+            // a `?? 1` fallback a precision misconfig would compute APR as
+            // `2_000_000 / 1 = 200_000_000%`.
+            let totalStakedDecimal = Decimal.fromSubstrateAmount(
+                totalStaked, precision: assetPrecision
+            ) ?? 0
+
+            let grossApr = Self.computeApr(
+                growthInfoResponses: try? growthInfoWrapper.targetOperation.extractNoCancellableResultData(),
+                totalStakedDecimal: totalStakedDecimal,
+                assetPrecision: assetPrecision
+            )
+
+            return ParachainAvnRewardSnapshot(
+                annualApr: grossApr,
+                commission: commission,
+                totalStaked: totalStaked
+            )
+        }
+    }
+
+    private static func computeApr(
+        growthInfoResponses: [StorageResponse<ParachainAvn.GrowthInfo>]?,
+        totalStakedDecimal: Decimal,
+        assetPrecision: Int16
+    ) -> Decimal {
+        let fallback: Decimal = totalStakedDecimal > 0
+            ? fallbackAnnualRewardsEwt / totalStakedDecimal
+            : 0
+
+        guard
+            let growthInfo = growthInfoResponses?.first?.value,
+            growthInfo.numberOfAccumulations > 0,
+            growthInfo.totalStakeAccumulated > 0
+        else {
+            return fallback
+        }
+
+        let stakerRewardDecimal = Decimal.fromSubstrateAmount(
+            growthInfo.totalStakerReward, precision: assetPrecision
+        ) ?? 0
+        let stakeAccumulatedDecimal = Decimal.fromSubstrateAmount(
+            growthInfo.totalStakeAccumulated, precision: assetPrecision
+        ) ?? 0
+
+        guard stakeAccumulatedDecimal > 0 else { return fallback }
+
+        let perPeriod = stakerRewardDecimal / stakeAccumulatedDecimal
+        let accumulations = Decimal(growthInfo.numberOfAccumulations)
+        return accumulations > 0 ? perPeriod * (erasPerYear / accumulations) : fallback
     }
 }

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Tests/ParachainAvnCallsTests.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Tests/ParachainAvnCallsTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+import BigInt
+@testable import novawallet
+
+/// Verifies that every `ParachainAvn` call struct emits the exact
+/// SCALE call name the Energy Web X runtime expects. EWX inherits
+/// Aventus's pre-rename API, not Moonbeam's post-rename one — if any
+/// of these tests break because someone "unified" the call types with
+/// `ParachainStaking.*Call` in `ParaStkCalls.swift`, the resulting
+/// extrinsics will be rejected on-chain with an invalid-call decoding
+/// error.
+///
+/// Call names verified against EWX mainnet metadata v15 (spec version
+/// 105, 2026-04-11).
+final class ParachainAvnCallsTests: XCTestCase {
+    private let stubAccountId = AccountId(repeating: 0xAB, count: 32)
+    private let otherStubAccountId = AccountId(repeating: 0xCD, count: 32)
+    private let oneEwt: BigUInt = 1_000_000_000_000_000_000
+
+    func test_nominateCall_usesAvnCallName() {
+        let call = ParachainAvn.NominateCall(
+            candidate: stubAccountId,
+            amount: oneEwt,
+            candidateNominationCount: 42,
+            nominationCount: 0
+        )
+        let runtimeCall = call.runtimeCall
+        XCTAssertEqual(runtimeCall.moduleName, "ParachainStaking")
+        XCTAssertEqual(runtimeCall.callName, "nominate")
+    }
+
+    func test_bondExtraCall_usesAvnCallName() {
+        let call = ParachainAvn.BondExtraCall(candidate: stubAccountId, more: oneEwt)
+        XCTAssertEqual(call.runtimeCall.moduleName, "ParachainStaking")
+        XCTAssertEqual(call.runtimeCall.callName, "bond_extra")
+    }
+
+    func test_scheduleNominatorUnbondCall_usesAvnCallName() {
+        let call = ParachainAvn.ScheduleNominatorUnbondCall(
+            candidate: stubAccountId,
+            less: oneEwt
+        )
+        XCTAssertEqual(call.runtimeCall.callName, "schedule_nominator_unbond")
+    }
+
+    func test_scheduleRevokeNominationCall_usesAvnCallName() {
+        let call = ParachainAvn.ScheduleRevokeNominationCall(collator: stubAccountId)
+        XCTAssertEqual(call.runtimeCall.callName, "schedule_revoke_nomination")
+    }
+
+    func test_executeNominationRequestCall_usesAvnCallName() {
+        let call = ParachainAvn.ExecuteNominationRequestCall(
+            nominator: stubAccountId,
+            candidate: otherStubAccountId
+        )
+        XCTAssertEqual(call.runtimeCall.callName, "execute_nomination_request")
+    }
+
+    func test_cancelNominationRequestCall_usesAvnCallName() {
+        let call = ParachainAvn.CancelNominationRequestCall(candidate: stubAccountId)
+        XCTAssertEqual(call.runtimeCall.callName, "cancel_nomination_request")
+    }
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Types/ParachainAvn+ConstantPaths.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Types/ParachainAvn+ConstantPaths.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Runtime constant paths for Energy Web X's `ParachainStaking` pallet.
+/// Verified live against EWX mainnet runtime metadata v15 (spec version
+/// 105, 2026-04-11).
+///
+/// All of these are `ConstantCodingPath` values intended to be fed into
+/// Nova's existing `PrimitiveConstantOperation.operation(for:dependingOn:)`
+/// at service init time so the real values from chain metadata are used,
+/// not hardcoded Swift literals.
+extension ParachainAvn {
+    /// `u128` — minimum nomination a user can place on a single collator.
+    /// Current value: 1 EWT (10^18 wei). Used to gate the stake-amount
+    /// input field.
+    static var minNominationPerCollator: ConstantCodingPath {
+        ConstantCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            constantName: "MinNominationPerCollator"
+        )
+    }
+
+    /// `u32` — maximum number of distinct collators a single user may
+    /// nominate. Current value: 100.
+    static var maxNominationsPerNominator: ConstantCodingPath {
+        ConstantCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            constantName: "MaxNominationsPerNominator"
+        )
+    }
+
+    /// `u32` — number of eras that must pass after a reward period ends
+    /// before the payout is released. Current value: 2.
+    static var rewardPaymentDelay: ConstantCodingPath {
+        ConstantCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            constantName: "RewardPaymentDelay"
+        )
+    }
+
+    /// `u32` — length of each growth period in eras. Rewards accumulate
+    /// for this many eras before being distributed. Current value: 28.
+    static var erasPerGrowthPeriod: ConstantCodingPath {
+        ConstantCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            constantName: "ErasPerGrowthPeriod"
+        )
+    }
+
+    /// `u32` — maximum number of top (counted) nominations per collator.
+    /// Current value: 300. Used to pre-validate the
+    /// `candidate_nomination_count` arg to `nominate`.
+    static var maxTopNominationsPerCandidate: ConstantCodingPath {
+        ConstantCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            constantName: "MaxTopNominationsPerCandidate"
+        )
+    }
+}

--- a/novawallet/Modules/Staking/ParachainAvnStaking/Types/ParachainAvn+StoragePaths.swift
+++ b/novawallet/Modules/Staking/ParachainAvnStaking/Types/ParachainAvn+StoragePaths.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// Storage item paths for Energy Web X's `ParachainStaking` pallet
+/// (AvN fork). Verified live against EWX mainnet runtime metadata v15
+/// (spec version 105, 2026-04-11).
+///
+/// These paths are DELIBERATELY separate from
+/// `StorageCodingPath+ParachainStaking.swift` (the Moonbeam variant)
+/// even though the pallet string matches and some item names overlap.
+/// Isolating them makes the ownership explicit and keeps ParachainAvn
+/// from accidentally depending on Moonbeam types.
+extension ParachainAvn {
+    /// `Vec<Bond>` — all registered candidates and their self-bond.
+    /// Shape per entry: `{ owner: AccountId, amount: u128 }`.
+    static var candidatePoolPath: StorageCodingPath {
+        StorageCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            itemName: "CandidatePool"
+        )
+    }
+
+    /// `Map<AccountId, CandidateMetadata>` — per-candidate detail:
+    /// `bond`, `nominationCount`, `totalCounted`,
+    /// `lowestTopNominationAmount`, `topCapacity`, `status`, etc.
+    static var candidateInfoPath: StorageCodingPath {
+        StorageCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            itemName: "CandidateInfo"
+        )
+    }
+
+    /// `Vec<AccountId>` — the collator set elected for the current era.
+    static var selectedCandidatesPath: StorageCodingPath {
+        StorageCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            itemName: "SelectedCandidates"
+        )
+    }
+
+    /// `u32` — maximum active collator slots. Currently 20 on mainnet.
+    static var totalSelectedPath: StorageCodingPath {
+        StorageCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            itemName: "TotalSelected"
+        )
+    }
+
+    /// `u128` — total staked amount across all candidates + nominators.
+    static var totalPath: StorageCodingPath {
+        StorageCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            itemName: "Total"
+        )
+    }
+
+    /// `EraInfo` — current era number, first block, and length.
+    /// Shape: `{ current: u32, first: u64, length: u32 }`.
+    static var eraPath: StorageCodingPath {
+        StorageCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            itemName: "Era"
+        )
+    }
+
+    /// `u32` — scheduled-unbond / revoke delay in eras. Currently 2.
+    /// Stored (not a runtime constant) so governance can adjust via
+    /// `set_admin_setting`.
+    static var delayPath: StorageCodingPath {
+        StorageCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            itemName: "Delay"
+        )
+    }
+
+    /// `CommissionSetting` — global collator commission as Perbill.
+    /// Shape: `{ current: Perbill, scheduled: Option<Perbill> }`.
+    /// Currently 10% (100_000_000 Perbill) on mainnet.
+    static var defaultCollatorCommissionPath: StorageCodingPath {
+        StorageCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            itemName: "DefaultCollatorCommission"
+        )
+    }
+
+    /// `Map<u32, GrowthInfo>` — reward accumulation per growth period.
+    /// Shape per entry:
+    /// `{ numberOfAccumulations: u32, totalStakeAccumulated: u128,
+    ///    totalStakerReward: u128, totalPoints: u32,
+    ///    collatorScores: Vec<CollatorScore>, txId, triggered }`.
+    /// Used for live APR estimation.
+    static var growthPath: StorageCodingPath {
+        StorageCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            itemName: "Growth"
+        )
+    }
+
+    /// `{ startEraIndex: u32, index: u32 }` — current growth period.
+    static var growthPeriodPath: StorageCodingPath {
+        StorageCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            itemName: "GrowthPeriod"
+        )
+    }
+
+    /// `Map<AccountId, NominatorState>` — per-user delegation list
+    /// and amounts. Used for "your position" rendering.
+    static var nominatorStatePath: StorageCodingPath {
+        StorageCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            itemName: "NominatorState"
+        )
+    }
+
+    /// `Map<AccountId, Vec<ScheduledRequest>>` — pending unbond / revoke
+    /// requests keyed by candidate.
+    static var nominationScheduledRequestsPath: StorageCodingPath {
+        StorageCodingPath(
+            moduleName: ParachainAvnStakingConstants.palletName,
+            itemName: "NominationScheduledRequests"
+        )
+    }
+}

--- a/novawallet/Modules/Staking/Services/EraValidatorsService/ParachainStaking/ParachainStakingCollatorService.swift
+++ b/novawallet/Modules/Staking/Services/EraValidatorsService/ParachainStaking/ParachainStakingCollatorService.swift
@@ -48,7 +48,8 @@ final class ParachainStakingCollatorService {
         providerFactory: ParachainStakingLocalSubscriptionFactoryProtocol,
         operationQueue: OperationQueue,
         eventCenter: EventCenterProtocol,
-        logger: LoggerProtocol
+        logger: LoggerProtocol,
+        defaultCommission: BigUInt? = nil
     ) {
         self.chainId = chainId
         self.storageFacade = storageFacade
@@ -58,6 +59,7 @@ final class ParachainStakingCollatorService {
         self.operationQueue = operationQueue
         self.eventCenter = eventCenter
         self.logger = logger
+        collatorCommission = defaultCommission
     }
 
     func didReceiveSnapshot(_ snapshot: SelectedRoundCollators) {
@@ -165,13 +167,18 @@ final class ParachainStakingCollatorService {
         updateClosure = { [weak self] changes in
             let value = changes.reduceToLastChange()
 
-            let oldCollatorCommission = self?.collatorCommission
-            self?.collatorCommission = value?.item?.value
+            // Only update if decoded value is non-nil. On chains where the
+            // storage type doesn't match (e.g. EWX CommissionSetting struct),
+            // the decoder returns nil — keep the existing/default value.
+            guard let newCommission = value?.item?.value else {
+                return
+            }
 
-            if
-                let collatorCommission = self?.collatorCommission,
-                oldCollatorCommission != collatorCommission {
-                self?.didUpdateCollatorCommission(collatorCommission)
+            let oldCollatorCommission = self?.collatorCommission
+            self?.collatorCommission = newCommission
+
+            if oldCollatorCommission != newCommission {
+                self?.didUpdateCollatorCommission(newCommission)
             }
         }
 

--- a/novawallet/Modules/Staking/Services/ParachainStakingServiceFactory.swift
+++ b/novawallet/Modules/Staking/Services/ParachainStakingServiceFactory.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BigInt
 import Operation_iOS
 
 protocol ParachainStakingServiceFactoryProtocol {
@@ -18,6 +19,7 @@ protocol ParachainStakingServiceFactoryProtocol {
 
 final class ParachainStakingServiceFactory: CollatorStakingServiceFactory, ParachainStakingServiceFactoryProtocol {
     let stakingProviderFactory: ParachainStakingLocalSubscriptionFactoryProtocol
+    let defaultCollatorCommission: BigUInt?
 
     init(
         stakingProviderFactory: ParachainStakingLocalSubscriptionFactoryProtocol,
@@ -25,9 +27,11 @@ final class ParachainStakingServiceFactory: CollatorStakingServiceFactory, Parac
         storageFacade: StorageFacadeProtocol,
         eventCenter: EventCenterProtocol,
         operationQueue: OperationQueue,
-        logger: LoggerProtocol
+        logger: LoggerProtocol,
+        defaultCollatorCommission: BigUInt? = nil
     ) {
         self.stakingProviderFactory = stakingProviderFactory
+        self.defaultCollatorCommission = defaultCollatorCommission
 
         super.init(
             chainRegisty: chainRegisty,
@@ -57,7 +61,8 @@ final class ParachainStakingServiceFactory: CollatorStakingServiceFactory, Parac
             providerFactory: stakingProviderFactory,
             operationQueue: operationQueue,
             eventCenter: eventCenter,
-            logger: logger
+            logger: logger,
+            defaultCommission: defaultCollatorCommission
         )
     }
 
@@ -87,6 +92,17 @@ final class ParachainStakingServiceFactory: CollatorStakingServiceFactory, Parac
                 connection: connection,
                 runtimeCodingService: runtimeService,
                 repositoryFactory: repositoryFactory,
+                operationQueue: operationQueue,
+                assetPrecision: assetPrecision,
+                eventCenter: eventCenter,
+                logger: logger
+            )
+        case .parachainAvn:
+            return ParachainAvnRewardCalculatorService(
+                chainId: chainId,
+                collatorsService: collatorService,
+                connection: connection,
+                runtimeCodingService: runtimeService,
                 operationQueue: operationQueue,
                 assetPrecision: assetPrecision,
                 eventCenter: eventCenter,

--- a/novawallet/Modules/Staking/StakingMain/Parachain/StakingMainPresenterFactory+ParachainAvn.swift
+++ b/novawallet/Modules/Staking/StakingMain/Parachain/StakingMainPresenterFactory+ParachainAvn.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Operation_iOS
+import Foundation_iOS
+import SubstrateSdk
+
+extension StakingMainPresenterFactory {
+    func createParachainAvnPresenter(
+        for stakingOption: Multistaking.ChainAssetOption,
+        view: StakingMainViewProtocol
+    ) -> StakingParachainPresenter? {
+        guard let sharedState = try? sharedStateFactory.createParachainAvn(for: stakingOption) else {
+            return nil
+        }
+
+        guard let interactor = createParachainAvnInteractor(state: sharedState),
+              let currencyManager = CurrencyManager.shared else {
+            return nil
+        }
+
+        let wireframe = StakingParachainWireframe(state: sharedState)
+
+        let priceAssetInfoFactory = PriceAssetInfoFactory(currencyManager: currencyManager)
+        let networkInfoViewModelFactory = CollatorStkNetworkInfoViewModelFactory(
+            priceAssetInfoFactory: priceAssetInfoFactory
+        )
+        let stateViewModelFactory = ParaStkStateViewModelFactory(priceAssetInfoFactory: priceAssetInfoFactory)
+
+        let presenter = StakingParachainPresenter(
+            interactor: interactor,
+            wireframe: wireframe,
+            networkInfoViewModelFactory: networkInfoViewModelFactory,
+            stateViewModelFactory: stateViewModelFactory,
+            priceAssetInfoFactory: priceAssetInfoFactory,
+            localizationManager: LocalizationManager.shared,
+            logger: Logger.shared
+        )
+
+        presenter.view = view
+        interactor.presenter = presenter
+
+        return presenter
+    }
+
+    private func createParachainAvnInteractor(
+        state: ParachainStakingSharedStateProtocol
+    ) -> StakingParachainInteractor? {
+        let chainAsset = state.stakingOption.chainAsset
+
+        guard
+            let currencyManager = CurrencyManager.shared,
+            let connection = state.chainRegistry.getConnection(for: chainAsset.chain.chainId),
+            let runtimeProvider = state.chainRegistry.getRuntimeProvider(for: chainAsset.chain.chainId) else {
+            return nil
+        }
+
+        let operationQueue = OperationManagerFacade.sharedDefaultQueue
+        let operationManager = OperationManager(operationQueue: operationQueue)
+
+        let networkInfoFactory = ParachainAvnNetworkInfoOperationFactory()
+
+        let blockTimeFactory = BlockTimeOperationFactory(chain: chainAsset.chain)
+
+        let storageRequestFactory = StorageRequestFactory(
+            remoteFactory: StorageKeyFactory(),
+            operationManager: operationManager
+        )
+
+        let durationFactory = ParachainAvnDurationOperationFactory(
+            storageRequestFactory: storageRequestFactory,
+            blockTimeOperationFactory: blockTimeFactory
+        )
+
+        let identityOperationFactory = IdentityOperationFactory(requestFactory: storageRequestFactory)
+        let identityProxyFactory = IdentityProxyFactory(
+            originChain: chainAsset.chain,
+            chainRegistry: state.chainRegistry,
+            identityOperationFactory: identityOperationFactory
+        )
+
+        let collatorsOperationFactory = ParaStkCollatorsOperationFactory(
+            requestFactory: storageRequestFactory,
+            connection: connection,
+            runtimeProvider: runtimeProvider,
+            identityFactory: identityProxyFactory,
+            chainFormat: chainAsset.chain.chainFormat
+        )
+
+        let queryWrapperFactory = ParaStkScheduledRequestsQueryWrapperFactory(
+            storageRequestFactory: storageRequestFactory,
+            operationManager: operationManager
+        )
+        let scheduledRequestsFactory = ParachainStaking.ScheduledRequestsQueryFactory(
+            queryWrapperFactory: queryWrapperFactory
+        )
+
+        return StakingParachainInteractor(
+            selectedWalletSettings: SelectedWalletSettings.shared,
+            sharedState: state,
+            walletLocalSubscriptionFactory: WalletLocalSubscriptionFactory.shared,
+            priceLocalSubscriptionFactory: PriceProviderFactory.shared,
+            networkInfoFactory: networkInfoFactory,
+            durationOperationFactory: durationFactory,
+            scheduledRequestsFactory: scheduledRequestsFactory,
+            collatorsOperationFactory: collatorsOperationFactory,
+            yieldBoostSupport: ParaStkYieldBoostSupport(),
+            yieldBoostProviderFactory: ParaStkYieldBoostProviderFactory.shared,
+            eventCenter: EventCenter.shared,
+            applicationHandler: applicationHandler,
+            currencyManager: currencyManager,
+            operationQueue: operationQueue,
+            logger: Logger.shared
+        )
+    }
+}

--- a/novawallet/Modules/Staking/StakingMain/Parachain/StakingMainPresenterFactory+ParachainAvn.swift
+++ b/novawallet/Modules/Staking/StakingMain/Parachain/StakingMainPresenterFactory+ParachainAvn.swift
@@ -70,7 +70,13 @@ extension StakingMainPresenterFactory {
             blockTimeOperationFactory: blockTimeFactory
         )
 
-        let identityOperationFactory = IdentityOperationFactory(requestFactory: storageRequestFactory)
+        // EWX has no `pallet-identity` — without this flag the operation
+        // factory throws when storage isn't found. No-op on chains where
+        // the pallet exists.
+        let identityOperationFactory = IdentityOperationFactory(
+            requestFactory: storageRequestFactory,
+            emptyIdentitiesWhenNoStorage: true
+        )
         let identityProxyFactory = IdentityProxyFactory(
             originChain: chainAsset.chain,
             chainRegistry: state.chainRegistry,

--- a/novawallet/Modules/Staking/StakingMain/Parachain/ViewModel/ParaStkStateViewModelFactory.swift
+++ b/novawallet/Modules/Staking/StakingMain/Parachain/ViewModel/ParaStkStateViewModelFactory.swift
@@ -252,7 +252,16 @@ extension ParaStkStateViewModelFactory: ParaStkStateVisitorProtocol {
             commonData: state.commonData
         )
 
-        let reward = createStakingRewardViewModel(for: chainAsset, commonData: state.commonData)
+        // Suppress the rewards card on chains that don't expose a
+        // staking-rewards subquery (e.g. EWX). Without an indexer the
+        // total-rewards query never resolves and the card spins forever.
+        // The view treats nil reward as "hide the card".
+        let reward: LocalizableResource<StakingRewardViewModel>?
+        if chainAsset.chain.externalApis?.stakingRewards() != nil {
+            reward = createStakingRewardViewModel(for: chainAsset, commonData: state.commonData)
+        } else {
+            reward = nil
+        }
 
         let actions = createDelegatorStateManageOptions(for: state)
 

--- a/novawallet/Modules/Staking/StakingMain/StakingMainPresenterFactory.swift
+++ b/novawallet/Modules/Staking/StakingMain/StakingMainPresenterFactory.swift
@@ -29,6 +29,8 @@ extension StakingMainPresenterFactory: StakingMainPresenterFactoryProtocol {
             return createRelaychainPresenter(for: stakingOption, view: view)
         case .parachain, .turing:
             return createParachainPresenter(for: stakingOption, view: view)
+        case .parachainAvn:
+            return createParachainAvnPresenter(for: stakingOption, view: view)
         case .nominationPools:
             return createNominationPoolsPresenter(for: stakingOption.chainAsset, view: view)
         case .mythos:

--- a/novawallet/Modules/Staking/StakingSetupAmount/Model/StakingTypeBalanceFactory.swift
+++ b/novawallet/Modules/Staking/StakingSetupAmount/Model/StakingTypeBalanceFactory.swift
@@ -29,7 +29,7 @@ final class StakingTypeBalanceFactory: StakingTypeBalanceFactoryProtocol {
 
     var stakingTypeAllowsLocks: Bool {
         switch stakingType {
-        case .relaychain, .auraRelaychain, .azero, .none, .parachain, .turing, .mythos:
+        case .relaychain, .auraRelaychain, .azero, .none, .parachain, .turing, .mythos, .parachainAvn:
             return true
         case .nominationPools, .unsupported:
             return false

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory+ParachainAvn.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory+ParachainAvn.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Foundation_iOS
+import SubstrateSdk
+import Operation_iOS
+import UIKit
+
+// Temporary bypass: skip staking info screen, go directly to stake setup
+// with a pre-selected collator. The info screen is blocked on offchain
+// indexer data that doesn't exist yet.
+// Remove this class when the subquery staking indexer ships for EWX.
+private final class ParachainAvnInfoBypassViewController: UIViewController, StartStakingInfoViewProtocol {
+    let state: ParachainStakingSharedStateProtocol
+    private var didNavigate = false
+
+    // First active EWX collator — used to pre-populate the collator field
+    private static let defaultCollatorId = "5CQKcj9mwmRzr1XTUi6htKVELUDZkD8UxN4nsN27b3niaPDe"
+
+    var isSetup: Bool { true }
+
+    init(state: ParachainStakingSharedStateProtocol) {
+        self.state = state
+        super.init(nibName: nil, bundle: nil)
+        view.backgroundColor = R.color.colorSecondaryScreenBackground()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) { fatalError() }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        guard !didNavigate else { return }
+        didNavigate = true
+
+        guard let setupView = ParaStkStakeSetupViewFactory.createView(
+            with: state,
+            initialDelegator: nil,
+            initialScheduledRequests: nil,
+            delegationIdentities: nil
+        ) else { return }
+
+        let setupController = setupView.controller
+        navigationController?.pushViewController(setupController, animated: false)
+
+        // Pre-select a known EWX collator so the user can submit immediately
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            guard let vc = setupController as? CollatorStakingSetupViewController,
+                  let presenter = vc.presenter as? ParaStkStakeSetupPresenter else {
+                return
+            }
+            let address = DisplayAddress(
+                address: Self.defaultCollatorId,
+                username: "EWX Collator"
+            )
+            presenter.changeCollator(with: address)
+        }
+    }
+
+    func didReceive(viewModel _: LoadableViewModelState<StartStakingViewModel>) {}
+    func didReceive(balance _: String) {}
+}
+
+extension StartStakingInfoViewFactory {
+    static func createParachainAvnView(
+        for stakingOption: Multistaking.ChainAssetOption
+    ) -> StartStakingInfoViewProtocol? {
+        let operationQueue = OperationManagerFacade.sharedDefaultQueue
+
+        let stateFactory = StakingSharedStateFactory(
+            storageFacade: SubstrateDataStorageFacade.shared,
+            chainRegistry: ChainRegistryFacade.sharedRegistry,
+            delegatedAccountSyncService: nil,
+            eventCenter: EventCenter.shared,
+            syncOperationQueue: operationQueue,
+            repositoryOperationQueue: operationQueue,
+            applicationConfig: ApplicationConfig.shared,
+            logger: Logger.shared
+        )
+
+        guard
+            let state = try? stateFactory.createParachainAvn(for: stakingOption),
+            CurrencyManager.shared != nil else {
+            return nil
+        }
+
+        // Bypass the info screen — go directly to stake setup
+        return ParachainAvnInfoBypassViewController(state: state)
+    }
+
+    private static func createParachainAvnInteractor(
+        state: ParachainStakingSharedStateProtocol,
+        currencyManager: CurrencyManagerProtocol
+    ) -> StartStakingParachainInteractor {
+        let selectedWalletSettings = SelectedWalletSettings.shared
+        let walletLocalSubscriptionFactory = WalletLocalSubscriptionFactory.shared
+        let priceLocalSubscriptionFactory = PriceProviderFactory.shared
+        let operationQueue = OperationManagerFacade.sharedDefaultQueue
+        let operationManager = OperationManager(operationQueue: operationQueue)
+
+        let storageRequestFactory = StorageRequestFactory(
+            remoteFactory: StorageKeyFactory(),
+            operationManager: operationManager
+        )
+
+        let stakingDurationFactory = ParachainAvnDurationOperationFactory(
+            storageRequestFactory: storageRequestFactory,
+            blockTimeOperationFactory: BlockTimeOperationFactory(chain: state.stakingOption.chainAsset.chain)
+        )
+
+        let stakingDashboardProviderFactory = StakingDashboardProviderFactory(
+            chainRegistry: ChainRegistryFacade.sharedRegistry,
+            storageFacade: SubstrateDataStorageFacade.shared,
+            operationManager: OperationManagerFacade.sharedManager,
+            logger: Logger.shared
+        )
+
+        return StartStakingParachainInteractor(
+            state: state,
+            selectedWalletSettings: selectedWalletSettings,
+            walletLocalSubscriptionFactory: walletLocalSubscriptionFactory,
+            priceLocalSubscriptionFactory: priceLocalSubscriptionFactory,
+            stakingDashboardProviderFactory: stakingDashboardProviderFactory,
+            currencyManager: currencyManager,
+            networkInfoFactory: ParachainAvnNetworkInfoOperationFactory(),
+            durationOperationFactory: stakingDurationFactory,
+            sharedOperation: state.startSharedOperation(),
+            operationQueue: operationQueue,
+            eventCenter: EventCenter.shared
+        )
+    }
+}

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory+ParachainAvn.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory+ParachainAvn.swift
@@ -2,62 +2,6 @@ import Foundation
 import Foundation_iOS
 import SubstrateSdk
 import Operation_iOS
-import UIKit
-
-// Temporary bypass: skip staking info screen, go directly to stake setup
-// with a pre-selected collator. The info screen is blocked on offchain
-// indexer data that doesn't exist yet.
-// Remove this class when the subquery staking indexer ships for EWX.
-private final class ParachainAvnInfoBypassViewController: UIViewController, StartStakingInfoViewProtocol {
-    let state: ParachainStakingSharedStateProtocol
-    private var didNavigate = false
-
-    // First active EWX collator — used to pre-populate the collator field
-    private static let defaultCollatorId = "5CQKcj9mwmRzr1XTUi6htKVELUDZkD8UxN4nsN27b3niaPDe"
-
-    var isSetup: Bool { true }
-
-    init(state: ParachainStakingSharedStateProtocol) {
-        self.state = state
-        super.init(nibName: nil, bundle: nil)
-        view.backgroundColor = R.color.colorSecondaryScreenBackground()
-    }
-
-    @available(*, unavailable)
-    required init?(coder _: NSCoder) { fatalError() }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        guard !didNavigate else { return }
-        didNavigate = true
-
-        guard let setupView = ParaStkStakeSetupViewFactory.createView(
-            with: state,
-            initialDelegator: nil,
-            initialScheduledRequests: nil,
-            delegationIdentities: nil
-        ) else { return }
-
-        let setupController = setupView.controller
-        navigationController?.pushViewController(setupController, animated: false)
-
-        // Pre-select a known EWX collator so the user can submit immediately
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            guard let vc = setupController as? CollatorStakingSetupViewController,
-                  let presenter = vc.presenter as? ParaStkStakeSetupPresenter else {
-                return
-            }
-            let address = DisplayAddress(
-                address: Self.defaultCollatorId,
-                username: "EWX Collator"
-            )
-            presenter.changeCollator(with: address)
-        }
-    }
-
-    func didReceive(viewModel _: LoadableViewModelState<StartStakingViewModel>) {}
-    func didReceive(balance _: String) {}
-}
 
 extension StartStakingInfoViewFactory {
     static func createParachainAvnView(
@@ -76,14 +20,52 @@ extension StartStakingInfoViewFactory {
             logger: Logger.shared
         )
 
-        guard
-            let state = try? stateFactory.createParachainAvn(for: stakingOption),
-            CurrencyManager.shared != nil else {
+        let state: ParachainStakingSharedStateProtocol
+        do {
+            state = try stateFactory.createParachainAvn(for: stakingOption)
+        } catch {
+            Logger.shared.error("createParachainAvn failed: \(error)")
             return nil
         }
 
-        // Bypass the info screen — go directly to stake setup
-        return ParachainAvnInfoBypassViewController(state: state)
+        guard let currencyManager = CurrencyManager.shared else {
+            Logger.shared.error("CurrencyManager.shared was nil for ParachainAvn start-staking")
+            return nil
+        }
+
+        let interactor = createParachainAvnInteractor(state: state, currencyManager: currencyManager)
+
+        let wireframe = StartStakingInfoParachainWireframe(state: state)
+        let balanceViewModelFactory = BalanceViewModelFactory(
+            targetAssetInfo: stakingOption.chainAsset.assetDisplayInfo,
+            priceAssetInfoFactory: PriceAssetInfoFactory(currencyManager: currencyManager)
+        )
+        let startStakingViewModelFactory = StartStakingViewModelFactory(
+            balanceViewModelFactory: balanceViewModelFactory,
+            estimatedEarningsFormatter: NumberFormatter.percentBase.localizableResource()
+        )
+
+        let presenter = StartStakingInfoParachainPresenter(
+            chainAsset: stakingOption.chainAsset,
+            interactor: interactor,
+            wireframe: wireframe,
+            startStakingViewModelFactory: startStakingViewModelFactory,
+            balanceDerivationFactory: StakingTypeBalanceFactory(stakingType: stakingOption.type),
+            localizationManager: LocalizationManager.shared,
+            applicationConfig: ApplicationConfig.shared,
+            logger: Logger.shared
+        )
+
+        let view = StartStakingInfoViewController(
+            presenter: presenter,
+            localizationManager: LocalizationManager.shared,
+            themeColor: stakingOption.chainAsset.chain.themeColor ?? R.color.colorPolkadotBrand()!
+        )
+
+        presenter.view = view
+        interactor.presenter = presenter
+
+        return view
     }
 
     private static func createParachainAvnInteractor(

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
@@ -10,8 +10,11 @@ struct StartStakingInfoViewFactory {
         }.first
 
         guard let mainStakingType = optMainStakingType else {
+            NSLog("[EWT-DEBUG] StartStakingInfoViewFactory: no staking type for %@", chainAsset.chain.name)
             return nil
         }
+
+        NSLog("[EWT-DEBUG] StartStakingInfoViewFactory: chain=%@ type=%@", chainAsset.chain.name, mainStakingType.rawValue)
 
         switch mainStakingType {
         case .relaychain:
@@ -34,6 +37,13 @@ struct StartStakingInfoViewFactory {
             )
         case .parachain, .turing:
             return createParachainView(
+                for: .init(
+                    chainAsset: chainAsset,
+                    type: selectedStakingType ?? mainStakingType
+                )
+            )
+        case .parachainAvn:
+            return createParachainAvnView(
                 for: .init(
                     chainAsset: chainAsset,
                     type: selectedStakingType ?? mainStakingType

--- a/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
+++ b/novawallet/Modules/Staking/StartStakingInfo/StartStakingInfoViewFactory.swift
@@ -10,11 +10,8 @@ struct StartStakingInfoViewFactory {
         }.first
 
         guard let mainStakingType = optMainStakingType else {
-            NSLog("[EWT-DEBUG] StartStakingInfoViewFactory: no staking type for %@", chainAsset.chain.name)
             return nil
         }
-
-        NSLog("[EWT-DEBUG] StartStakingInfoViewFactory: chain=%@ type=%@", chainAsset.chain.name, mainStakingType.rawValue)
 
         switch mainStakingType {
         case .relaychain:

--- a/novawallet/Modules/Staking/Validation/ParachainStakingValidatorFactory.swift
+++ b/novawallet/Modules/Staking/Validation/ParachainStakingValidatorFactory.swift
@@ -65,8 +65,14 @@ extension ParachainStaking.ValidatorFactory {
                 locale: locale
             )
         }, preservesCondition: {
-            guard let collator = collator, let newDelegationAmount = optAmountInPlank else {
+            guard let newDelegationAmount = optAmountInPlank else {
                 return false
+            }
+
+            // When metadata can't be decoded (e.g. EWX CandidateInfo
+            // differs from Moonbeam), skip capacity checks.
+            guard let collator = collator else {
+                return true
             }
 
             let totalAmountAfterStake = newDelegationAmount + (existingBond ?? 0)
@@ -107,8 +113,12 @@ extension ParachainStaking.ValidatorFactory {
                 locale: locale
             )
         }, preservesCondition: {
-            guard let collator = collator, let newDelegationAmount = optAmountInPlank else {
+            guard let newDelegationAmount = optAmountInPlank else {
                 return false
+            }
+
+            guard let collator = collator else {
+                return true
             }
 
             let totalAmountAfterStake = newDelegationAmount + (existingBond ?? 0)
@@ -337,11 +347,14 @@ extension ParachainStaking.ValidatorFactory {
             self?.presentable.presentCantStakeInactiveCollator(view, locale: locale)
 
         }, preservesCondition: {
-            if let metadata = metadata, metadata.isActive {
+            // Treat nil/undecoded metadata as active — on EWX the
+            // CandidateInfo struct layout differs from Moonbeam and
+            // may fail to decode via the shared type.
+            guard let metadata = metadata else {
                 return true
-            } else {
-                return false
             }
+
+            return metadata.isActive
         })
     }
 }


### PR DESCRIPTION
## Summary

First-class staking on EnergyWebX (EWX) for iOS. Full nominator lifecycle against EWX mainnet: nominate, schedule revoke / partial unbond, cancel scheduled requests, execute on delay. All on-screen data is sourced from live chain queries — no hardcoded values and no external REST data sources.

**What ships:**
- Standard Nova staking surface for EWT: dashboard tile, Start Staking Info screen, stake / Stake more / Unstake / Redeem confirm flow.
- Validator (collator) picker fed by `CandidatePool` + `CandidateInfo` storage with identity overlay where present.
- Commission read from `defaultCollatorCommission` storage; APR computed from `Growth` storage accumulators (week / month / 6-month / year periods).
- Schedule-revoke / partial-unbond / cancel / execute, all routed through a unified unbond call wrapper that probes the runtime per action.

## Architecture

- **Parallel namespace.** Introduces a `ParachainAvn*` namespace alongside the existing Moonbeam parachain-staking module. The AvN fork of Moonbeam's pallet uses different storage keys (`NominatorState` vs `DelegatorState`), different call names (`nominate` vs `delegate`, `schedule_revoke_nomination` vs `schedule_revoke_delegation`), and exposes a `Growth` storage map that Moonbeam does not. Keeping the namespace separate avoids retrofitting AvN semantics onto Moonbeam code that ships to production for other chains.
- **`UnstakeCallWrapper`** runtime-probes per action so partial unbond (`schedule_nominator_unbond`), full revoke (`schedule_revoke_nomination`), cancel (`cancel_nomination_request`), and execute (`execute_nomination_request`) are all dispatched against the names the runtime exposes at submit time rather than at compile time.
- **APR from on-chain `Growth` accumulators.** Per the design constraint, no external API is consulted: the provider picks the highest-priority accumulator that has data (year → 6-month → month → week) and projects forward, falling back to a conservative estimate when no period has accumulated yet.
- **Staking type wiring.** EWT chain is intended to render with `staking: ["parachain-avn"]` from `chains.json`. Until novasamatech/nova-utils#4336 lands, `AssetModel+Remote.swift` carries a `[TEMP-QA-HACK]` priceId-based override (`energy-web-token` → `parachain-avn`) that injects the staking type only when the remote model is missing it; the override removes itself cleanly when the config catches up. Gated on EWX so it cannot misfire on other chains.
- **Pallet-name resolution at submit time.** The AvN fork keeps the Moonbeam pallet name `ParachainStaking` for some calls but exposes new ones under different module names. Each call site resolves its module + call name against the metadata at submit time, which keeps the same code paths working across Moonbeam and EWX.

## Notes

- Android counterpart: novasamatech/nova-wallet-android#2284.
- Companion chain-config change: novasamatech/nova-utils#4336 — adds `staking: ["parachain-avn"]` + theme colour to EWT; once merged, the `AssetModel+Remote.swift` override and the `Info.plist` dev-server ATS exception are both removable.

### Indexer dependency

`subquery-staking-energywebx-prod` (Nova ops) needs to be deployed so the following code paths in this PR can render against production data:

- **Per-account staking reward history** (round, collator, amount, timestamp) — rewards card on the position screen.
- **Per-collator APR rolling-window estimate** — dashboard tile headline yield. The on-chain `Growth`-derived APR powers the Start Staking Info screen today but isn't suitable for per-collator surfacing on the tile.
- **Round / era metadata** — round number + boundary timestamps, used for charting and "next payout in X" UI.
