### PR TITLE
fix(ci): fetch Scaleway secrets by path to avoid list permission error

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -52,7 +52,7 @@ runs:
       shell: bash
       run: mint bootstrap --mintfile CIMintfile
 
-    - uses: scaleway/action-scw-secret@v0
+    - uses: stepanLav/action-scw-secret@f82d97e369067fac558961a5bb128c9a90416f63 # fork of scaleway/action-scw-secret#148 — fetch secrets by path (accessSecretVersionByPath); revert to upstream after release
       with:
         # ENV_NAME,SECRET_NAME (with path)
         secret-names: |


### PR DESCRIPTION
## Problem

Fetching Scaleway secrets fails with:

```
Error: PermissionsDeniedError: insufficient permissions: list secret.
```

`scaleway/action-scw-secret` resolves each secret via `ListSecrets` (to get its id) before reading it. `ListSecrets` requires the `SecretManagerReadOnly` (list) permission, which our project-scoped API keys do not have. The recent upstream hotfixes only re-scoped the list call — they did not remove the list requirement.

## Fix

Repoint the action at a fork that fetches each secret directly by path + name via `accessSecretVersionByPath`. That endpoint needs only `SecretManagerSecretAccess` (which the keys already have) and never calls `ListSecrets`.

- Ref changed to `stepanLav/action-scw-secret@f82d97e` (dist is built and committed on that ref).
- Upstream PR: scaleway/action-scw-secret#148

## Scope

Only the `uses:` ref of `scaleway/action-scw-secret` changes. Secret names, env vars, and inputs are untouched.

## Follow-up

**Temporary** pin to a personal fork. Once scaleway/action-scw-secret#148 is merged and released, revert to `scaleway/action-scw-secret@<release>`.
