### PR TITLE
feat: remove crowdloan tab from vote screen

### DIFF
--- a/novawallet/Modules/Vote/Parent/View/VoteTableHeaderView.swift
+++ b/novawallet/Modules/Vote/Parent/View/VoteTableHeaderView.swift
@@ -11,14 +11,6 @@ final class VoteTableHeaderView: UIView {
 
     let walletSwitch = WalletSwitchControl()
 
-    let votingTypeSwitch: RoundedSegmentedControl = .create { view in
-        view.backgroundView.fillColor = R.color.colorSegmentedBackground()!
-        view.selectionColor = R.color.colorSegmentedTabActive()!
-        view.titleFont = .regularFootnote
-        view.selectedTitleColor = R.color.colorTextPrimary()!
-        view.titleColor = R.color.colorTextSecondary()!
-    }
-
     let chainSelectionView: VoteTableChainSelectionControl = .create {
         $0.preferredHeight = Constants.chainSelectionHeight
     }
@@ -64,16 +56,9 @@ private extension VoteTableHeaderView {
             make.centerY.equalTo(walletSwitch)
         }
 
-        addSubview(votingTypeSwitch)
-        votingTypeSwitch.snp.makeConstraints { make in
-            make.top.equalTo(walletSwitch.snp.bottom).offset(Constants.votingTypeSwitchTopOffset)
-            make.leading.trailing.equalToSuperview().inset(Constants.standardHorizontalInset)
-            make.height.equalTo(Constants.votingTypeSwitchHeight)
-        }
-
         addSubview(chainSelectionView)
         chainSelectionView.snp.makeConstraints { make in
-            make.top.equalTo(votingTypeSwitch.snp.bottom).offset(Constants.chainSelectionTopOffset)
+            make.top.equalTo(walletSwitch.snp.bottom).offset(Constants.chainSelectionTopOffset)
             make.leading.trailing.equalToSuperview().inset(Constants.standardHorizontalInset)
             make.bottom.equalToSuperview().inset(Constants.chainSelectionBottomInset)
             make.height.equalTo(Constants.chainSelectionHeight)
@@ -84,11 +69,6 @@ private extension VoteTableHeaderView {
         let languages = locale.rLanguages
 
         titleLabel.text = R.string(preferredLanguages: languages).localizable.tabbarVoteTitle()
-
-        votingTypeSwitch.titles = [
-            R.string(preferredLanguages: languages).localizable.tabbarGovernanceTitle(),
-            R.string(preferredLanguages: languages).localizable.tabbarCrowdloanTitle_v190()
-        ]
     }
 }
 
@@ -114,10 +94,8 @@ private extension VoteTableHeaderView {
     enum Constants {
         static let walletSwitchTopInset: CGFloat = 10.0
         static let titleTrailingOffset: CGFloat = 8.0
-        static let votingTypeSwitchTopOffset: CGFloat = 16.0
         static let standardHorizontalInset: CGFloat = 16.0
-        static let votingTypeSwitchHeight: CGFloat = 40.0
-        static let chainSelectionTopOffset: CGFloat = 8.0
+        static let chainSelectionTopOffset: CGFloat = 16.0
         static let chainSelectionBottomInset: CGFloat = 8.0
         static let chainSelectionHeight: CGFloat = 56.0
     }

--- a/novawallet/Modules/Vote/Parent/VoteChildPresenterFactory.swift
+++ b/novawallet/Modules/Vote/Parent/VoteChildPresenterFactory.swift
@@ -4,11 +4,6 @@ import Operation_iOS
 import SubstrateSdk
 
 protocol VoteChildPresenterFactoryProtocol {
-    func createCrowdloanPresenter(
-        from view: CrowdloansViewProtocol,
-        wallet: MetaAccountModel
-    ) -> VoteChildPresenterProtocol?
-
     func createGovernancePresenter(
         from view: ReferendumsViewProtocol,
         wallet: MetaAccountModel,
@@ -22,7 +17,6 @@ final class VoteChildPresenterFactory {
     let repositoryFactory: SubstrateRepositoryFactoryProtocol
     let chainRegistry: ChainRegistryProtocol
     let walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol
-    let jsonDataProviderFactory: JsonDataProviderFactoryProtocol
     let priceProviderFactory: PriceProviderFactoryProtocol
     let applicationHandler: ApplicationHandlerProtocol
     let substrateStorageFacade: StorageFacadeProtocol
@@ -35,7 +29,6 @@ final class VoteChildPresenterFactory {
         applicationHandler: ApplicationHandlerProtocol,
         chainRegistry: ChainRegistryProtocol = ChainRegistryFacade.sharedRegistry,
         walletLocalSubscriptionFactory: WalletLocalSubscriptionFactoryProtocol = WalletLocalSubscriptionFactory.shared,
-        jsonDataProviderFactory: JsonDataProviderFactoryProtocol = JsonDataProviderFactory.shared,
         priceProviderFactory: PriceProviderFactoryProtocol = PriceProviderFactory.shared,
         repositoryFactory: SubstrateRepositoryFactoryProtocol = SubstrateRepositoryFactory(),
         substrateStorageFacade: StorageFacadeProtocol = SubstrateDataStorageFacade.shared,
@@ -47,7 +40,6 @@ final class VoteChildPresenterFactory {
         self.currencyManager = currencyManager
         self.chainRegistry = chainRegistry
         self.walletLocalSubscriptionFactory = walletLocalSubscriptionFactory
-        self.jsonDataProviderFactory = jsonDataProviderFactory
         self.priceProviderFactory = priceProviderFactory
         self.repositoryFactory = repositoryFactory
         self.applicationHandler = applicationHandler
@@ -56,33 +48,6 @@ final class VoteChildPresenterFactory {
         self.operationQueue = operationQueue
         self.localizationManager = localizationManager
         self.logger = logger
-    }
-
-    private func createCrowdloanInteractor(
-        from state: CrowdloanSharedState,
-        wallet: MetaAccountModel
-    ) -> CrowdloanListInteractor {
-        let serviceFactory = VoteServiceFactory(
-            chainRegisty: chainRegistry,
-            storageFacade: substrateStorageFacade,
-            eventCenter: eventCenter,
-            operationQueue: operationQueue,
-            logger: logger
-        )
-
-        return CrowdloanListInteractor(
-            selectedMetaAccount: wallet,
-            crowdloanState: state,
-            chainRegistry: chainRegistry,
-            voteServiceFactory: serviceFactory,
-            walletLocalSubscriptionFactory: walletLocalSubscriptionFactory,
-            jsonDataProviderFactory: jsonDataProviderFactory,
-            priceLocalSubscriptionFactory: priceProviderFactory,
-            eventCenter: eventCenter,
-            operationQueue: operationQueue,
-            currencyManager: currencyManager,
-            logger: logger
-        )
     }
 
     private func createGovernanceInteractor(
@@ -118,38 +83,6 @@ final class VoteChildPresenterFactory {
 }
 
 extension VoteChildPresenterFactory: VoteChildPresenterFactoryProtocol {
-    func createCrowdloanPresenter(
-        from view: CrowdloansViewProtocol,
-        wallet: MetaAccountModel
-    ) -> VoteChildPresenterProtocol? {
-        let state = CrowdloanSharedState()
-
-        let interactor = createCrowdloanInteractor(from: state, wallet: wallet)
-        let wireframe = CrowdloanListWireframe(state: state)
-
-        let viewModelFactory = CrowdloansViewModelFactory(
-            balanceViewModelFactoryFacade: BalanceViewModelFactoryFacade(
-                priceAssetInfoFactory: PriceAssetInfoFactory(currencyManager: currencyManager)
-            )
-        )
-
-        let presenter = CrowdloanListPresenter(
-            interactor: interactor,
-            wireframe: wireframe,
-            viewModelFactory: viewModelFactory,
-            localizationManager: localizationManager,
-            appearanceFacade: AppearanceFacade.shared,
-            privacyStateManager: PrivacyStateManager.shared,
-            logger: Logger.shared
-        )
-
-        presenter.view = view
-        view.presenter = presenter
-        interactor.presenter = presenter
-
-        return presenter
-    }
-
     func createGovernancePresenter(
         from view: ReferendumsViewProtocol,
         wallet: MetaAccountModel,

--- a/novawallet/Modules/Vote/Parent/VotePresenter.swift
+++ b/novawallet/Modules/Vote/Parent/VotePresenter.swift
@@ -75,22 +75,12 @@ extension VotePresenter: VotePresenterProtocol {
         childPresenter?.setup()
     }
 
-    func switchToCrowdloans(_ view: CrowdloansViewProtocol) {
-        guard let wallet = wallet else {
-            return
-        }
-
-        childPresenter?.putOffline()
-        childPresenter = childPresenterFactory.createCrowdloanPresenter(from: view, wallet: wallet)
-        childPresenter?.setup()
-    }
-
     func showReferendumsDetails(_ referendumIndex: Referenda.ReferendumIndex) {
         referendumsState = .init(referendumIndex: referendumIndex) { [weak self] in
             self?.referendumsState = nil
         }
         if view?.isSetup == true {
-            view?.didReceive(voteType: .governance)
+            view?.didReceiveGovernanceRequest()
         }
     }
 }

--- a/novawallet/Modules/Vote/Parent/VoteProtocols.swift
+++ b/novawallet/Modules/Vote/Parent/VoteProtocols.swift
@@ -1,14 +1,9 @@
 import Foundation
 
-enum VoteType: UInt8 {
-    case governance
-    case crowdloan
-}
-
 protocol VoteViewProtocol: ControllerBackedProtocol, LoadableViewProtocol {
     func didSwitchWallet(with viewModel: WalletSwitchViewModel)
     func showReferendumsDetails(_ index: Referenda.ReferendumIndex)
-    func didReceive(voteType: VoteType)
+    func didReceiveGovernanceRequest()
 }
 
 protocol VoteChainViewProtocol {
@@ -22,7 +17,6 @@ protocol VotePresenterProtocol: AnyObject {
     func selectChain()
     func selectWallet()
     func switchToGovernance(_ view: ReferendumsViewProtocol)
-    func switchToCrowdloans(_ view: CrowdloansViewProtocol)
     func showReferendumsDetails(_ index: Referenda.ReferendumIndex)
 }
 

--- a/novawallet/Modules/Vote/Parent/VoteViewController.swift
+++ b/novawallet/Modules/Vote/Parent/VoteViewController.swift
@@ -9,10 +9,6 @@ final class VoteViewController: UIViewController, ViewHolder {
 
     private(set) var childView: VoteChildViewProtocol?
 
-    var selectedType: VoteType {
-        VoteType(rawValue: UInt8(rootView.headerView.votingTypeSwitch.selectedSegmentIndex)) ?? .governance
-    }
-
     init(
         presenter: VotePresenterProtocol,
         localizationManager: LocalizationManagerProtocol
@@ -66,12 +62,6 @@ final class VoteViewController: UIViewController, ViewHolder {
             action: #selector(actionWalletSwitch),
             for: .touchUpInside
         )
-
-        rootView.headerView.votingTypeSwitch.addTarget(
-            self,
-            action: #selector(actionVoteTypeChanged),
-            for: .valueChanged
-        )
     }
 
     private func setupLocalization() {
@@ -87,40 +77,21 @@ final class VoteViewController: UIViewController, ViewHolder {
         presenter.selectWallet()
     }
 
-    @objc func actionVoteTypeChanged() {
-        setupChildView()
-    }
-
     private func setupChildView() {
         childView?.unbind()
         childView = nil
 
-        switch selectedType {
-        case .governance:
-            let governanceChildView = ReferendumsViewManager(
-                tableView: rootView.tableView,
-                chainSelectionView: rootView.headerView,
-                parent: self
-            )
+        let governanceChildView = ReferendumsViewManager(
+            tableView: rootView.tableView,
+            chainSelectionView: rootView.headerView,
+            parent: self
+        )
 
-            childView = governanceChildView
-            childView?.bind()
-            childView?.locale = selectedLocale
+        childView = governanceChildView
+        childView?.bind()
+        childView?.locale = selectedLocale
 
-            presenter.switchToGovernance(governanceChildView)
-        case .crowdloan:
-            let crowdloanChildView = CrowdloanListViewManager(
-                tableView: rootView.tableView,
-                chainSelectionView: rootView.headerView,
-                parent: self
-            )
-
-            childView = crowdloanChildView
-            childView?.bind()
-            childView?.locale = selectedLocale
-
-            presenter.switchToCrowdloans(crowdloanChildView)
-        }
+        presenter.switchToGovernance(governanceChildView)
     }
 }
 
@@ -131,9 +102,7 @@ extension VoteViewController: VoteViewProtocol {
         setupChildView()
     }
 
-    func didReceive(voteType: VoteType) {
-        rootView.headerView.votingTypeSwitch.selectedSegmentIndex = Int(voteType.rawValue)
-
+    func didReceiveGovernanceRequest() {
         setupChildView()
     }
 


### PR DESCRIPTION
Removes the "Crowdloans" segment from the Vote screen, leaving it governance-only.

<img width="300" height="650" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 06 19 17" src="https://github.com/user-attachments/assets/5aa270c4-ab0e-492b-801e-75d4cc20de75" />

### Why

Crowdloans are finished on both Polkadot and Kusama, and there is nothing left for
users to do in this screen:

- `Crowdloan.Funds` is empty on both relay chains (92 funds ever created on Polkadot,
  101 on Kusama — all dissolved). Every `py/cfund` sub-account has been reaped, so
  **0 DOT / 0 KSM** remain to be returned.
- The post-migration reclaim path is empty too: `AhOps.RcCrowdloanContribution`,
  `RcCrowdloanReserve` and `RcLeaseReserve` all have **0 entries** on both Polkadot
  and Kusama Asset Hub.
- No new crowdloans are possible — auctions ended with the move to Agile Coretime.
  `Auctions.AuctionInfo` is `None`, and lease deposits total 0 DOT.

So the tab currently renders nothing for every user.

### What changed

- `VoteTableHeaderView` — removed `votingTypeSwitch`; `chainSelectionView` now anchors
  directly under `walletSwitch`, and the two segmented-control constants are gone
- `VoteViewController` — removed `selectedType`, the segment target/action, and the
  `.crowdloan` branch of `setupChildView()`
- `VoteProtocols` — removed the `VoteType` enum and `switchToCrowdloans`;
  `didReceive(voteType:)` becomes `didReceiveGovernanceRequest()`, matching the existing
  `didReceiveRenderRequest()` shape in `DAppBrowserProtocols`
- `VotePresenter` — removed `switchToCrowdloans`; the referendum deep-link path calls the
  renamed callback
- `VoteChildPresenterFactory` — removed `createCrowdloanPresenter` / `createCrowdloanInteractor`,
  which lost their only caller, along with the `jsonDataProviderFactory` dependency they
  were the sole user of

### Deliberately not in this PR

The `Modules/Vote/Crowdloan/*` tree still compiles and is untouched — deleting it is a
separate follow-up, as is retiring the now-unused `tabbar.crowdloan.title_v1.9.0` string.
Note that `tabbar.crowdloan.title` (no `_v1.9.0`) is a **different** string still used by
`ExternalAssetBalance` for the Locks sheet and must be kept.

Crowdloan contributions continue to appear as a locked-balance row in the Locks sheet;
that is fed independently of this screen and is unaffected.

Paired with the equivalent Android change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
