### PR TITLE
Add missing dApp staking localization for all locales

### DIFF
--- a/novawallet/es.lproj/Localizable.strings
+++ b/novawallet/es.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "Introduce al menos una dirección...";
 "asset.list.watch.only.balance" = "Saldo solo de visualización";
 "create.watch.only.subtitle" = "Sigue la actividad de la cartera sin una clave privada.\nNo podrás realizar ninguna transacción.";
+"common.go.to.staking" = "Ir a Staking";
+"dapp.staking.banner.message" = "¿Quieres hacer Staking? Nova Wallet tiene Staking integrado.";
+"dapp.staking.notice.continue" = "Continuar al sitio";
+"dapp.staking.notice.message" = "Los sitios de Staking de terceros suelen quedar obsoletos. Recomendamos utilizar las funciones de Staking integradas de Nova Wallet.";
+"dapp.staking.notice.title" = "Aviso";

--- a/novawallet/fr.lproj/Localizable.strings
+++ b/novawallet/fr.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "Entrez au moins une adresse...";
 "asset.list.watch.only.balance" = "Solde en consultation seulement";
 "create.watch.only.subtitle" = "Suivez l'activité du portefeuille sans clé privée.\nVous ne pourrez effectuer aucune transaction.";
+"common.go.to.staking" = "Accéder au Staking";
+"dapp.staking.banner.message" = "Vous souhaitez faire du Stake ? Nova Wallet intègre le Staking.";
+"dapp.staking.notice.continue" = "Continuer vers le site";
+"dapp.staking.notice.message" = "Les sites de Staking tiers deviennent souvent obsolètes. Nous vous recommandons d’utiliser les fonctionnalités de Staking intégrées à Nova Wallet.";
+"dapp.staking.notice.title" = "Avis";

--- a/novawallet/hu.lproj/Localizable.strings
+++ b/novawallet/hu.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "Adjon meg legalább egy címet...";
 "asset.list.watch.only.balance" = "Csak-figyelési egyenleg";
 "create.watch.only.subtitle" = "Pénztárca aktivitás nyomon követése privát kulcs nélkül.\nNem lesz képes tranzakciók végrehajtására.";
+"common.go.to.staking" = "Ugrás a stakinghez";
+"dapp.staking.banner.message" = "Szeretnél stakelni? A Nova Wallet beépített stakingfunkciót kínál.";
+"dapp.staking.notice.continue" = "Tovább az oldalra";
+"dapp.staking.notice.message" = "A harmadik féltől származó stakingoldalak gyakran elavulnak. Javasoljuk a Nova Wallet beépített stakingfunkcióinak használatát.";
+"dapp.staking.notice.title" = "Figyelem";

--- a/novawallet/id.lproj/Localizable.strings
+++ b/novawallet/id.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "Masukkan setidaknya satu alamat...";
 "asset.list.watch.only.balance" = "Saldo untuk dilihat saja";
 "create.watch.only.subtitle" = "Lacak aktivitas dompet tanpa kunci privat.\nAnda tidak akan dapat melakukan transaksi apapun.";
+"common.go.to.staking" = "Buka Staking";
+"dapp.staking.banner.message" = "Ingin melakukan staking? Nova Wallet memiliki fitur staking bawaan.";
+"dapp.staking.notice.continue" = "Lanjutkan ke situs";
+"dapp.staking.notice.message" = "Situs staking pihak ketiga sering kali tidak lagi tersedia. Kami menyarankan Anda menggunakan fitur staking bawaan Nova Wallet.";
+"dapp.staking.notice.title" = "Pemberitahuan";

--- a/novawallet/it.lproj/Localizable.strings
+++ b/novawallet/it.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "Inserisci almeno un indirizzo...";
 "asset.list.watch.only.balance" = "Saldo solo visualizzazione";
 "create.watch.only.subtitle" = "Tieni traccia dell’attività del portafoglio senza una chiave privata.\nNon potrai eseguire alcuna transazione.";
+"common.go.to.staking" = "Vai allo staking";
+"dapp.staking.banner.message" = "Vuoi fare staking? Nova Wallet offre lo staking integrato.";
+"dapp.staking.notice.continue" = "Continua al sito";
+"dapp.staking.notice.message" = "I siti di staking di terze parti spesso diventano obsoleti. Ti consigliamo di utilizzare le funzionalità di staking integrate di Nova Wallet.";
+"dapp.staking.notice.title" = "Avviso";

--- a/novawallet/ja.lproj/Localizable.strings
+++ b/novawallet/ja.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "少なくとも1つのアドレスを入力してください...";
 "asset.list.watch.only.balance" = "ウォッチオンリーバランス";
 "create.watch.only.subtitle" = "秘密鍵を使わずにウォレットのアクティビティを追跡することができます。\nトランザクションを実行することはできません。";
+"common.go.to.staking" = "Stakingへ移動";
+"dapp.staking.banner.message" = "stakeをお考えですか？Nova Walletには組み込みのstaking機能があります。";
+"dapp.staking.notice.continue" = "サイトへ移動";
+"dapp.staking.notice.message" = "サードパーティのstakingサイトは使用できなくなることがよくあります。Nova Walletの組み込みstaking機能の利用をおすすめします。";
+"dapp.staking.notice.title" = "注意";

--- a/novawallet/ko.lproj/Localizable.strings
+++ b/novawallet/ko.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "최소 하나의 주소를 입력하세요...";
 "asset.list.watch.only.balance" = "보기 전용 잔액";
 "create.watch.only.subtitle" = "비공개 키 없이 지갑 활동을 추적합니다.\n어떠한 거래도 수행할 수 없습니다.";
+"common.go.to.staking" = "Staking으로 이동";
+"dapp.staking.banner.message" = "Stake를 원하시나요? Nova Wallet에는 기본 제공되는 Staking 기능이 있습니다.";
+"dapp.staking.notice.continue" = "사이트로 계속하기";
+"dapp.staking.notice.message" = "타사 Staking 사이트는 종종 더 이상 사용되지 않게 됩니다. Nova Wallet의 기본 제공 Staking 기능을 사용하는 것을 권장합니다.";
+"dapp.staking.notice.title" = "알림";

--- a/novawallet/pl.lproj/Localizable.strings
+++ b/novawallet/pl.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "Wprowadź co najmniej jeden adres...";
 "asset.list.watch.only.balance" = "Saldo tylko do obserwacji";
 "create.watch.only.subtitle" = "Śledź aktywność portfela bez klucza prywatnego.\nNie będziesz w stanie przeprowadzać żadnych transakcji.";
+"common.go.to.staking" = "Przejdź do Staking";
+"dapp.staking.banner.message" = "Chcesz korzystać ze Staking? Nova Wallet ma wbudowany Staking.";
+"dapp.staking.notice.continue" = "Przejdź do witryny";
+"dapp.staking.notice.message" = "Witryny Staking stron trzecich często stają się nieaktualne. Zalecamy korzystanie z wbudowanych funkcji Staking w Nova Wallet.";
+"dapp.staking.notice.title" = "Uwaga";

--- a/novawallet/pt-PT.lproj/Localizable.strings
+++ b/novawallet/pt-PT.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "Insira pelo menos um endereço...";
 "asset.list.watch.only.balance" = "Saldo somente de visualização";
 "create.watch.only.subtitle" = "Acompanhe a atividade da carteira sem uma chave privada.\nVocê não poderá realizar transações.";
+"common.go.to.staking" = "Ir para staking";
+"dapp.staking.banner.message" = "Quer fazer staking? A Nova Wallet oferece staking integrado.";
+"dapp.staking.notice.continue" = "Continuar para o site";
+"dapp.staking.notice.message" = "Sites de staking de terceiros frequentemente ficam desatualizados. Recomendamos usar os recursos de staking integrados da Nova Wallet.";
+"dapp.staking.notice.title" = "Aviso";

--- a/novawallet/ru.lproj/Localizable.strings
+++ b/novawallet/ru.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "Введите хотя бы один адрес...";
 "asset.list.watch.only.balance" = "Только просмотр баланса";
 "create.watch.only.subtitle" = "Отслеживание активности кошелька без приватного ключа.\nВы не сможете выполнить никакие транзакции.";
+"common.go.to.staking" = "Перейти к Staking";
+"dapp.staking.banner.message" = "Хотите застейкать? В Nova Wallet есть встроенный Staking.";
+"dapp.staking.notice.continue" = "Перейти на сайт";
+"dapp.staking.notice.message" = "Сторонние сайты для Staking часто устаревают. Мы рекомендуем использовать встроенные функции Staking в Nova Wallet.";
+"dapp.staking.notice.title" = "Уведомление";

--- a/novawallet/tr.lproj/Localizable.strings
+++ b/novawallet/tr.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "En az bir adres girin...";
 "asset.list.watch.only.balance" = "Sadece-izleme bakiyesi";
 "create.watch.only.subtitle" = "Cüzdan aktivitesini özel anahtar olmadan izleyin.\nHerhangi bir işlem gerçekleştiremezsiniz.";
+"common.go.to.staking" = "Staking'e Git";
+"dapp.staking.banner.message" = "Stake etmek mi istiyorsunuz? Nova Wallet'ta yerleşik staking özelliği bulunur.";
+"dapp.staking.notice.continue" = "Siteye devam et";
+"dapp.staking.notice.message" = "Üçüncü taraf staking siteleri çoğu zaman kullanımdan kaldırılır. Nova Wallet'ın yerleşik staking özelliklerini kullanmanızı öneririz.";
+"dapp.staking.notice.title" = "Bildirim";

--- a/novawallet/vi.lproj/Localizable.strings
+++ b/novawallet/vi.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "Nhập ít nhất một địa chỉ...";
 "asset.list.watch.only.balance" = "Số dư chỉ theo dõi";
 "create.watch.only.subtitle" = "Theo dõi hoạt động ví mà không cần khóa riêng.\nBạn sẽ không thể thực hiện bất kỳ giao dịch nào.";
+"common.go.to.staking" = "Đi đến Staking";
+"dapp.staking.banner.message" = "Bạn muốn Stake? Nova Wallet có tính năng Staking tích hợp sẵn.";
+"dapp.staking.notice.continue" = "Tiếp tục đến trang web";
+"dapp.staking.notice.message" = "Các trang web Staking của bên thứ ba thường trở nên lỗi thời. Chúng tôi khuyên bạn nên sử dụng các tính năng Staking tích hợp sẵn của Nova Wallet.";
+"dapp.staking.notice.title" = "Thông báo";

--- a/novawallet/zh-Hans.lproj/Localizable.strings
+++ b/novawallet/zh-Hans.lproj/Localizable.strings
@@ -2036,3 +2036,8 @@
 "create.watch.only.missing.any.address" = "请输入至少一个地址...";
 "asset.list.watch.only.balance" = "仅观察余额";
 "create.watch.only.subtitle" = "在没有私钥的情况下跟踪钱包活动。\n您将无法执行任何交易。";
+"common.go.to.staking" = "前往质押";
+"dapp.staking.banner.message" = "想要进行质押？Nova Wallet 内置质押功能。";
+"dapp.staking.notice.continue" = "继续访问网站";
+"dapp.staking.notice.message" = "第三方质押网站经常会被弃用。我们建议使用 Nova Wallet 内置的质押功能。";
+"dapp.staking.notice.title" = "注意";


### PR DESCRIPTION
## What

The browser staking feature (#1842, #1844) added 5 keys to `en.lproj` only, so the other 13 locales rendered raw keys (`dapp.staking.banner.message`, `common.go.to.staking`, …) in the dApp staking banner and notice sheet.

This PR adds the missing translations for all 13 locales (es, fr, hu, id, it, ja, ko, pl, pt-PT, ru, tr, vi, zh-Hans) — 5 strings per locale:

- `common.go.to.staking`
- `dapp.staking.banner.message`
- `dapp.staking.notice.title`
- `dapp.staking.notice.message`
- `dapp.staking.notice.continue`

## How

Produced by the automated `nova-localization` cycle (novasamatech/nova-localization#16): keys pushed to the Lokalise branch `feature/browser-staking-popup` via API, translated, and exported back via API. Key parity between `en.lproj` and all locales verified after export. The Lokalise branch holds the same translations and awaits merge into the Lokalise main branch.

The one-line change at the end of each file is a trailing-newline fix on the previously last line.