### PR TITLE
Count locked validators in the custom validator list proceed button

### DIFF
--- a/novawallet/Modules/Staking/SelectValidatorsFlow/CustomValidatorList/CustomValidatorListViewController.swift
+++ b/novawallet/Modules/Staking/SelectValidatorsFlow/CustomValidatorList/CustomValidatorListViewController.swift
@@ -133,19 +133,19 @@ final class CustomValidatorListViewController: UIViewController, ViewHolder, Imp
         let buttonTitle: String
         let isEnabled: Bool
 
-        if selection.communitySelected == 0, selection.lockedSelected == 0 {
+        if selection.totalSelected == 0 {
             isEnabled = false
 
             buttonTitle = R.string(preferredLanguages: selectedLocale.rLanguages
-            ).localizable.stakingCustomProceedButtonDisabledTitle(selection.communityLimit)
+            ).localizable.stakingCustomProceedButtonDisabledTitle(selection.totalLimit)
 
         } else {
             isEnabled = true
 
             buttonTitle = R.string(preferredLanguages: selectedLocale.rLanguages
             ).localizable.stakingCustomProceedButtonEnabledTitle(
-                selection.communitySelected,
-                selection.communityLimit
+                selection.totalSelected,
+                selection.totalLimit
             )
         }
 

--- a/novawallet/Modules/Staking/SelectValidatorsFlow/CustomValidatorList/Model/ValidatorSelectionCounter.swift
+++ b/novawallet/Modules/Staking/SelectValidatorsFlow/CustomValidatorList/Model/ValidatorSelectionCounter.swift
@@ -4,11 +4,15 @@ struct ValidatorSelectionState: Equatable {
     let communitySelected: Int
     let communityLimit: Int
     let lockedSelected: Int
+    let totalLimit: Int
+
+    var totalSelected: Int { communitySelected + lockedSelected }
 
     static let empty = ValidatorSelectionState(
         communitySelected: 0,
         communityLimit: 0,
-        lockedSelected: 0
+        lockedSelected: 0,
+        totalLimit: 0
     )
 }
 
@@ -22,7 +26,8 @@ struct ValidatorSelectionCounter {
         return .init(
             communitySelected: selected.count - lockedSelected,
             communityLimit: max(maxNominations - lockedAddresses.count, 0),
-            lockedSelected: lockedSelected
+            lockedSelected: lockedSelected,
+            totalLimit: maxNominations
         )
     }
 }

--- a/novawalletTests/Modules/Staking/SelectValidatorsFlow/CustomValidators/CustomValidatorListTests.swift
+++ b/novawalletTests/Modules/Staking/SelectValidatorsFlow/CustomValidators/CustomValidatorListTests.swift
@@ -249,6 +249,8 @@ class CustomValidatorListTests: XCTestCase {
         XCTAssertEqual(lastViewModel?.selection.communitySelected, 0)
         XCTAssertEqual(lastViewModel?.selection.lockedSelected, 1)
         XCTAssertEqual(lastViewModel?.selection.communityLimit, 15)
+        XCTAssertEqual(lastViewModel?.selection.totalSelected, 1)
+        XCTAssertEqual(lastViewModel?.selection.totalLimit, 16)
     }
 
     func testSetupDoesNotGrowTheSelection() {
@@ -407,5 +409,7 @@ class CustomValidatorListTests: XCTestCase {
         XCTAssertEqual(selection?.lockedSelected, 1)
         XCTAssertEqual(selection?.communityLimit, 2)
         XCTAssertEqual(selection?.communitySelected, 2)
+        XCTAssertEqual(selection?.totalSelected, 3)
+        XCTAssertEqual(selection?.totalLimit, 3)
     }
 }


### PR DESCRIPTION
## Problem

On **Select validators**, the proceed button reported `Show selected: 0 (max 12)` while 4 locked (preferred / Novasama) validators were selected out of 16 nominations. The **Selected validators** screen described the same state as `Validators: 4 of 16`.

The title was built from community-only counters (`CustomValidatorListViewController.updateProceedButton`), which subtract locked validators from both the count and the limit. The enable/disable branch, on the other hand, already took `lockedSelected` into account — so the button could be active while showing `0`.

## Fix

- `ValidatorSelectionState` gains `totalLimit` (the raw `maxNominations`) and a computed `totalSelected` (`communitySelected + lockedSelected`).
- The proceed button title and its disabled state now use those totals: `Show selected: 4 (max 16)`, and `Select validators (max 16)` when nothing is selected.
- `Fill rest with recommended` and `Deselect` keep using the community counters on purpose — they are about free slots (12) and removable items (locked ones can't be deselected).

## Tests

Extended `CustomValidatorListTests` with `totalSelected` / `totalLimit` assertions in `testDeselectAllKeepsLockedValidators` and `testFillWithRecommendedRespectsTheCommunityLimit`.

<img width="547" height="1041" alt="Screenshot 2026-08-10 at 18 24 30" src="https://github.com/user-attachments/assets/1a6a0235-68d3-44a5-848d-c4ae288b1690" />
