### PR TITLE
Exclude .claude worktrees from SwiftLint and SwiftFormat

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,4 +1,5 @@
 --swiftversion 5.3
+--exclude .claude
 --wraparguments before-first
 --wrapparameters before-first
 --enable isEmpty

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ excluded:
   - novawalletIntegrationTests
   - NovaPushNotificationServiceExtension/R.generated.swift
   - vendor/bundle
+  - .claude
 identifier_name:
   excluded:
     - id


### PR DESCRIPTION
## What

Adds `.claude` to the SwiftLint `excluded:` list and `--exclude .claude` to the SwiftFormat config.

## Why

Claude Code agent worktrees live under `.claude/worktrees/<name>/` and contain full copies of the source tree. The SwiftLint build phase scans the repo root recursively, and the relative excludes (`novawalletTests`, `novawalletIntegrationTests`, …) don't match their worktree copies — so error-level violations (e.g. `force_try` in integration tests) failed every build while a worktree session existed.

## Verification

- Reproduced with a scratch worktree: 9,785 violations from worktree copies; after the fix, lint exits 0 with zero hits under `.claude`.
- SwiftFormat was verified unaffected either way (it skips hidden directories by default; the exclude is defensive).
- Full Debug build with a scratch worktree present: **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)