### PR TITLE
Browser staking popup and hints

### DIFF
--- a/.claude/docs/review/code-checklist.md
+++ b/.claude/docs/review/code-checklist.md
@@ -44,6 +44,9 @@ give a concrete fix.
 - [ ] `.failure` branches handled, not ignored
 - [ ] Remote subscription ids detached
 - [ ] `EventCenter` observers removed on teardown
+- [ ] Process-wide state acquired in a lifecycle hook (e.g. `DeviceOrientationManager.enableLandscape()`
+      in `viewWillAppear`) is released on **every** teardown route — including routes added later that
+      bypass the screen's own close action
 
 **Ref:** architecture/data-flow.md
 

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,4 +1,5 @@
 --swiftversion 5.3
+--exclude .claude
 --wraparguments before-first
 --wrapparameters before-first
 --enable isEmpty

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ excluded:
   - novawalletIntegrationTests
   - NovaPushNotificationServiceExtension/R.generated.swift
   - vendor/bundle
+  - .claude
 identifier_name:
   excluded:
     - id

--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -7,6 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		59AE5FD3210FC06AE1BA990F /* DAppStakingDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F556DBEECD9C4D3900BD3857 /* DAppStakingDetection.swift */; };
+		AC40C2EC9FBFEF00B8B3E3E3 /* DAppStakingBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F7047C317DD935EC1CADF7 /* DAppStakingBannerView.swift */; };
+		B8709B087FA7BD21F5EDA9FC /* StakingRedirectPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F139BB802048BFD0A462BE9E /* StakingRedirectPresentable.swift */; };
+		7B90EC879AA60B60153AA2AC /* DAppStakingNoticePresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4B9A7A673DB9064593F4B /* DAppStakingNoticePresentable.swift */; };
+		3D5310ABCA998FB83EFF3101 /* DAppStakingNoticeProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5540989F30DD2AF2ADADDB48 /* DAppStakingNoticeProtocols.swift */; };
+		CFB4922BA02EFBD88D2DF934 /* DAppStakingNoticeViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F78AB7ADF5F9F2340BB4D0C4 /* DAppStakingNoticeViewFactory.swift */; };
+		40D45F29E302E8E152632C41 /* DAppStakingNoticeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B289BCAD707C6EAEA6AAF4B /* DAppStakingNoticeViewController.swift */; };
+		B8431A56D6DC244F975DA2A8 /* DAppStakingNoticeViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A528395A49D1BEFAA85DC96 /* DAppStakingNoticeViewLayout.swift */; };
+		AB9D8B04DD7E71798AB7C66A /* DAppStakingNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C62BA51B6F83AE3637E0B8 /* DAppStakingNoticePresenter.swift */; };
+		5FC46D20DA8172B4C33A54BF /* DAppStakingNoticeWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B21FCEF2244EE9F005EA5FF /* DAppStakingNoticeWireframe.swift */; };
+		727AA208A3DBD489D9E6FDE8 /* DAppStakingDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EE07A02459EDE50188E49D /* DAppStakingDetectionTests.swift */; };
 		003063A17B04BA6327EA355F /* ReferendumVotersProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FE9E98CB265815986BE909 /* ReferendumVotersProtocols.swift */; };
 		006BEDBD2F98FF54DB993D8C /* DAppAddFavoriteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 057EF626183878DD2C9E7BC7 /* DAppAddFavoriteViewController.swift */; };
 		0075488169C69B97C0630EB8 /* AssetReceiveProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47042BBA5082B1EC1D017B56 /* AssetReceiveProtocols.swift */; };
@@ -6612,6 +6623,17 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F556DBEECD9C4D3900BD3857 /* DAppStakingDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppStakingDetection.swift; sourceTree = "<group>"; };
+		B0F7047C317DD935EC1CADF7 /* DAppStakingBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppStakingBannerView.swift; sourceTree = "<group>"; };
+		F139BB802048BFD0A462BE9E /* StakingRedirectPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingRedirectPresentable.swift; sourceTree = "<group>"; };
+		21A4B9A7A673DB9064593F4B /* DAppStakingNoticePresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppStakingNoticePresentable.swift; sourceTree = "<group>"; };
+		5540989F30DD2AF2ADADDB48 /* DAppStakingNoticeProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppStakingNoticeProtocols.swift; sourceTree = "<group>"; };
+		F78AB7ADF5F9F2340BB4D0C4 /* DAppStakingNoticeViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppStakingNoticeViewFactory.swift; sourceTree = "<group>"; };
+		6B289BCAD707C6EAEA6AAF4B /* DAppStakingNoticeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppStakingNoticeViewController.swift; sourceTree = "<group>"; };
+		7A528395A49D1BEFAA85DC96 /* DAppStakingNoticeViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppStakingNoticeViewLayout.swift; sourceTree = "<group>"; };
+		38C62BA51B6F83AE3637E0B8 /* DAppStakingNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppStakingNoticePresenter.swift; sourceTree = "<group>"; };
+		8B21FCEF2244EE9F005EA5FF /* DAppStakingNoticeWireframe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppStakingNoticeWireframe.swift; sourceTree = "<group>"; };
+		F1EE07A02459EDE50188E49D /* DAppStakingDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAppStakingDetectionTests.swift; sourceTree = "<group>"; };
 		002A29AE58EB53E915330490 /* ControllerAccountViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ControllerAccountViewFactory.swift; sourceTree = "<group>"; };
 		003FA37F2B240C5D7605340D /* StakingMainInteractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StakingMainInteractor.swift; sourceTree = "<group>"; };
 		0043E77B2DBB3546A9E54C4B /* AdvancedWalletProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AdvancedWalletProtocols.swift; sourceTree = "<group>"; };
@@ -23144,6 +23166,19 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		BC3AF41AE9B172024263B16C /* DAppStakingNotice */ = {
+			isa = PBXGroup;
+			children = (
+				5540989F30DD2AF2ADADDB48 /* DAppStakingNoticeProtocols.swift */,
+				F78AB7ADF5F9F2340BB4D0C4 /* DAppStakingNoticeViewFactory.swift */,
+				6B289BCAD707C6EAEA6AAF4B /* DAppStakingNoticeViewController.swift */,
+				7A528395A49D1BEFAA85DC96 /* DAppStakingNoticeViewLayout.swift */,
+				38C62BA51B6F83AE3637E0B8 /* DAppStakingNoticePresenter.swift */,
+				8B21FCEF2244EE9F005EA5FF /* DAppStakingNoticeWireframe.swift */,
+			);
+			path = DAppStakingNotice;
+			sourceTree = "<group>";
+		};
 		846B49A92769EEC80066B875 /* DApp */ = {
 			isa = PBXGroup;
 			children = (
@@ -23160,6 +23195,7 @@
 				9482C532739CF72E0D6C96E3 /* DAppAuthConfirm */,
 				E530843F8B8FC936EF07C08F /* DAppWalletAuth */,
 				54CA53FE46396489FDE213E0 /* DAppPhishing */,
+				BC3AF41AE9B172024263B16C /* DAppStakingNotice */,
 				1673C6B5E37788C92D8E37D4 /* DAppAddFavorite */,
 				17C8516C4BEF61B6DE078C60 /* DAppAuthSettings */,
 				58F5C296A0CFDD0BDACDB4D7 /* DAppSettings */,
@@ -24281,6 +24317,7 @@
 				77C35CE62B56D07300308F16 /* ScanAddressPresentable.swift */,
 				0C1998EE2C4CC51D000EBFB8 /* SCLoadableControllerProtocol.swift */,
 				2D74CA3E2CF7262E004EAD8C /* BrowserOpening.swift */,
+				F139BB802048BFD0A462BE9E /* StakingRedirectPresentable.swift */,
 				0CFF82502D9275C900DB17A4 /* AvailableBalanceMapping.swift */,
 			);
 			path = Protocols;
@@ -25691,6 +25728,7 @@
 				84B7C69F289BFA79001A3566 /* DAppAuthConfirm */,
 				84B7C6A1289BFA79001A3566 /* DAppOperationConfirm */,
 				84B7C6A3289BFA79001A3566 /* DAppSearch */,
+				F1EE07A02459EDE50188E49D /* DAppStakingDetectionTests.swift */,
 				84B7C6A5289BFA79001A3566 /* Model */,
 				84B7C6A7289BFA79001A3566 /* DAppList */,
 			);
@@ -26668,6 +26706,7 @@
 			isa = PBXGroup;
 			children = (
 				84D17EE02805A62600F7BAFF /* DAppAlertPresentable.swift */,
+				21A4B9A7A673DB9064593F4B /* DAppStakingNoticePresentable.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -26724,6 +26763,7 @@
 			children = (
 				849E17DB27909179002D1744 /* DAppSearchQueryTableViewCell.swift */,
 				849E17DF279094E7002D1744 /* DAppSearchHeaderView.swift */,
+				B0F7047C317DD935EC1CADF7 /* DAppStakingBannerView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -27182,6 +27222,7 @@
 				849976C227B2869800B14A6C /* MetamaskProtocol */,
 				846E5016277AD3AF0049B659 /* PolkadotExtensionProtocol */,
 				846E5017277AD3D50049B659 /* DAppList.swift */,
+				F556DBEECD9C4D3900BD3857 /* DAppStakingDetection.swift */,
 				843612BA278FD6E000DC739E /* DAppSigningType.swift */,
 				849E17EF2791909C002D1744 /* DAppSettings.swift */,
 				849E17F1279191EB002D1744 /* DAppSettingsMapper.swift */,
@@ -35117,6 +35158,16 @@
 				8321399396FA5B25BC93A090 /* DAppPhishingViewLayout.swift in Sources */,
 				0C1666862D7FEF90005E6CD3 /* XcmModelFactory.swift in Sources */,
 				B1BB78684B059A113AB3AD30 /* DAppPhishingViewFactory.swift in Sources */,
+				59AE5FD3210FC06AE1BA990F /* DAppStakingDetection.swift in Sources */,
+				AC40C2EC9FBFEF00B8B3E3E3 /* DAppStakingBannerView.swift in Sources */,
+				B8709B087FA7BD21F5EDA9FC /* StakingRedirectPresentable.swift in Sources */,
+				7B90EC879AA60B60153AA2AC /* DAppStakingNoticePresentable.swift in Sources */,
+				3D5310ABCA998FB83EFF3101 /* DAppStakingNoticeProtocols.swift in Sources */,
+				CFB4922BA02EFBD88D2DF934 /* DAppStakingNoticeViewFactory.swift in Sources */,
+				40D45F29E302E8E152632C41 /* DAppStakingNoticeViewController.swift in Sources */,
+				B8431A56D6DC244F975DA2A8 /* DAppStakingNoticeViewLayout.swift in Sources */,
+				AB9D8B04DD7E71798AB7C66A /* DAppStakingNoticePresenter.swift in Sources */,
+				5FC46D20DA8172B4C33A54BF /* DAppStakingNoticeWireframe.swift in Sources */,
 				6ECB27B386124F87382073FD /* DAppAddFavoriteProtocols.swift in Sources */,
 				84033057290FD8AB009C18E6 /* ReferendumsPersonalActivityView.swift in Sources */,
 				433A3C2B0D1E4BA5974D681B /* DAppAddFavoriteWireframe.swift in Sources */,
@@ -36991,6 +37042,7 @@
 				8434C9EA2540AE51009E4191 /* ExtrinsicEraTests.swift in Sources */,
 				84B7C749289BFA79001A3566 /* ControllerAccountTests.swift in Sources */,
 				84B7C719289BFA79001A3566 /* DAppSearchTests.swift in Sources */,
+				727AA208A3DBD489D9E6FDE8 /* DAppStakingDetectionTests.swift in Sources */,
 				0C0AE4072DE45A9000D506F3 /* MockBranchService.swift in Sources */,
 				84B7C740289BFA79001A3566 /* RootTests.swift in Sources */,
 				84B7C712289BFA79001A3566 /* ExtrinsicDetailsTests.swift in Sources */,

--- a/novawallet/Common/Extension/UIKit/RoundedButton+Styles.swift
+++ b/novawallet/Common/Extension/UIKit/RoundedButton+Styles.swift
@@ -75,6 +75,23 @@ extension RoundedButton {
         imageWithTitleView?.titleColor = R.color.colorButtonTextInactive()!
     }
 
+    func applyPrimaryStyle() {
+        roundedBackgroundView?.shadowOpacity = 0.0
+        roundedBackgroundView?.fillColor = R.color.colorButtonBackgroundPrimary()!
+        roundedBackgroundView?.highlightedFillColor = R.color.colorButtonBackgroundPrimary()!
+        roundedBackgroundView?.strokeColor = .clear
+        roundedBackgroundView?.highlightedStrokeColor = .clear
+        roundedBackgroundView?.cornerRadius = 10.0
+
+        imageWithTitleView?.titleColor = R.color.colorButtonText()!
+        imageWithTitleView?.titleFont = .semiBoldFootnote
+
+        contentInsets = UIEdgeInsets(top: 8.0, left: 12.0, bottom: 8.0, right: 12.0)
+
+        changesContentOpacityWhenHighlighted = true
+        opacityAnimationDuration = 0
+    }
+
     func applyTextStyle() {
         applyIconStyle()
 

--- a/novawallet/Common/Protocols/BrowserOpening.swift
+++ b/novawallet/Common/Protocols/BrowserOpening.swift
@@ -27,4 +27,12 @@ extension BrowserOpening {
 
         browserNavigation.openBrowser(with: result)
     }
+
+    func minimizeBrowser() {
+        guard let browserNavigation = BrowserNavigationFactory.createNavigation() else {
+            return
+        }
+
+        browserNavigation.minimizeBrowser()
+    }
 }

--- a/novawallet/Common/Protocols/StakingRedirectPresentable.swift
+++ b/novawallet/Common/Protocols/StakingRedirectPresentable.swift
@@ -11,17 +11,15 @@ extension StakingRedirectPresentable {
             // for the staking tab to become visible
             BrowserNavigationFactory.createNavigation()?.minimizeBrowser()
 
-            guard
-                let tabBarController = UIApplication.shared.tabBarController,
-                tabBarController.selectedIndex != MainTabBarIndex.staking
-            else {
+            guard let tabBarController = UIApplication.shared.tabBarController else {
                 return
             }
 
-            let navigationController = tabBarController.selectedViewController as? UINavigationController
-            navigationController?.popToRootViewController(animated: false)
-
             tabBarController.selectedIndex = MainTabBarIndex.staking
+
+            let navigationController = tabBarController
+                .viewControllers?[safe: MainTabBarIndex.staking] as? UINavigationController
+            navigationController?.popToRootViewController(animated: false)
         }
 
         if let presentingController = view?.controller.presentingViewController {

--- a/novawallet/Common/Protocols/StakingRedirectPresentable.swift
+++ b/novawallet/Common/Protocols/StakingRedirectPresentable.swift
@@ -1,0 +1,33 @@
+import UIKit
+
+protocol StakingRedirectPresentable {
+    func redirectToStaking(from view: ControllerBackedProtocol?)
+}
+
+extension StakingRedirectPresentable {
+    func redirectToStaking(from view: ControllerBackedProtocol?) {
+        let selectStakingTab = {
+            // the fullscreen browser covers the tab bar, so it must be minimized
+            // for the staking tab to become visible
+            BrowserNavigationFactory.createNavigation()?.minimizeBrowser()
+
+            guard
+                let tabBarController = UIApplication.shared.tabBarController,
+                tabBarController.selectedIndex != MainTabBarIndex.staking
+            else {
+                return
+            }
+
+            let navigationController = tabBarController.selectedViewController as? UINavigationController
+            navigationController?.popToRootViewController(animated: false)
+
+            tabBarController.selectedIndex = MainTabBarIndex.staking
+        }
+
+        if let presentingController = view?.controller.presentingViewController {
+            presentingController.dismiss(animated: true, completion: selectStakingTab)
+        } else {
+            selectStakingTab()
+        }
+    }
+}

--- a/novawallet/Modules/BrowserNavigation/BrowserNavigationFactory.swift
+++ b/novawallet/Modules/BrowserNavigation/BrowserNavigationFactory.swift
@@ -12,6 +12,7 @@ enum BrowserNavigationFactory {
             interactor: interactor,
             browserNavigationTaskFactory: navigationTaskFactory
         )
+        presenter.mainAppContainer = mainContainer
         interactor.presenter = presenter
 
         return presenter

--- a/novawallet/Modules/BrowserNavigation/BrowserNavigationPresenter.swift
+++ b/novawallet/Modules/BrowserNavigation/BrowserNavigationPresenter.swift
@@ -2,6 +2,8 @@ import Foundation
 import Operation_iOS
 
 final class BrowserNavigationPresenter {
+    weak var mainAppContainer: NovaMainAppContainerViewProtocol?
+
     let interactor: BrowserNavigationInteractorInputProtocol
     let browserNavigationTaskFactory: BrowserNavigationTaskFactoryProtocol
 
@@ -51,6 +53,10 @@ extension BrowserNavigationPresenter: BrowserNavigationProtocol {
             wallet: wallet
         )
         browserNavigationTask?(cleaner: self)
+    }
+
+    func minimizeBrowser() {
+        mainAppContainer?.minimizeBrowser()
     }
 }
 

--- a/novawallet/Modules/BrowserNavigation/BrowserNavigationProtocols.swift
+++ b/novawallet/Modules/BrowserNavigation/BrowserNavigationProtocols.swift
@@ -9,6 +9,7 @@ protocol BrowserNavigationProtocol {
     func openBrowser(with dAppId: String)
     func openBrowser(with model: DAppNavigation)
     func openBrowser(with result: DAppSearchResult)
+    func minimizeBrowser()
 }
 
 protocol BrowserNavigationInteractorInputProtocol {

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserPresenter.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserPresenter.swift
@@ -266,8 +266,11 @@ extension DAppBrowserPresenter: DAppOperationConfirmDelegate {
 // MARK: DAppSearchDelegate
 
 extension DAppBrowserPresenter: DAppSearchDelegate {
-    func didCompleteDAppSearchResult(_ result: DAppSearchResult) {
-        if DAppStakingDetection.isThirdPartyStakingSite(result: result, dAppList: nil) {
+    func didCompleteDAppSearchResult(
+        _ result: DAppSearchResult,
+        isThirdPartyStaking: Bool
+    ) {
+        if isThirdPartyStaking {
             pendingStakingSearchResult = result
             wireframe.presentStakingNotice(from: view, delegate: self)
         } else {

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserPresenter.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserPresenter.swift
@@ -13,6 +13,8 @@ final class DAppBrowserPresenter {
     private(set) var tabs: [DAppBrowserTab] = []
     private(set) var browserPage: DAppBrowserPage?
 
+    private var pendingStakingSearchResult: DAppSearchResult?
+
     init(
         interactor: DAppBrowserInteractorInputProtocol,
         wireframe: DAppBrowserWireframeProtocol,
@@ -265,6 +267,25 @@ extension DAppBrowserPresenter: DAppOperationConfirmDelegate {
 
 extension DAppBrowserPresenter: DAppSearchDelegate {
     func didCompleteDAppSearchResult(_ result: DAppSearchResult) {
+        if DAppStakingDetection.isThirdPartyStakingSite(result: result, dAppList: nil) {
+            pendingStakingSearchResult = result
+            wireframe.presentStakingNotice(from: view, delegate: self)
+        } else {
+            interactor.process(newQuery: result)
+        }
+    }
+}
+
+// MARK: DAppStakingNoticeDelegate
+
+extension DAppBrowserPresenter: DAppStakingNoticeDelegate {
+    func dappStakingNoticeDidSelectContinue() {
+        guard let result = pendingStakingSearchResult else {
+            return
+        }
+
+        pendingStakingSearchResult = nil
+
         interactor.process(newQuery: result)
     }
 }

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserProtocols.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserProtocols.swift
@@ -87,7 +87,8 @@ protocol DAppBrowserInteractorOutputProtocol: AnyObject {
 
 protocol DAppBrowserWireframeProtocol: DAppAlertPresentable,
     ErrorPresentable,
-    DAppBrowserSearchPresentable {
+    DAppBrowserSearchPresentable,
+    DAppStakingNoticePresentable {
     func presentOperationConfirm(
         from view: DAppBrowserViewProtocol?,
         request: DAppOperationRequest,

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListPresenter.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListPresenter.swift
@@ -12,6 +12,7 @@ final class DAppBrowserTabListPresenter {
     private let viewModelFactory: DAppBrowserTabListViewModelFactoryProtocol
 
     private var tabs: [DAppBrowserTab] = []
+    private var pendingStakingSearchResult: DAppSearchResult?
 
     init(
         interactor: DAppBrowserTabListInteractorInputProtocol,
@@ -38,6 +39,20 @@ private extension DAppBrowserTabListPresenter {
         )
 
         view?.didReceive(viewModels)
+    }
+
+    func openTab(for result: DAppSearchResult) {
+        guard let tab = DAppBrowserTab(from: result, metaId: metaId) else {
+            return
+        }
+
+        tabs.append(tab)
+        provideTabs()
+
+        wireframe.showTab(
+            tab,
+            from: view
+        )
     }
 }
 
@@ -115,16 +130,25 @@ extension DAppBrowserTabListPresenter: DAppBrowserTabListInteractorOutputProtoco
 
 extension DAppBrowserTabListPresenter: DAppSearchDelegate {
     func didCompleteDAppSearchResult(_ result: DAppSearchResult) {
-        guard let tab = DAppBrowserTab(from: result, metaId: metaId) else {
+        if DAppStakingDetection.isThirdPartyStakingSite(result: result, dAppList: nil) {
+            pendingStakingSearchResult = result
+            wireframe.presentStakingNotice(from: view, delegate: self)
+        } else {
+            openTab(for: result)
+        }
+    }
+}
+
+// MARK: DAppStakingNoticeDelegate
+
+extension DAppBrowserTabListPresenter: DAppStakingNoticeDelegate {
+    func dappStakingNoticeDidSelectContinue() {
+        guard let result = pendingStakingSearchResult else {
             return
         }
 
-        tabs.append(tab)
-        provideTabs()
+        pendingStakingSearchResult = nil
 
-        wireframe.showTab(
-            tab,
-            from: view
-        )
+        openTab(for: result)
     }
 }

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListPresenter.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListPresenter.swift
@@ -129,8 +129,11 @@ extension DAppBrowserTabListPresenter: DAppBrowserTabListInteractorOutputProtoco
 // MARK: DAppSearchDelegate
 
 extension DAppBrowserTabListPresenter: DAppSearchDelegate {
-    func didCompleteDAppSearchResult(_ result: DAppSearchResult) {
-        if DAppStakingDetection.isThirdPartyStakingSite(result: result, dAppList: nil) {
+    func didCompleteDAppSearchResult(
+        _ result: DAppSearchResult,
+        isThirdPartyStaking: Bool
+    ) {
+        if isThirdPartyStaking {
             pendingStakingSearchResult = result
             wireframe.presentStakingNotice(from: view, delegate: self)
         } else {

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListProtocols.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserTabList/DAppBrowserTabListProtocols.swift
@@ -34,7 +34,8 @@ protocol DAppBrowserTabListInteractorOutputProtocol: AnyObject {
 protocol DAppBrowserTabListWireframeProtocol: AlertPresentable,
     ErrorPresentable,
     DAppBrowserSearchPresentable,
-    DAppBrowserTabsClosePresentable {
+    DAppBrowserTabsClosePresentable,
+    DAppStakingNoticePresentable {
     func showTab(
         _ tab: DAppBrowserTab,
         from view: ControllerBackedProtocol?

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserViewController.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserViewController.swift
@@ -405,10 +405,7 @@ private extension DAppBrowserViewController {
     }
 
     @objc private func actionClose() {
-        snapshotWebView { [weak self] image in
-            let stateRender = DAppBrowserTabRender(for: image)
-            self?.presenter.close(stateRender: stateRender)
-        }
+        minimizeFromParent()
     }
 
     @objc private func actionTabs() {
@@ -424,6 +421,17 @@ private extension DAppBrowserViewController {
 extension DAppBrowserViewController: DAppBrowserScriptHandlerDelegate {
     func browserScriptHandler(_: DAppBrowserScriptHandler, didReceive message: WKScriptMessage) {
         presenter.process(message: message.body, transport: message.name)
+    }
+}
+
+// MARK: DAppBrowserMinimizing
+
+extension DAppBrowserViewController: DAppBrowserMinimizing {
+    func minimizeFromParent() {
+        snapshotWebView { [weak self] image in
+            let stateRender = DAppBrowserTabRender(for: image)
+            self?.presenter.close(stateRender: stateRender)
+        }
     }
 }
 

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetProtocols.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetProtocols.swift
@@ -12,6 +12,7 @@ protocol DAppBrowserWidgetProtocol {
     var view: UIView! { get set }
 
     func openBrowser(with tab: DAppBrowserTab?)
+    func minimizeBrowser()
 }
 
 // MARK: PRESENTER -> VIEW

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetProtocols.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetProtocols.swift
@@ -6,6 +6,12 @@ import UIKit
 typealias DAppBrowserParentWidgetViewProtocol = DAppBrowserWidgetViewProtocol
     & DAppBrowserParentViewProtocol
 
+// MARK: WIDGET -> CHILD
+
+protocol DAppBrowserMinimizing: AnyObject {
+    func minimizeFromParent()
+}
+
 // MARK: CONTAINER -> WIDGET
 
 protocol DAppBrowserWidgetProtocol {

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetViewController.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetViewController.swift
@@ -116,6 +116,14 @@ extension DAppBrowserWidgetViewController: DAppBrowserWidgetProtocol {
             transitionBuilder: transitionBuilder
         )
     }
+
+    func minimizeBrowser() {
+        // external minimize request must not affect a widget that is not fullscreen:
+        // the presenter also handles the closed state which restores the miniature on launch
+        guard state == .fullBrowser else { return }
+
+        minimize()
+    }
 }
 
 // MARK: DAppBrowserParentViewProtocol

--- a/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetViewController.swift
+++ b/novawallet/Modules/DApp/DAppBrowser/DAppBrowserWidget/DAppBrowserWidgetViewController.swift
@@ -122,7 +122,15 @@ extension DAppBrowserWidgetViewController: DAppBrowserWidgetProtocol {
         // the presenter also handles the closed state which restores the miniature on launch
         guard state == .fullBrowser else { return }
 
-        minimize()
+        let navigationController = children.first as? UINavigationController
+
+        if let browserController = navigationController?.topViewController as? DAppBrowserMinimizing {
+            // the browser must run its own close sequence so that the tab state
+            // is persisted and the landscape support is reverted
+            browserController.minimizeFromParent()
+        } else {
+            minimize()
+        }
     }
 }
 

--- a/novawallet/Modules/DApp/DAppList/DAppListPresenter.swift
+++ b/novawallet/Modules/DApp/DAppList/DAppListPresenter.swift
@@ -18,6 +18,7 @@ final class DAppListPresenter: BannersModuleInputOwnerProtocol {
     private var hasFavorites: Bool { !(favorites ?? [:]).isEmpty }
     private var randomizationSeed: Int = 1
     private var hasWalletsListUpdates: Bool = false
+    private var pendingStakingSearchResult: DAppSearchResult?
 
     private lazy var iconGenerator = NovaIconGenerator()
 
@@ -156,6 +157,30 @@ extension DAppListPresenter: DAppListInteractorOutputProtocol {
 
 extension DAppListPresenter: DAppSearchDelegate {
     func didCompleteDAppSearchResult(_ result: DAppSearchResult) {
+        let isThirdPartyStaking = DAppStakingDetection.isThirdPartyStakingSite(
+            result: result,
+            dAppList: try? dAppsResult?.get()
+        )
+
+        if isThirdPartyStaking {
+            pendingStakingSearchResult = result
+            wireframe.presentStakingNotice(from: view, delegate: self)
+        } else {
+            wireframe.openBrowser(with: result)
+        }
+    }
+}
+
+// MARK: DAppStakingNoticeDelegate
+
+extension DAppListPresenter: DAppStakingNoticeDelegate {
+    func dappStakingNoticeDidSelectContinue() {
+        guard let result = pendingStakingSearchResult else {
+            return
+        }
+
+        pendingStakingSearchResult = nil
+
         wireframe.openBrowser(with: result)
     }
 }

--- a/novawallet/Modules/DApp/DAppList/DAppListPresenter.swift
+++ b/novawallet/Modules/DApp/DAppList/DAppListPresenter.swift
@@ -156,12 +156,10 @@ extension DAppListPresenter: DAppListInteractorOutputProtocol {
 // MARK: DAppSearchDelegate
 
 extension DAppListPresenter: DAppSearchDelegate {
-    func didCompleteDAppSearchResult(_ result: DAppSearchResult) {
-        let isThirdPartyStaking = DAppStakingDetection.isThirdPartyStakingSite(
-            result: result,
-            dAppList: try? dAppsResult?.get()
-        )
-
+    func didCompleteDAppSearchResult(
+        _ result: DAppSearchResult,
+        isThirdPartyStaking: Bool
+    ) {
         if isThirdPartyStaking {
             pendingStakingSearchResult = result
             wireframe.presentStakingNotice(from: view, delegate: self)

--- a/novawallet/Modules/DApp/DAppList/DAppListProtocols.swift
+++ b/novawallet/Modules/DApp/DAppList/DAppListProtocols.swift
@@ -32,6 +32,7 @@ protocol DAppListInteractorOutputProtocol: AnyObject {
 
 protocol DAppListWireframeProtocol: DAppAlertPresentable,
     DAppBrowserSearchPresentable,
+    DAppStakingNoticePresentable,
     ErrorPresentable,
     WebPresentable,
     WalletSwitchPresentable,

--- a/novawallet/Modules/DApp/DAppSearch/DAppSearchPresenter.swift
+++ b/novawallet/Modules/DApp/DAppSearch/DAppSearchPresenter.swift
@@ -61,6 +61,23 @@ final class DAppSearchPresenter: DAppSearchingByQuery {
     private func provideStakingBanner() {
         view?.didReceive(stakingBannerVisible: DAppStakingDetection.isStakingQuery(query))
     }
+
+    // the classification happens here because this is the only delegate-independent
+    // place that has the curated dApp list; the delegate might present a screen from
+    // the underlying view, so it is notified only after the search is dismissed
+    private func completeSearch(with result: DAppSearchResult) {
+        let isThirdPartyStaking = DAppStakingDetection.isThirdPartyStakingSite(
+            result: result,
+            dAppList: dAppList
+        )
+
+        wireframe.close(from: view) { [weak self] in
+            self?.delegate?.didCompleteDAppSearchResult(
+                result,
+                isThirdPartyStaking: isThirdPartyStaking
+            )
+        }
+    }
 }
 
 // MARK: DAppSearchPresenterProtocol
@@ -105,20 +122,12 @@ extension DAppSearchPresenter: DAppSearchPresenterProtocol {
             .query(string: viewModel.identifier)
         }
 
-        // the delegate might present a screen from the underlying view,
-        // so it must be notified only after the search is dismissed
-        wireframe.close(from: view) { [weak self] in
-            self?.delegate?.didCompleteDAppSearchResult(result)
-        }
+        completeSearch(with: result)
     }
 
     func selectSearchQuery() {
         let proceedClosure: () -> Void = { [weak self] in
-            self?.wireframe.close(from: self?.view) {
-                self?.delegate?.didCompleteDAppSearchResult(
-                    .query(string: self?.query ?? "")
-                )
-            }
+            self?.completeSearch(with: .query(string: self?.query ?? ""))
         }
 
         guard search(by: query, in: dAppList).isEmpty else {

--- a/novawallet/Modules/DApp/DAppSearch/DAppSearchPresenter.swift
+++ b/novawallet/Modules/DApp/DAppSearch/DAppSearchPresenter.swift
@@ -57,6 +57,10 @@ final class DAppSearchPresenter: DAppSearchingByQuery {
             view?.didReceive(viewModel: nil)
         }
     }
+
+    private func provideStakingBanner() {
+        view?.didReceive(stakingBannerVisible: DAppStakingDetection.isStakingQuery(query))
+    }
 }
 
 // MARK: DAppSearchPresenterProtocol
@@ -72,6 +76,8 @@ extension DAppSearchPresenter: DAppSearchPresenterProtocol {
             view?.didReceive(initialQuery: query)
         }
 
+        provideStakingBanner()
+
         interactor.setup()
     }
 
@@ -79,6 +85,11 @@ extension DAppSearchPresenter: DAppSearchPresenterProtocol {
         self.query = query
 
         provideViewModel()
+        provideStakingBanner()
+    }
+
+    func activateStaking() {
+        wireframe.redirectToStaking(from: view)
     }
 
     func selectDApp(viewModel: DAppViewModel) {
@@ -86,21 +97,28 @@ extension DAppSearchPresenter: DAppSearchPresenterProtocol {
             return
         }
 
-        if let dApp = dAppList.dApps.first(where: { $0.identifier == viewModel.identifier }) {
-            delegate?.didCompleteDAppSearchResult(.dApp(model: dApp))
+        let result: DAppSearchResult = if let dApp = dAppList.dApps.first(
+            where: { $0.identifier == viewModel.identifier }
+        ) {
+            .dApp(model: dApp)
         } else {
-            delegate?.didCompleteDAppSearchResult(.query(string: viewModel.identifier))
+            .query(string: viewModel.identifier)
         }
 
-        wireframe.close(from: view)
+        // the delegate might present a screen from the underlying view,
+        // so it must be notified only after the search is dismissed
+        wireframe.close(from: view) { [weak self] in
+            self?.delegate?.didCompleteDAppSearchResult(result)
+        }
     }
 
     func selectSearchQuery() {
         let proceedClosure: () -> Void = { [weak self] in
-            self?.delegate?.didCompleteDAppSearchResult(
-                .query(string: self?.query ?? "")
-            )
-            self?.wireframe.close(from: self?.view)
+            self?.wireframe.close(from: self?.view) {
+                self?.delegate?.didCompleteDAppSearchResult(
+                    .query(string: self?.query ?? "")
+                )
+            }
         }
 
         guard search(by: query, in: dAppList).isEmpty else {

--- a/novawallet/Modules/DApp/DAppSearch/DAppSearchProtocols.swift
+++ b/novawallet/Modules/DApp/DAppSearch/DAppSearchProtocols.swift
@@ -3,6 +3,7 @@ import Operation_iOS
 protocol DAppSearchViewProtocol: ControllerBackedProtocol {
     func didReceive(initialQuery: String)
     func didReceive(viewModel: DAppListViewModel?)
+    func didReceive(stakingBannerVisible: Bool)
 }
 
 protocol DAppSearchPresenterProtocol: AnyObject {
@@ -11,6 +12,7 @@ protocol DAppSearchPresenterProtocol: AnyObject {
     func selectDApp(viewModel: DAppViewModel)
     func selectCategory(with id: String?)
     func selectSearchQuery()
+    func activateStaking()
     func cancel()
 }
 
@@ -23,8 +25,14 @@ protocol DAppSearchInteractorOutputProtocol: AnyObject {
     func didReceiveFavorite(changes: [DataProviderChange<DAppFavorite>])
 }
 
-protocol DAppSearchWireframeProtocol: DAppAlertPresentable {
-    func close(from view: DAppSearchViewProtocol?)
+protocol DAppSearchWireframeProtocol: DAppAlertPresentable, StakingRedirectPresentable {
+    func close(from view: DAppSearchViewProtocol?, completion: (() -> Void)?)
+}
+
+extension DAppSearchWireframeProtocol {
+    func close(from view: DAppSearchViewProtocol?) {
+        close(from: view, completion: nil)
+    }
 }
 
 protocol DAppSearchDelegate: AnyObject {

--- a/novawallet/Modules/DApp/DAppSearch/DAppSearchProtocols.swift
+++ b/novawallet/Modules/DApp/DAppSearch/DAppSearchProtocols.swift
@@ -36,5 +36,8 @@ extension DAppSearchWireframeProtocol {
 }
 
 protocol DAppSearchDelegate: AnyObject {
-    func didCompleteDAppSearchResult(_ result: DAppSearchResult)
+    func didCompleteDAppSearchResult(
+        _ result: DAppSearchResult,
+        isThirdPartyStaking: Bool
+    )
 }

--- a/novawallet/Modules/DApp/DAppSearch/DAppSearchViewController.swift
+++ b/novawallet/Modules/DApp/DAppSearch/DAppSearchViewController.swift
@@ -61,6 +61,7 @@ final class DAppSearchViewController: UIViewController, ViewHolder {
         setupTableView()
         setupSearchBar()
         setupCategoriesBar()
+        setupStakingBanner()
         setupLocalization()
 
         presenter.setup()
@@ -81,6 +82,11 @@ private extension DAppSearchViewController {
         rootView.searchBar.textField.placeholder = R.string(preferredLanguages: languages).localizable.dappListSearch()
 
         rootView.cancelBarItem.title = R.string(preferredLanguages: languages).localizable.commonCancel()
+
+        rootView.stakingBannerView.bind(
+            message: R.string(preferredLanguages: languages).localizable.dappStakingBannerMessage(),
+            actionTitle: R.string(preferredLanguages: languages).localizable.commonGoToStaking()
+        )
     }
 
     func setupTableView() {
@@ -111,6 +117,18 @@ private extension DAppSearchViewController {
 
     func setupCategoriesBar() {
         rootView.categoriesView.delegate = self
+    }
+
+    func setupStakingBanner() {
+        rootView.stakingBannerView.actionButton.addTarget(
+            self,
+            action: #selector(actionStakingBanner),
+            for: .touchUpInside
+        )
+    }
+
+    @objc func actionStakingBanner() {
+        presenter.activateStaking()
     }
 
     @objc func actionTextFieldChanged() {
@@ -276,6 +294,10 @@ extension DAppSearchViewController: DAppSearchViewProtocol {
         )
 
         rootView.tableView.reloadData()
+    }
+
+    func didReceive(stakingBannerVisible: Bool) {
+        rootView.setStakingBanner(visible: stakingBannerVisible)
     }
 }
 

--- a/novawallet/Modules/DApp/DAppSearch/DAppSearchViewLayout.swift
+++ b/novawallet/Modules/DApp/DAppSearch/DAppSearchViewLayout.swift
@@ -13,6 +13,10 @@ final class DAppSearchViewLayout: UIView {
         view.borderType = []
     }
 
+    let stakingBannerView: DAppStakingBannerView = .create { view in
+        view.isHidden = true
+    }
+
     let tableView: UITableView = {
         let view = UITableView()
         view.backgroundColor = .clear
@@ -40,9 +44,18 @@ final class DAppSearchViewLayout: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    func setStakingBanner(visible: Bool) {
+        stakingBannerView.isHidden = !visible
+
+        stakingBannerView.snp.updateConstraints { make in
+            make.height.equalTo(visible ? Constants.stakingBannerHeight : 0.0)
+        }
+    }
+
     private func setupLayout() {
         addSubview(topBackgroundView)
         addSubview(categoriesView)
+        addSubview(stakingBannerView)
         addSubview(tableView)
 
         categoriesView.snp.makeConstraints { make in
@@ -56,8 +69,14 @@ final class DAppSearchViewLayout: UIView {
             make.bottom.equalTo(categoriesView).inset(-Constants.categoriesViewVerticalInset)
         }
 
-        tableView.snp.makeConstraints { make in
+        stakingBannerView.snp.makeConstraints { make in
             make.top.equalTo(topBackgroundView.snp.bottom)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(0.0)
+        }
+
+        tableView.snp.makeConstraints { make in
+            make.top.equalTo(stakingBannerView.snp.bottom)
             make.leading.trailing.bottom.equalToSuperview()
         }
     }
@@ -68,5 +87,6 @@ final class DAppSearchViewLayout: UIView {
 private extension DAppSearchViewLayout {
     enum Constants {
         static let categoriesViewVerticalInset: CGFloat = 8.0
+        static let stakingBannerHeight: CGFloat = 64.0
     }
 }

--- a/novawallet/Modules/DApp/DAppSearch/DAppSearchWireframe.swift
+++ b/novawallet/Modules/DApp/DAppSearch/DAppSearchWireframe.swift
@@ -1,7 +1,11 @@
 import Foundation
 
 final class DAppSearchWireframe: DAppSearchWireframeProtocol {
-    func close(from view: DAppSearchViewProtocol?) {
-        view?.controller.presentingViewController?.dismiss(animated: true)
+    func close(from view: DAppSearchViewProtocol?, completion: (() -> Void)?) {
+        if let presentingController = view?.controller.presentingViewController {
+            presentingController.dismiss(animated: true, completion: completion)
+        } else {
+            completion?()
+        }
     }
 }

--- a/novawallet/Modules/DApp/DAppSearch/View/DAppStakingBannerView.swift
+++ b/novawallet/Modules/DApp/DAppSearch/View/DAppStakingBannerView.swift
@@ -1,0 +1,67 @@
+import UIKit
+import UIKit_iOS
+
+final class DAppStakingBannerView: UIView {
+    let titleLabel: UILabel = .create { view in
+        view.apply(style: .footnotePrimary)
+        view.numberOfLines = 2
+    }
+
+    let actionButton: RoundedButton = .create { view in
+        view.applyPrimaryStyle()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = R.color.colorBlockBackground()
+
+        setupLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: Internal
+
+extension DAppStakingBannerView {
+    func bind(message: String, actionTitle: String) {
+        titleLabel.text = message
+        actionButton.imageWithTitleView?.title = actionTitle
+        actionButton.invalidateLayout()
+    }
+}
+
+// MARK: Private
+
+private extension DAppStakingBannerView {
+    func setupLayout() {
+        addSubview(actionButton)
+        actionButton.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().inset(Constants.horizontalInset)
+            make.centerY.equalToSuperview()
+        }
+
+        actionButton.setContentHuggingPriority(.required, for: .horizontal)
+        actionButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(Constants.horizontalInset)
+            make.trailing.lessThanOrEqualTo(actionButton.snp.leading).offset(-Constants.contentSpacing)
+            make.centerY.equalToSuperview()
+        }
+    }
+}
+
+// MARK: Constants
+
+private extension DAppStakingBannerView {
+    enum Constants {
+        static let horizontalInset: CGFloat = 16.0
+        static let contentSpacing: CGFloat = 12.0
+    }
+}

--- a/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticePresenter.swift
+++ b/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticePresenter.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+final class DAppStakingNoticePresenter {
+    weak var view: DAppStakingNoticeViewProtocol?
+    let wireframe: DAppStakingNoticeWireframeProtocol
+
+    init(wireframe: DAppStakingNoticeWireframeProtocol) {
+        self.wireframe = wireframe
+    }
+}
+
+// MARK: DAppStakingNoticePresenterProtocol
+
+extension DAppStakingNoticePresenter: DAppStakingNoticePresenterProtocol {
+    func setup() {}
+
+    func goToStaking() {
+        wireframe.redirectToStaking(from: view)
+    }
+
+    func continueToSite() {
+        wireframe.complete(from: view)
+    }
+}

--- a/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticeProtocols.swift
+++ b/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticeProtocols.swift
@@ -1,0 +1,15 @@
+protocol DAppStakingNoticeDelegate: AnyObject {
+    func dappStakingNoticeDidSelectContinue()
+}
+
+protocol DAppStakingNoticeViewProtocol: ControllerBackedProtocol {}
+
+protocol DAppStakingNoticePresenterProtocol: AnyObject {
+    func setup()
+    func goToStaking()
+    func continueToSite()
+}
+
+protocol DAppStakingNoticeWireframeProtocol: StakingRedirectPresentable {
+    func complete(from view: DAppStakingNoticeViewProtocol?)
+}

--- a/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticeViewController.swift
+++ b/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticeViewController.swift
@@ -1,0 +1,129 @@
+import UIKit
+import Foundation_iOS
+
+final class DAppStakingNoticeViewController: UIViewController, ViewHolder {
+    typealias RootViewType = DAppStakingNoticeViewLayout
+
+    let presenter: DAppStakingNoticePresenterProtocol
+
+    private var isContinueRevealed: Bool = false
+
+    init(
+        presenter: DAppStakingNoticePresenterProtocol,
+        localizationManager: LocalizationManagerProtocol
+    ) {
+        self.presenter = presenter
+        super.init(nibName: nil, bundle: nil)
+
+        preferredContentSize = CGSize(width: 0.0, height: Constants.preferredHeight)
+        self.localizationManager = localizationManager
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = DAppStakingNoticeViewLayout()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupHandlers()
+        setupLocalization()
+        presenter.setup()
+    }
+}
+
+// MARK: Private
+
+private extension DAppStakingNoticeViewController {
+    func setupHandlers() {
+        rootView.actionButton.addTarget(
+            self,
+            action: #selector(actionGoToStaking),
+            for: .touchUpInside
+        )
+
+        rootView.secondaryActionButton.addTarget(
+            self,
+            action: #selector(actionSecondary),
+            for: .touchUpInside
+        )
+    }
+
+    func setupLocalization() {
+        let languages = selectedLocale.rLanguages
+
+        rootView.titleLabel.text = R.string(
+            preferredLanguages: languages
+        ).localizable.dappStakingNoticeTitle()
+
+        rootView.subtitleLabel.text = R.string(
+            preferredLanguages: languages
+        ).localizable.dappStakingNoticeMessage()
+
+        rootView.actionButton.imageWithTitleView?.title = R.string(
+            preferredLanguages: languages
+        ).localizable.commonGoToStaking()
+
+        applySecondaryActionState()
+    }
+
+    func applySecondaryActionState() {
+        let languages = selectedLocale.rLanguages
+
+        let title = if isContinueRevealed {
+            R.string(preferredLanguages: languages).localizable.dappStakingNoticeContinue()
+        } else {
+            R.string(preferredLanguages: languages).localizable.commonAdvanced()
+        }
+
+        rootView.setSecondaryAction(title: title, prominent: isContinueRevealed)
+    }
+
+    @objc func actionGoToStaking() {
+        presenter.goToStaking()
+    }
+
+    @objc func actionSecondary() {
+        if isContinueRevealed {
+            presenter.continueToSite()
+        } else {
+            isContinueRevealed = true
+
+            UIView.transition(
+                with: rootView.secondaryActionButton,
+                duration: Constants.revealAnimationDuration,
+                options: .transitionCrossDissolve
+            ) { [weak self] in
+                self?.applySecondaryActionState()
+            }
+        }
+    }
+}
+
+// MARK: DAppStakingNoticeViewProtocol
+
+extension DAppStakingNoticeViewController: DAppStakingNoticeViewProtocol {}
+
+// MARK: Localizable
+
+extension DAppStakingNoticeViewController: Localizable {
+    func applyLocalization() {
+        if isViewLoaded {
+            setupLocalization()
+        }
+    }
+}
+
+// MARK: Constants
+
+private extension DAppStakingNoticeViewController {
+    enum Constants {
+        static let preferredHeight: CGFloat = 336.0
+        static let revealAnimationDuration: TimeInterval = 0.2
+    }
+}

--- a/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticeViewFactory.swift
+++ b/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticeViewFactory.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Foundation_iOS
+
+struct DAppStakingNoticeViewFactory {
+    static func createView(with delegate: DAppStakingNoticeDelegate) -> DAppStakingNoticeViewProtocol? {
+        let wireframe = DAppStakingNoticeWireframe()
+        wireframe.delegate = delegate
+
+        let presenter = DAppStakingNoticePresenter(wireframe: wireframe)
+
+        let view = DAppStakingNoticeViewController(
+            presenter: presenter,
+            localizationManager: LocalizationManager.shared
+        )
+
+        presenter.view = view
+
+        return view
+    }
+}

--- a/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticeViewLayout.swift
+++ b/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticeViewLayout.swift
@@ -4,6 +4,7 @@ import UIKit_iOS
 final class DAppStakingNoticeViewLayout: UIView {
     let iconView: DAppIconView = .create { view in
         view.backgroundView.cornerRadius = Constants.iconCornerRadius
+        view.contentInsets = Constants.iconInsets
 
         let viewModel = StaticImageViewModel(image: R.image.iconInfoFilled()!)
         view.bind(viewModel: viewModel, size: Constants.displayIconSize)

--- a/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticeViewLayout.swift
+++ b/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticeViewLayout.swift
@@ -1,0 +1,118 @@
+import UIKit
+import UIKit_iOS
+
+final class DAppStakingNoticeViewLayout: UIView {
+    let iconView: DAppIconView = .create { view in
+        view.backgroundView.cornerRadius = Constants.iconCornerRadius
+
+        let viewModel = StaticImageViewModel(image: R.image.iconInfoFilled()!)
+        view.bind(viewModel: viewModel, size: Constants.displayIconSize)
+    }
+
+    let titleLabel: UILabel = .create { view in
+        view.apply(style: .title3Primary)
+        view.textAlignment = .center
+        view.numberOfLines = 1
+    }
+
+    let subtitleLabel: UILabel = .create { view in
+        view.apply(style: .footnoteSecondary)
+        view.textAlignment = .center
+        view.numberOfLines = 0
+    }
+
+    let actionButton: TriangularedButton = .create { view in
+        view.applyDefaultStyle()
+    }
+
+    let secondaryActionButton: RoundedButton = .create { view in
+        view.applyTextStyle()
+        view.imageWithTitleView?.titleFont = .semiBoldSubheadline
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = R.color.colorBottomSheetBackground()
+
+        setupLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: Internal
+
+extension DAppStakingNoticeViewLayout {
+    func setSecondaryAction(title: String, prominent: Bool) {
+        secondaryActionButton.imageWithTitleView?.title = title
+        secondaryActionButton.imageWithTitleView?.titleColor = prominent
+            ? R.color.colorButtonTextAccent()!
+            : R.color.colorTextSecondary()!
+        secondaryActionButton.invalidateLayout()
+    }
+}
+
+// MARK: Private
+
+private extension DAppStakingNoticeViewLayout {
+    func setupLayout() {
+        addSubview(iconView)
+        iconView.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(Constants.iconTopInset)
+            make.size.equalTo(Constants.iconSize)
+            make.centerX.equalToSuperview()
+        }
+
+        addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(iconView.snp.bottom).offset(Constants.titleTopOffset)
+            make.leading.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
+        }
+
+        addSubview(subtitleLabel)
+        subtitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(Constants.subtitleTopOffset)
+            make.leading.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
+        }
+
+        addSubview(secondaryActionButton)
+        secondaryActionButton.snp.makeConstraints { make in
+            make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).offset(-UIConstants.actionBottomInset)
+            make.centerX.equalToSuperview()
+            make.height.equalTo(Constants.secondaryActionHeight)
+        }
+
+        addSubview(actionButton)
+        actionButton.snp.makeConstraints { make in
+            make.bottom.equalTo(secondaryActionButton.snp.top).offset(-Constants.actionsSpacing)
+            make.leading.trailing.equalToSuperview().inset(UIConstants.horizontalInset)
+            make.height.equalTo(UIConstants.actionHeight)
+        }
+    }
+}
+
+// MARK: Constants
+
+private extension DAppStakingNoticeViewLayout {
+    enum Constants {
+        static let iconSize = CGSize(width: 88, height: 88)
+        static let iconCornerRadius: CGFloat = 24.0
+        static let iconInsets = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+        static let iconTopInset: CGFloat = 4.0
+        static let titleTopOffset: CGFloat = 20.0
+        static let subtitleTopOffset: CGFloat = 12.0
+        static let actionsSpacing: CGFloat = 12.0
+        static let secondaryActionHeight: CGFloat = 24.0
+
+        static var displayIconSize: CGSize {
+            CGSize(
+                width: iconSize.width - iconInsets.left - iconInsets.right,
+                height: iconSize.height - iconInsets.top - iconInsets.bottom
+            )
+        }
+    }
+}

--- a/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticeWireframe.swift
+++ b/novawallet/Modules/DApp/DAppStakingNotice/DAppStakingNoticeWireframe.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+final class DAppStakingNoticeWireframe: DAppStakingNoticeWireframeProtocol {
+    weak var delegate: DAppStakingNoticeDelegate?
+
+    func complete(from view: DAppStakingNoticeViewProtocol?) {
+        view?.controller.dismiss(animated: true) { [weak delegate] in
+            delegate?.dappStakingNoticeDidSelectContinue()
+        }
+    }
+}

--- a/novawallet/Modules/DApp/Model/DAppStakingDetection.swift
+++ b/novawallet/Modules/DApp/Model/DAppStakingDetection.swift
@@ -73,11 +73,19 @@ private extension DAppStakingDetection {
             return false
         }
 
-        let normalizedHost = host.lowercased()
+        let normalizedHost = normalized(host: host)
 
         return dAppList.dApps.contains { dApp in
-            isStakingDApp(dApp) && dApp.url.host?.lowercased() == normalizedHost
+            isStakingDApp(dApp) && dApp.url.host.map { normalized(host: $0) } == normalizedHost
         }
+    }
+
+    static func normalized(host: String) -> String {
+        let lowercasedHost = host.lowercased()
+
+        return lowercasedHost.hasPrefix("www.")
+            ? String(lowercasedHost.dropFirst("www.".count))
+            : lowercasedHost
     }
 
     static func resolveHost(for query: String) -> String? {

--- a/novawallet/Modules/DApp/Model/DAppStakingDetection.swift
+++ b/novawallet/Modules/DApp/Model/DAppStakingDetection.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+enum DAppStakingDetection {
+    // Latin/Cyrillic keywords are matched as token prefixes so that "staking", "staker",
+    // "стейкинг" match while "mistake" does not; CJK scripts have no word boundaries,
+    // so full terms are matched as substrings
+    private static let stakingTokenPrefixes = ["stak", "стейк"]
+    private static let stakingSubstrings = ["质押", "質押", "ステーキング", "스테이킹"]
+
+    static func isStakingQuery(_ query: String?) -> Bool {
+        guard let query, !query.isEmpty else {
+            return false
+        }
+
+        let normalizedQuery = query.lowercased()
+
+        let tokens = normalizedQuery.components(separatedBy: CharacterSet.alphanumerics.inverted)
+
+        let hasKeywordToken = tokens.contains { token in
+            stakingTokenPrefixes.contains { token.hasPrefix($0) }
+        }
+
+        guard !hasKeywordToken else {
+            return true
+        }
+
+        return stakingSubstrings.contains { normalizedQuery.contains($0) }
+    }
+
+    static func isThirdPartyStakingSite(
+        result: DAppSearchResult,
+        dAppList: DAppList?
+    ) -> Bool {
+        switch result {
+        case let .dApp(dApp):
+            return isStakingDApp(dApp) || isStakingHost(dApp.url.host)
+        case let .query(query):
+            // a free-text query falls back to a web search page which is not a staking site,
+            // so only queries resolving to a url the same way DAppBrowserTab does are checked
+            guard
+                NSPredicate.urlPredicate.evaluate(with: query),
+                let host = resolveHost(for: query)
+            else {
+                return false
+            }
+
+            return isStakingHost(host) || hasCuratedStakingDApp(withHost: host, in: dAppList)
+        }
+    }
+}
+
+// MARK: Private
+
+private extension DAppStakingDetection {
+    static func isStakingDApp(_ dApp: DApp) -> Bool {
+        dApp.categories.contains(KnownDAppCategory.staking.rawValue)
+    }
+
+    static func isStakingHost(_ host: String?) -> Bool {
+        guard let host else {
+            return false
+        }
+
+        let labels = host.lowercased().components(separatedBy: ".")
+
+        return labels.contains { label in
+            stakingTokenPrefixes.contains { label.hasPrefix($0) }
+        }
+    }
+
+    static func hasCuratedStakingDApp(withHost host: String, in dAppList: DAppList?) -> Bool {
+        guard let dAppList else {
+            return false
+        }
+
+        let normalizedHost = host.lowercased()
+
+        return dAppList.dApps.contains { dApp in
+            isStakingDApp(dApp) && dApp.url.host?.lowercased() == normalizedHost
+        }
+    }
+
+    static func resolveHost(for query: String) -> String? {
+        var urlComponents = URLComponents(string: query)
+
+        if urlComponents?.scheme == nil {
+            urlComponents = URLComponents(string: "https://" + query)
+        }
+
+        return urlComponents?.host
+    }
+}

--- a/novawallet/Modules/DApp/Protocols/DAppStakingNoticePresentable.swift
+++ b/novawallet/Modules/DApp/Protocols/DAppStakingNoticePresentable.swift
@@ -1,0 +1,28 @@
+import UIKit
+import UIKit_iOS
+
+protocol DAppStakingNoticePresentable {
+    func presentStakingNotice(
+        from view: ControllerBackedProtocol?,
+        delegate: DAppStakingNoticeDelegate
+    )
+}
+
+extension DAppStakingNoticePresentable {
+    func presentStakingNotice(
+        from view: ControllerBackedProtocol?,
+        delegate: DAppStakingNoticeDelegate
+    ) {
+        guard let noticeView = DAppStakingNoticeViewFactory.createView(with: delegate) else {
+            return
+        }
+
+        let factory = ModalSheetPresentationFactory(
+            configuration: ModalSheetPresentationConfiguration.novaManual
+        )
+        noticeView.controller.modalTransitioningFactory = factory
+        noticeView.controller.modalPresentationStyle = .custom
+
+        view?.controller.present(noticeView.controller, animated: true, completion: nil)
+    }
+}

--- a/novawallet/Modules/NovaMainAppContainer/NovaMainAppContainerProtocols.swift
+++ b/novawallet/Modules/NovaMainAppContainer/NovaMainAppContainerProtocols.swift
@@ -1,5 +1,6 @@
 protocol NovaMainAppContainerViewProtocol: ControllerBackedProtocol, BrowserNavigationProviding {
     func openBrowser(with tab: DAppBrowserTab?)
+    func minimizeBrowser()
 }
 
 protocol NovaMainAppContainerPresenterProtocol: AnyObject {

--- a/novawallet/Modules/NovaMainAppContainer/NovaMainAppContainerViewController.swift
+++ b/novawallet/Modules/NovaMainAppContainer/NovaMainAppContainerViewController.swift
@@ -269,6 +269,10 @@ extension NovaMainAppContainerViewController: NovaMainAppContainerViewProtocol {
     func openBrowser(with tab: DAppBrowserTab?) {
         browserWidget?.openBrowser(with: tab)
     }
+
+    func minimizeBrowser() {
+        browserWidget?.minimizeBrowser()
+    }
 }
 
 // MARK: Constants

--- a/novawallet/en.lproj/Localizable.strings
+++ b/novawallet/en.lproj/Localizable.strings
@@ -2043,3 +2043,8 @@ Do you want to continue?";
 "inlinable.alert.wo.message" = "Beware of scammers. No one can unlock a watch-only wallet or its funds";
 "create.watch.only.missing.any.address" = "Enter at least one address...";
 "asset.list.watch.only.balance" = "Watch-only balance";
+"common.go.to.staking" = "Go to Staking";
+"dapp.staking.banner.message" = "Looking to stake? Nova Wallet has built-in staking.";
+"dapp.staking.notice.title" = "Notice";
+"dapp.staking.notice.message" = "Third-party staking sites often become deprecated. We recommend using Nova Wallet's built-in staking features.";
+"dapp.staking.notice.continue" = "Continue to site";

--- a/novawalletTests/Modules/DApps/DAppSearch/DAppSearchTests.swift
+++ b/novawalletTests/Modules/DApps/DAppSearch/DAppSearchTests.swift
@@ -62,6 +62,8 @@ class DAppSearchTests: XCTestCase {
                     dAppSetupExpectatation.fulfill()
                 }
             }
+
+            when(stub.didReceive(stakingBannerVisible: any())).thenDoNothing()
         }
 
         presenter.setup()
@@ -109,8 +111,9 @@ class DAppSearchTests: XCTestCase {
         }
 
         stub(wireframe) { stub in
-            when(stub.close(from: any())).then { _ in
+            when(stub.close(from: any(), completion: any())).then { _, completion in
                 dAppSelectionCloseExpectation.fulfill()
+                completion?()
             }
         }
 

--- a/novawalletTests/Modules/DApps/DAppSearch/DAppSearchTests.swift
+++ b/novawalletTests/Modules/DApps/DAppSearch/DAppSearchTests.swift
@@ -103,7 +103,7 @@ class DAppSearchTests: XCTestCase {
         let dAppSelectionCloseExpectation = XCTestExpectation()
 
         stub(delegate) { stub in
-            when(stub.didCompleteDAppSearchResult(any())).then { result in
+            when(stub.didCompleteDAppSearchResult(any(), isThirdPartyStaking: any())).then { result, _ in
                 if case .dApp = result {
                     dAppSelectionExpectation.fulfill()
                 }

--- a/novawalletTests/Modules/DApps/DAppStakingDetectionTests.swift
+++ b/novawalletTests/Modules/DApps/DAppStakingDetectionTests.swift
@@ -76,6 +76,21 @@ final class DAppStakingDetectionTests: XCTestCase {
                 dAppList: dAppList
             )
         )
+
+        // the www spelling of a curated host is the same site
+        XCTAssertTrue(
+            DAppStakingDetection.isThirdPartyStakingSite(
+                result: .query(string: "www.omni.ls"),
+                dAppList: dAppList
+            )
+        )
+
+        XCTAssertTrue(
+            DAppStakingDetection.isThirdPartyStakingSite(
+                result: .query(string: "https://www.omni.ls/app"),
+                dAppList: dAppList
+            )
+        )
     }
 
     func testNonStakingQueryResultsIgnored() {

--- a/novawalletTests/Modules/DApps/DAppStakingDetectionTests.swift
+++ b/novawalletTests/Modules/DApps/DAppStakingDetectionTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import novawallet
+
+final class DAppStakingDetectionTests: XCTestCase {
+    func testStakingQueriesDetected() {
+        XCTAssertTrue(DAppStakingDetection.isStakingQuery("staking"))
+        XCTAssertTrue(DAppStakingDetection.isStakingQuery("dot Staking"))
+        XCTAssertTrue(DAppStakingDetection.isStakingQuery("STAKE dot"))
+        XCTAssertTrue(DAppStakingDetection.isStakingQuery("stake yapmak"))
+        XCTAssertTrue(DAppStakingDetection.isStakingQuery("стейкинг"))
+        XCTAssertTrue(DAppStakingDetection.isStakingQuery("стейкінг дот"))
+        XCTAssertTrue(DAppStakingDetection.isStakingQuery("质押"))
+        XCTAssertTrue(DAppStakingDetection.isStakingQuery("polkadot 質押"))
+        XCTAssertTrue(DAppStakingDetection.isStakingQuery("ステーキング"))
+        XCTAssertTrue(DAppStakingDetection.isStakingQuery("스테이킹"))
+        XCTAssertTrue(DAppStakingDetection.isStakingQuery("staking.polkadot.cloud"))
+    }
+
+    func testNonStakingQueriesIgnored() {
+        XCTAssertFalse(DAppStakingDetection.isStakingQuery(nil))
+        XCTAssertFalse(DAppStakingDetection.isStakingQuery(""))
+        XCTAssertFalse(DAppStakingDetection.isStakingQuery("mistake"))
+        XCTAssertFalse(DAppStakingDetection.isStakingQuery("swap dot"))
+        XCTAssertFalse(DAppStakingDetection.isStakingQuery("hydration"))
+
+        // japanese "steak" must not trigger the japanese "staking" substring
+        XCTAssertFalse(DAppStakingDetection.isStakingQuery("ステーキ"))
+    }
+
+    func testStakingDAppResultDetected() {
+        let stakingDApp = makeDApp(url: "https://dashboard.example.com", categories: ["staking", "utilities"])
+
+        XCTAssertTrue(
+            DAppStakingDetection.isThirdPartyStakingSite(result: .dApp(model: stakingDApp), dAppList: nil)
+        )
+
+        let stakingHostDApp = makeDApp(url: "https://staking.example.com", categories: ["defi"])
+
+        XCTAssertTrue(
+            DAppStakingDetection.isThirdPartyStakingSite(result: .dApp(model: stakingHostDApp), dAppList: nil)
+        )
+    }
+
+    func testNonStakingDAppResultIgnored() {
+        let dexDApp = makeDApp(url: "https://app.hydration.net", categories: ["dex"])
+
+        XCTAssertFalse(
+            DAppStakingDetection.isThirdPartyStakingSite(result: .dApp(model: dexDApp), dAppList: nil)
+        )
+    }
+
+    func testStakingUrlQueryDetected() {
+        // host label detection works without a curated list
+        XCTAssertTrue(
+            DAppStakingDetection.isThirdPartyStakingSite(
+                result: .query(string: "staking.polkadot.cloud"),
+                dAppList: nil
+            )
+        )
+
+        XCTAssertTrue(
+            DAppStakingDetection.isThirdPartyStakingSite(
+                result: .query(string: "https://staking.polkadot.cloud/#/overview"),
+                dAppList: nil
+            )
+        )
+
+        // a neutral host is matched through the curated staking category
+        let dAppList = makeDAppList(
+            dApps: [makeDApp(url: "https://omni.ls/app", categories: ["staking"])]
+        )
+
+        XCTAssertTrue(
+            DAppStakingDetection.isThirdPartyStakingSite(
+                result: .query(string: "omni.ls"),
+                dAppList: dAppList
+            )
+        )
+    }
+
+    func testNonStakingQueryResultsIgnored() {
+        let dAppList = makeDAppList(
+            dApps: [makeDApp(url: "https://omni.ls/app", categories: ["staking"])]
+        )
+
+        // free text falls back to a web search page, not a staking site
+        XCTAssertFalse(
+            DAppStakingDetection.isThirdPartyStakingSite(
+                result: .query(string: "staking"),
+                dAppList: dAppList
+            )
+        )
+
+        XCTAssertFalse(
+            DAppStakingDetection.isThirdPartyStakingSite(
+                result: .query(string: "hydration.net"),
+                dAppList: dAppList
+            )
+        )
+
+        XCTAssertFalse(
+            DAppStakingDetection.isThirdPartyStakingSite(
+                result: .query(string: "https://app.hydration.net/trade"),
+                dAppList: dAppList
+            )
+        )
+    }
+}
+
+// MARK: Private
+
+private extension DAppStakingDetectionTests {
+    func makeDApp(url: String, categories: [String]) -> DApp {
+        DApp(
+            name: "DApp",
+            url: URL(string: url)!,
+            icon: nil,
+            categories: categories,
+            desktopOnly: nil
+        )
+    }
+
+    func makeDAppList(dApps: [DApp]) -> DAppList {
+        DAppList(popular: [], categories: [], dApps: dApps)
+    }
+}


### PR DESCRIPTION
## Purpose

Steer users towards built-in staking before they reach a third-party staking site from the dApp browser: an inline banner in dApp search while the query looks like staking, and a bottom-sheet notice when the destination they actually picked is a staking site.

## Key Changes

### Detection

`DAppStakingDetection` — two independent checks, deliberately not the same rule:

- `isStakingQuery` drives the inline banner while typing. Latin/Cyrillic keywords match as **token prefixes** (`stak`, `стейк`) so "staking", "staker", "стейкинг" hit and "mistake" does not; CJK terms (质押 / 質押 / ステーキング / 스테이킹) match as substrings, because those scripts have no word boundaries to anchor a prefix to.
- `isThirdPartyStakingSite` decides whether the notice is shown. A curated dApp qualifies via the `staking` category or a `stak*` host label. A free-text query resolves its host exactly the way `DAppBrowserTab.resolveUrl` does — same `NSPredicate.urlPredicate` gate — so typing "staking" as free text (which becomes a DuckDuckGo search page, not a staking site) does **not** raise the sheet, while `staking.polkadot.cloud` or a curated staking host does, with or without a `www.` prefix.

### Search banner

- New `DAppStakingBannerView` and `RoundedButton.applyPrimaryStyle()`. `DAppSearchViewLayout` puts it between the categories bar and the table and collapses its height to 0 when hidden, so the table does not shift.
- `DAppSearchPresenter.provideStakingBanner()` runs on setup and on every query change; the "Go to Staking" button routes through the new `StakingRedirectPresentable`.

### Notice sheet

- New `DAppStakingNotice` VIPER module, presented as a `novaManual` modal sheet via `DAppStakingNoticePresentable` — adopted by the three wireframes whose presenters own a search delegate (browser, tab list, dApp list).
- The secondary action is two-step: it starts as "Advanced" and cross-dissolves into an accent-coloured "Continue to site" on first tap, so proceeding to the third-party site is a deliberate second action rather than a mis-tap.
- Classification happens in `DAppSearchPresenter` — the only delegate-independent place that holds the curated dApp list — but the delegate is notified only **after** the search screen has dismissed, since it may present a screen from the view underneath. That is what `close(from:completion:)` and the new `isThirdPartyStaking` flag on `didCompleteDAppSearchResult` are for. Each of the three delegates parks the result in `pendingStakingSearchResult` and replays it from `dappStakingNoticeDidSelectContinue()`.

### Staking redirect

- `StakingRedirectPresentable` dismisses whatever is presented, minimizes the browser (the fullscreen browser covers the tab bar), selects the staking tab and pops it to root.
- `minimizeBrowser()` is plumbed `BrowserNavigationProtocol` → `NovaMainAppContainer` → `DAppBrowserWidget`. The widget ignores the request unless it is `.fullBrowser` — the presenter also owns the `.closed` state that restores the miniature on launch — and delegates to the browser controller's own `minimizeFromParent()` (new `DAppBrowserMinimizing`) instead of its plain `minimize()`. That matters: only the browser's own close sequence persists the tab render and calls `didDecideClose()`, which reverts `DeviceOrientationManager.enableLandscape()` taken in `viewWillAppear`. `DAppBrowserViewController.actionClose()` now calls the same method, so the close button and the external minimize share one path.

### Tooling

- `.claude` excluded from SwiftLint and SwiftFormat.
- New code-checklist item for process-wide state acquired in a lifecycle hook — written from the landscape case above.

## Tests

- `DAppStakingDetectionTests` (new) — query detection across Latin, Cyrillic and CJK, including the negatives that matter: `mistake`, and Japanese ステーキ ("steak") against the ステーキング substring; dApp results by category and by host label; URL queries by host label and via the curated staking list, `www.` included; and the free-text/non-staking-host cases that must stay silent.
- `DAppSearchTests` — updated for the new `didCompleteDAppSearchResult(_:isThirdPartyStaking:)` signature and for `close(from:completion:)`, with the completion invoked so the delegate assertion still runs.

## Screenshots

The inline banner while the query looks like staking, and the same screen with a query that does not:

<img width="35%" height="35%" alt="image-1786017763939" src="https://github.com/user-attachments/assets/33d5b802-35d5-4756-900b-9bd8da5c1948" />
<img width="35%" height="35%" alt="image-1786017758134" src="https://github.com/user-attachments/assets/4706ad10-53c1-4ae6-8469-af59c7079c62" />

The notice raised by a third-party staking host, and the secondary action after the first tap — "Advanced" has cross-dissolved into "Continue to site":

<img width="35%" height="35%" alt="image-1786017771441" src="https://github.com/user-attachments/assets/12b38afe-828b-4947-a77a-b8babf3883ad" />
<img width="35%" height="35%" alt="image-1786017767593" src="https://github.com/user-attachments/assets/ccd84010-9772-48c5-a93a-37c6e1ca1af3" />
