### PR TITLE
Reject swap routes that enter the same Hydration pool twice

### DIFF
--- a/novawallet.xcodeproj/project.pbxproj
+++ b/novawallet.xcodeproj/project.pbxproj
@@ -1017,6 +1017,7 @@
 		0CA81D542CE5108A00166969 /* AssetHubExchangeFeeSupportFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA81D532CE5108A00166969 /* AssetHubExchangeFeeSupportFetcher.swift */; };
 		0CA81D572CE5AF2600166969 /* AssetExchangeFeeSupportFetchersProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA81D562CE5AF2600166969 /* AssetExchangeFeeSupportFetchersProvider.swift */; };
 		0CA81D592CE60AA700166969 /* AssetExchangeEdgeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA81D582CE60AA700166969 /* AssetExchangeEdgeType.swift */; };
+		F7F5B5BEB5FABB5FF53E8D85 /* AssetExchangePoolId.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46468A4A3E40DBED37BFC05 /* AssetExchangePoolId.swift */; };
 		0CA8AD562CE06FA000ED9746 /* XcmTransactService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA8AD552CE06FA000ED9746 /* XcmTransactService.swift */; };
 		0CA8AD5A2CE0789100ED9746 /* WalletRemoteSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA8AD592CE0789100ED9746 /* WalletRemoteSubscription.swift */; };
 		0CA8AD622CE08FEE00ED9746 /* BlockEventsQueryFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA8AD5B2CE08FEE00ED9746 /* BlockEventsQueryFactory.swift */; };
@@ -5596,6 +5597,8 @@
 		3185E9401279423ECA14DC29 /* AssetExchangeCommissionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2FB3A2AC2F2A632BA150650 /* AssetExchangeCommissionPolicyTests.swift */; };
 		8196EBD22DDAD2737F3767F8 /* HydraExchangeExtrinsicParamsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BC3F73E3EA1C3C95EDBE6C /* HydraExchangeExtrinsicParamsFactoryTests.swift */; };
 		3F45C083BC601842FBBFD08E /* HydraExchangeAtomicOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15FD86DFB69D54DAC2636F05 /* HydraExchangeAtomicOperationTests.swift */; };
+		2DD2DA594997269200AFDCDD /* AssetExchangePathFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D8EB5C57DA2340B534BC7D9 /* AssetExchangePathFilterTests.swift */; };
+		ECD37C92F8EA802204A907B7 /* HydraSwapRoutePoolIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D62A1D647644741D4C6D4A6 /* HydraSwapRoutePoolIdentityTests.swift */; };
 		A0720F255A511A623EE8C6F0 /* AssetsExchangeRouteManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C639F7A52A4668717369874 /* AssetsExchangeRouteManagerTests.swift */; };
 		E512B2B42B505AF2BEE87FB4 /* AssetExchangeGraphProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95559705353C1460D999A6AE /* AssetExchangeGraphProxyTests.swift */; };
 		881BA30929DC1B3000EB8C48 /* kilt-addresses.json in Resources */ = {isa = PBXBuildFile; fileRef = 881BA30829DC1B3000EB8C48 /* kilt-addresses.json */; };
@@ -7691,6 +7694,7 @@
 		0CA81D532CE5108A00166969 /* AssetHubExchangeFeeSupportFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetHubExchangeFeeSupportFetcher.swift; sourceTree = "<group>"; };
 		0CA81D562CE5AF2600166969 /* AssetExchangeFeeSupportFetchersProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetExchangeFeeSupportFetchersProvider.swift; sourceTree = "<group>"; };
 		0CA81D582CE60AA700166969 /* AssetExchangeEdgeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetExchangeEdgeType.swift; sourceTree = "<group>"; };
+		A46468A4A3E40DBED37BFC05 /* AssetExchangePoolId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetExchangePoolId.swift; sourceTree = "<group>"; };
 		0CA8AD552CE06FA000ED9746 /* XcmTransactService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcmTransactService.swift; sourceTree = "<group>"; };
 		0CA8AD592CE0789100ED9746 /* WalletRemoteSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletRemoteSubscription.swift; sourceTree = "<group>"; };
 		0CA8AD5B2CE08FEE00ED9746 /* BlockEventsQueryFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockEventsQueryFactory.swift; sourceTree = "<group>"; };
@@ -11949,6 +11953,8 @@
 		F2FB3A2AC2F2A632BA150650 /* AssetExchangeCommissionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetExchangeCommissionPolicyTests.swift; sourceTree = "<group>"; };
 		A3BC3F73E3EA1C3C95EDBE6C /* HydraExchangeExtrinsicParamsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraExchangeExtrinsicParamsFactoryTests.swift; sourceTree = "<group>"; };
 		15FD86DFB69D54DAC2636F05 /* HydraExchangeAtomicOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraExchangeAtomicOperationTests.swift; sourceTree = "<group>"; };
+		0D8EB5C57DA2340B534BC7D9 /* AssetExchangePathFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetExchangePathFilterTests.swift; sourceTree = "<group>"; };
+		8D62A1D647644741D4C6D4A6 /* HydraSwapRoutePoolIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydraSwapRoutePoolIdentityTests.swift; sourceTree = "<group>"; };
 		1C639F7A52A4668717369874 /* AssetsExchangeRouteManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsExchangeRouteManagerTests.swift; sourceTree = "<group>"; };
 		95559705353C1460D999A6AE /* AssetExchangeGraphProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetExchangeGraphProxyTests.swift; sourceTree = "<group>"; };
 		881BA30829DC1B3000EB8C48 /* kilt-addresses.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "kilt-addresses.json"; sourceTree = "<group>"; };
@@ -14052,6 +14058,7 @@
 				0C746DBD2CCF440800E9178B /* AssetExchangeAtomicOperation.swift */,
 				0C6353462CE46FB200EAB200 /* AssetExchangeSufficiencyProvider.swift */,
 				0CA81D582CE60AA700166969 /* AssetExchangeEdgeType.swift */,
+				A46468A4A3E40DBED37BFC05 /* AssetExchangePoolId.swift */,
 				0C12BC3D2CEA9DF800AB919D /* AssetExchangeTimeEstimation.swift */,
 				0CF4ADF82CEBF71A009C51FA /* AssetExchangeMetaOperationProtocol.swift */,
 				0CBABFEA2CED37E30047F29E /* AssetExchangeQuote.swift */,
@@ -22490,6 +22497,8 @@
 				F2FB3A2AC2F2A632BA150650 /* AssetExchangeCommissionPolicyTests.swift */,
 				A3BC3F73E3EA1C3C95EDBE6C /* HydraExchangeExtrinsicParamsFactoryTests.swift */,
 				15FD86DFB69D54DAC2636F05 /* HydraExchangeAtomicOperationTests.swift */,
+				0D8EB5C57DA2340B534BC7D9 /* AssetExchangePathFilterTests.swift */,
+				8D62A1D647644741D4C6D4A6 /* HydraSwapRoutePoolIdentityTests.swift */,
 				1C639F7A52A4668717369874 /* AssetsExchangeRouteManagerTests.swift */,
 				95559705353C1460D999A6AE /* AssetExchangeGraphProxyTests.swift */,
 				0000000066609881CB682044 /* AssetExchangeCommissionNetFlowTests.swift */,
@@ -35346,6 +35355,7 @@
 				0C0F6E2D2D46187400943A7C /* CollatorStakingValidatorFactory.swift in Sources */,
 				2D7978792E82A00F0049F02A /* NftSecureImageFactory.swift in Sources */,
 				0CA81D592CE60AA700166969 /* AssetExchangeEdgeType.swift in Sources */,
+				F7F5B5BEB5FABB5FF53E8D85 /* AssetExchangePoolId.swift in Sources */,
 				2D4F55262CCBFC4700B65B76 /* AssetOperationNetworkListCell.swift in Sources */,
 				84C3420B283187D800156569 /* BlockTimeEstimationService.swift in Sources */,
 				EB376E61CD1C39AC148DE80C /* NftListViewController.swift in Sources */,
@@ -37237,6 +37247,8 @@
 				3185E9401279423ECA14DC29 /* AssetExchangeCommissionPolicyTests.swift in Sources */,
 				8196EBD22DDAD2737F3767F8 /* HydraExchangeExtrinsicParamsFactoryTests.swift in Sources */,
 				3F45C083BC601842FBBFD08E /* HydraExchangeAtomicOperationTests.swift in Sources */,
+				2DD2DA594997269200AFDCDD /* AssetExchangePathFilterTests.swift in Sources */,
+				ECD37C92F8EA802204A907B7 /* HydraSwapRoutePoolIdentityTests.swift in Sources */,
 				A0720F255A511A623EE8C6F0 /* AssetsExchangeRouteManagerTests.swift in Sources */,
 				E512B2B42B505AF2BEE87FB4 /* AssetExchangeGraphProxyTests.swift in Sources */,
 				8B518898F682EABB39C9F7BF /* SwapModelTests.swift in Sources */,

--- a/novawallet/Common/Services/AssetConversion/HydraDx/HydraSwapRoute.swift
+++ b/novawallet/Common/Services/AssetConversion/HydraDx/HydraSwapRoute.swift
@@ -57,3 +57,23 @@ extension HydraDx {
 
 extension HydraDx.SwapRoute.ComponentType: Equatable & Hashable where Asset: Equatable & Hashable {}
 extension HydraDx.SwapRoute.Component: Equatable & Hashable where Asset: Equatable & Hashable {}
+
+extension HydraDx.SwapRoute.Component {
+    /// Identifies the pool the component trades through within the chain
+    var poolIdentifier: String {
+        switch type {
+        case .omnipool:
+            return "omnipool"
+        case let .stableswap(poolAsset):
+            return "stableswap:\(poolAsset)"
+        case .xyk:
+            return "xyk:\(pairIdentifier)"
+        case .aave:
+            return "aave:\(pairIdentifier)"
+        }
+    }
+
+    private var pairIdentifier: String {
+        [assetIn, assetOut].map { "\($0)" }.sorted().joined(separator: "-")
+    }
+}

--- a/novawallet/Common/Services/AssetExchange/AssetExchangePathFilter.swift
+++ b/novawallet/Common/Services/AssetExchange/AssetExchangePathFilter.swift
@@ -44,6 +44,11 @@ extension AssetExchangePathFilter: GraphEdgeFiltering {
             return true
         }
 
+        // a pool modified by the previous hop can't be entered again in the same route
+        if let poolId = edge.poolId, poolId == predecessor.poolId {
+            return false
+        }
+
         let delayedCallExec = delayedCallExecVerifier.executesCallWithDelay(
             selectedWallet,
             chain: chainIn

--- a/novawallet/Common/Services/AssetExchange/AssetHubExchange/AssetHubExchangeEdge.swift
+++ b/novawallet/Common/Services/AssetExchange/AssetHubExchange/AssetHubExchangeEdge.swift
@@ -22,6 +22,7 @@ final class AssetHubExchangeEdge {
 
 extension AssetHubExchangeEdge: AssetExchangableGraphEdge {
     var type: AssetExchangeEdgeType { .assetHubSwap }
+    var poolId: AssetExchangePoolId? { nil }
 
     var weight: Int { 3 * AssetsExchange.defaultEdgeWeight + 10 }
 

--- a/novawallet/Common/Services/AssetExchange/Common/AnyAssetExchangeEdge.swift
+++ b/novawallet/Common/Services/AssetExchange/Common/AnyAssetExchangeEdge.swift
@@ -25,6 +25,7 @@ class AnyAssetExchangeEdge {
     private let canPayFeesInIntermedPositionClosure: () -> Bool
     private let requiresKeepAliveOnIntermediatePositionClosure: () -> Bool
     private let typeClosure: () -> AssetExchangeEdgeType
+    private let poolIdClosure: () -> AssetExchangePoolId?
 
     private let beginMetaOperationClosure: (Balance, Balance) throws -> AssetExchangeMetaOperationProtocol
 
@@ -49,6 +50,7 @@ class AnyAssetExchangeEdge {
         canPayFeesInIntermedPositionClosure = edge.canPayNonNativeFeesInIntermediatePosition
         requiresKeepAliveOnIntermediatePositionClosure = edge.requiresOriginKeepAliveOnIntermediatePosition
         typeClosure = { edge.type }
+        poolIdClosure = { edge.poolId }
         beginMetaOperationClosure = edge.beginMetaOperation
         appendToMetaOperationClosure = edge.appendToMetaOperation
         beginOperationPrototypeClosure = edge.beginOperationPrototype
@@ -71,6 +73,7 @@ extension AnyAssetExchangeEdge: AssetExchangableGraphEdge {
     var origin: ChainAssetId { fetchOrigin() }
     var destination: ChainAssetId { fetchDestination() }
     var type: AssetExchangeEdgeType { typeClosure() }
+    var poolId: AssetExchangePoolId? { poolIdClosure() }
 
     func addingWeight(to currentWeight: Int, predecessor edge: AnyGraphEdgeProtocol?) -> Int {
         addingWeight(currentWeight, edge)

--- a/novawallet/Common/Services/AssetExchange/Common/AssetExchangeGraphEdge.swift
+++ b/novawallet/Common/Services/AssetExchange/Common/AssetExchangeGraphEdge.swift
@@ -24,6 +24,9 @@ protocol AssetExchangableGraphEdge: GraphQuotableEdge {
 
     var type: AssetExchangeEdgeType { get }
 
+    /// The pool the edge trades through, when the route must not enter it twice
+    var poolId: AssetExchangePoolId? { get }
+
     func beginMetaOperation(for amountIn: Balance, amountOut: Balance) throws -> AssetExchangeMetaOperationProtocol
 
     func appendToMetaOperation(

--- a/novawallet/Common/Services/AssetExchange/Common/AssetExchangePoolId.swift
+++ b/novawallet/Common/Services/AssetExchange/Common/AssetExchangePoolId.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/**
+ *  Identifies the on-chain liquidity pool an exchange edge trades through.
+ *
+ *  A route must not enter the same pool twice. Hydration router pre-computes every hop of a buy
+ *  from the state before execution and passes the result as an exact per-hop limit, so a pool
+ *  modified by an earlier hop of the same route reverts the later hop with a slippage error.
+ */
+struct AssetExchangePoolId: Hashable {
+    let chainId: ChainModel.Id
+    let identifier: String
+}

--- a/novawallet/Common/Services/AssetExchange/CrosschainExchange/CrosschainExchangeEdge.swift
+++ b/novawallet/Common/Services/AssetExchange/CrosschainExchange/CrosschainExchangeEdge.swift
@@ -34,6 +34,7 @@ final class CrosschainExchangeEdge {
 
 extension CrosschainExchangeEdge: AssetExchangableGraphEdge {
     var type: AssetExchangeEdgeType { .crossChain }
+    var poolId: AssetExchangePoolId? { nil }
 
     var weight: Int { AssetsExchange.defaultEdgeWeight }
 

--- a/novawallet/Common/Services/AssetExchange/HydraExchange/AssetsHydraExchangeEdge.swift
+++ b/novawallet/Common/Services/AssetExchange/HydraExchange/AssetsHydraExchangeEdge.swift
@@ -5,6 +5,12 @@ protocol AssetsHydraExchangeEdgeProtocol {
     var routeComponent: HydraDx.RemoteSwapRoute.Component { get }
 }
 
+extension AssetsHydraExchangeEdgeProtocol where Self: AssetsHydraExchangeEdge {
+    var poolId: AssetExchangePoolId? {
+        AssetExchangePoolId(chainId: host.chain.chainId, identifier: routeComponent.poolIdentifier)
+    }
+}
+
 class AssetsHydraExchangeEdge {
     let origin: ChainAssetId
     let destination: ChainAssetId

--- a/novawalletIntegrationTests/AssetsExchange/AssetsExchangeTests.swift
+++ b/novawalletIntegrationTests/AssetsExchange/AssetsExchangeTests.swift
@@ -262,6 +262,39 @@ final class AssetsExchangeTests: XCTestCase {
         }
     }
 
+    func testRoutesUSDCDOTHydrationNeverReenterPool() throws {
+        let params = buildCommonParams()
+
+        let hydrationChain = try params.chainRegistry.getChainOrError(for: KnowChainId.hydra)
+
+        let usdc = try hydrationChain.chainAssetForSymbolOrError("USDC").chainAssetId
+        let dot = try hydrationChain.chainAssetForSymbolOrError("DOT").chainAssetId
+
+        guard let graph = createGraph(for: params) else {
+            XCTFail("No graph")
+            return
+        }
+
+        let paths = graph.fetchPaths(from: usdc, to: dot, maxTopPaths: 10)
+
+        XCTAssertFalse(paths.isEmpty)
+
+        for path in paths {
+            let pathDescription = AssetsExchangeGraphDescription.getDescriptionForPath(
+                edges: path,
+                chainRegistry: params.chainRegistry
+            )
+
+            Logger.shared.info("Route: \(pathDescription)")
+
+            let reentersPool = zip(path, path.dropFirst()).contains { predecessor, edge in
+                edge.poolId != nil && edge.poolId == predecessor.poolId
+            }
+
+            XCTAssertFalse(reentersPool, "Route re-enters a pool: \(pathDescription)")
+        }
+    }
+
     func testRouteUSDTAHDOTAH() throws {
         let params = buildCommonParams()
 

--- a/novawalletTests/Common/Services/AssetExchange/AssetExchangePathFilterTests.swift
+++ b/novawalletTests/Common/Services/AssetExchange/AssetExchangePathFilterTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import novawallet
+import Cuckoo
+
+final class AssetExchangePathFilterTests: XCTestCase {
+    private let chain = CommissionTestFixtures.chain
+
+    private var stableswapPool: AssetExchangePoolId {
+        AssetExchangePoolId(chainId: chain.chainId, identifier: "stableswap-110")
+    }
+
+    private var omnipool: AssetExchangePoolId {
+        AssetExchangePoolId(chainId: chain.chainId, identifier: "omnipool")
+    }
+
+    func testRejectsEdgeReenteringPredecessorPool() {
+        // given
+        let filter = createFilter()
+        let addLiquidity = createEdge(from: 0, to: 1, poolId: stableswapPool)
+        let withdraw = createEdge(from: 1, to: 2, poolId: stableswapPool)
+
+        // when
+        let shouldVisit = filter.shouldVisit(edge: withdraw, predecessor: addLiquidity)
+
+        // then
+        XCTAssertFalse(shouldVisit)
+    }
+
+    func testAllowsEdgeEnteringAnotherPool() {
+        // given
+        let filter = createFilter()
+        let stableswap = createEdge(from: 0, to: 1, poolId: stableswapPool)
+        let omnipoolSwap = createEdge(from: 1, to: 2, poolId: omnipool)
+
+        // when
+        let shouldVisit = filter.shouldVisit(edge: omnipoolSwap, predecessor: stableswap)
+
+        // then
+        XCTAssertTrue(shouldVisit)
+    }
+
+    func testAllowsEdgesWithoutPool() {
+        // given
+        let filter = createFilter()
+        let first = createEdge(from: 0, to: 1, poolId: nil)
+        let second = createEdge(from: 1, to: 2, poolId: nil)
+
+        // when
+        let shouldVisit = filter.shouldVisit(edge: second, predecessor: first)
+
+        // then
+        XCTAssertTrue(shouldVisit)
+    }
+}
+
+private extension AssetExchangePathFilterTests {
+    struct SufficientAssets: AssetExchangeSufficiencyProviding {
+        func isSufficient(asset _: AssetModel) -> Bool { true }
+    }
+
+    struct AnyAssetPaysFee: AssetExchangeFeeSupporting {
+        func canPayFee(inNonNative _: ChainAssetId) -> Bool { true }
+    }
+
+    struct ImmediateExecution: WalletDelayedExecVerifing {
+        func executesCallWithDelay(_: MetaAccountModel, chain _: ChainModel) -> Bool { false }
+    }
+
+    func createFilter() -> AssetExchangePathFilter {
+        AssetExchangePathFilter(
+            selectedWallet: AccountGenerator.generateMetaAccount(),
+            chainRegistry: MockChainRegistryProtocol().applyDefault(for: [chain]),
+            sufficiencyProvider: SufficientAssets(),
+            feeSupport: AnyAssetPaysFee(),
+            delayedCallExecVerifier: ImmediateExecution()
+        )
+    }
+
+    func createEdge(from: AssetModel.Id, to: AssetModel.Id, poolId: AssetExchangePoolId?) -> AnyAssetExchangeEdge {
+        AnyAssetExchangeEdge(
+            StubAssetExchangeEdge(
+                origin: CommissionTestFixtures.asset(from),
+                destination: CommissionTestFixtures.asset(to),
+                type: .hydraSwap,
+                chain: chain,
+                poolId: poolId
+            )
+        )
+    }
+}

--- a/novawalletTests/Common/Services/AssetExchange/HydraSwapRoutePoolIdentityTests.swift
+++ b/novawalletTests/Common/Services/AssetExchange/HydraSwapRoutePoolIdentityTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import novawallet
+
+final class HydraSwapRoutePoolIdentityTests: XCTestCase {
+    typealias Component = HydraDx.RemoteSwapRoute.Component
+
+    func testStableswapComponentsOfTheSamePoolShareIdentity() {
+        // given
+        let addLiquidity = Component(assetIn: 22, assetOut: 110, type: .stableswap(110))
+        let withdraw = Component(assetIn: 110, assetOut: 222, type: .stableswap(110))
+
+        // then
+        XCTAssertEqual(addLiquidity.poolIdentifier, withdraw.poolIdentifier)
+    }
+
+    func testStableswapComponentsOfDifferentPoolsDontShareIdentity() {
+        // given
+        let firstPool = Component(assetIn: 22, assetOut: 222, type: .stableswap(110))
+        let secondPool = Component(assetIn: 10, assetOut: 222, type: .stableswap(111))
+
+        // then
+        XCTAssertNotEqual(firstPool.poolIdentifier, secondPool.poolIdentifier)
+    }
+
+    func testOmnipoolComponentsAlwaysShareIdentity() {
+        // given
+        let first = Component(assetIn: 222, assetOut: 1001, type: .omnipool)
+        let second = Component(assetIn: 1001, assetOut: 0, type: .omnipool)
+
+        // then
+        XCTAssertEqual(first.poolIdentifier, second.poolIdentifier)
+    }
+
+    func testPairPoolsShareIdentityOnlyForTheSamePair() {
+        // given
+        let xykForward = Component(assetIn: 5, assetOut: 10, type: .xyk)
+        let xykBackward = Component(assetIn: 10, assetOut: 5, type: .xyk)
+        let xykOther = Component(assetIn: 10, assetOut: 0, type: .xyk)
+        let aaveSamePair = Component(assetIn: 5, assetOut: 10, type: .aave)
+
+        // then
+        XCTAssertEqual(xykForward.poolIdentifier, xykBackward.poolIdentifier)
+        XCTAssertNotEqual(xykForward.poolIdentifier, xykOther.poolIdentifier)
+        XCTAssertNotEqual(xykForward.poolIdentifier, aaveSamePair.poolIdentifier)
+    }
+}

--- a/novawalletTests/Common/Services/AssetExchange/StubAssetExchangeEdge.swift
+++ b/novawalletTests/Common/Services/AssetExchange/StubAssetExchangeEdge.swift
@@ -11,6 +11,7 @@ final class StubAssetExchangeEdge {
     let destination: ChainAssetId
     let type: AssetExchangeEdgeType
     let chain: ChainModel
+    let poolId: AssetExchangePoolId?
     let quoteClosure: (Balance, AssetConversion.Direction) -> Balance
 
     init(
@@ -18,12 +19,14 @@ final class StubAssetExchangeEdge {
         destination: ChainAssetId,
         type: AssetExchangeEdgeType,
         chain: ChainModel,
+        poolId: AssetExchangePoolId? = nil,
         quoteClosure: @escaping (Balance, AssetConversion.Direction) -> Balance = { amount, _ in amount }
     ) {
         self.origin = origin
         self.destination = destination
         self.type = type
         self.chain = chain
+        self.poolId = poolId
         self.quoteClosure = quoteClosure
     }
 }


### PR DESCRIPTION
## Problem

Swaps with the amount specified via **receive** (`router.buy`) for USDC → DOT on Hydration reverted every time with `Stableswap.SlippageLimit`. The same pairs worked when the amount was specified via **send**.

The route search produced paths that use the same stableswap pool twice in a row, e.g.

`USDC → aUSDC (Aave) → 2-Pool-HUSDC (Stableswap#110) → HOLLAR (Stableswap#110) → aDOT (Omnipool) → DOT (Aave)`

i.e. add liquidity to pool 110 and then withdraw from pool 110.

- `router.sell` executes each hop on the router's actual balance with a zero limit and only checks the final amount, so this route succeeds.
- `router.buy` pre-computes every hop from the state *before* execution and passes the result as the exact per-hop `max_limit`. The first hop changes the pool's reserves, the second hop needs more shares than pre-computed, and the stableswap pallet reverts with `SlippageLimit`.

Fee-account data confirms it: every `Router.buy` whose route re-enters a stableswap pool reverted (12 × `SlippageLimit`, 2 × `Token.BelowMinimum`), all 18 `Router.buy` without pool re-entry succeeded, and 135 `Router.sell` with the same share detours succeeded. The detour is never needed: a direct edge between any two assets of the same pool always exists.

## Fix

- Every exchange edge declares the pool it trades through (`poolId`): Omnipool is one pool per chain, stableswap by pool id, XYK and Aave by unordered asset pair. AssetHub and cross-chain edges return `nil`.
- `AssetExchangePathFilter` refuses an edge that re-enters the pool of its predecessor.

Best USDC → DOT route on Hydration is now `USDC → aUSDC → HOLLAR → aDOT → DOT`.

## Tests

- `AssetExchangePathFilterTests` (filter rejects pool re-entry, allows other pools / no pool).
- `HydraSwapRoutePoolIdentityTests` (pool identity per route component type).
- Integration `AssetsExchangeTests.testRoutesUSDCDOTHydrationNeverReenterPool` fails on `develop` (share detour and a double Omnipool hop show up among candidates) and passes with the fix.

Android counterpart: novasamatech/nova-wallet-android (same branch name).